### PR TITLE
Fix small typo in README.md file

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ All of the images and tags are [published to DockerHub here](https://hub.docker.
 
 We utilize many of these docker images in our own projects, with different CI providers.
 
-[Check out our docs for a examples.](https://on.cypress.io/docker)
+[Check out our docs for examples.](https://on.cypress.io/docker)
 
 ## Contributing
 


### PR DESCRIPTION
It looks like there was an extra `a` in `Check out our docs for a examples.`

I am hoping my next pull request for you will be a bit more technical! 😄