### PR TITLE
remove extra user from chrome image, close #24

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,6 +43,12 @@ More working CI examples available at [](https://docs.cypress.io/guides/guides/c
 
 We also build an image with a [Chrome browser included](browsers/chrome/Dockerfile). The image is based on `cypress/base:6` and is called `cypress/browsers:chrome62`. With this image you can install Cypress and test using `cypress run --browser chrome`.
 
+## Debugging
+
+If something is going wrong, you can build additional image on top of any of
+these images with X11 VNC server. Then you can connect and see what is going
+on inside the container. See [instructions here](https://github.com/cypress-io/browser-connect-experiment)
+
 ## Links
 
 * [Cypress.io Website](https://www.cypress.io/)

--- a/browsers/chrome/Dockerfile
+++ b/browsers/chrome/Dockerfile
@@ -1,5 +1,6 @@
 FROM cypress/base:6
 
+RUN node --version
 RUN echo "force new chrome here"
 
 RUN \
@@ -11,25 +12,11 @@ RUN \
 
 RUN google-chrome --version
 
-# Run Google Chrome with certain additional CLI options
-ADD chrome.sh /usr/bin/chrome
-
-RUN chrome --version
-
 # "fake" dbus address to prevent errors
 # https://github.com/SeleniumHQ/docker-selenium/issues/87
 ENV DBUS_SESSION_BUS_ADDRESS=/dev/null
 
 RUN apt-get update && apt-get install -y zip
-
-# run as non-root user inside the docker container
-# see https://vimeo.com/171803492 at 17:20 mark
-RUN groupadd -r regular-users && useradd -m -r -g regular-users person
-# now run as the new "non-root" user
-USER person
-
-# test the new user - can they access Chrome and Node?
-RUN ls /home
-RUN node --version
-RUN chrome --version
 RUN zip --version
+
+RUN ls /home

--- a/browsers/chrome/chrome.sh
+++ b/browsers/chrome/chrome.sh
@@ -1,2 +1,0 @@
-#!/bin/sh
-google-chrome --disable-gpu --no-sandbox "$@"


### PR DESCRIPTION
Removes extra alias `/usr/bin/chrome`. User `node` is default and Chrome connects if running with `--no-sandbox`