### PR TITLE
Add Cypress FireFox support warning

### DIFF
--- a/browsers/README.md
+++ b/browsers/README.md
@@ -6,3 +6,7 @@
 - Node 8 + Chrome 65 + Firefox 57 [/chrome65-ff57](chrome65-ff57)
 
 See Cypress on CI using these images [here](https://on.cypress.io/docker)
+
+## Note: No FireFox support yet in Cypress
+
+Please check https://github.com/cypress-io/cypress/issues/1096 for the progress of running Cypress with FireFox.


### PR DESCRIPTION
Make sure users know that FireFox is not supported yet in in the latest Cypress stable release, and refer them to the open issue.

I found out about the existence of the browser images, providing documentation on how to run Cypress with FireFox. Testing the image, I figured it doesn't work yet since there is an open issue for FireFox support. Hopefully this well help some people out for the time being :)