### PR TITLE
Upgrade npm to 6.1.0 (base/8 and base/10)

### DIFF
--- a/base/10/Dockerfile
+++ b/base/10/Dockerfile
@@ -10,7 +10,7 @@ RUN apt-get update && \
     libasound2 \
     xvfb
 
-RUN npm i -g npm@6
+RUN npm install -g npm@6.1.0
 
 # versions of local tools
 RUN node -v

--- a/base/8/Dockerfile
+++ b/base/8/Dockerfile
@@ -10,7 +10,7 @@ RUN apt-get update && \
     libasound2 \
     xvfb
 
-RUN npm install npm@5.8.0 -g
+RUN npm install -g npm@6.1.0
 
 # versions of local tools
 RUN node -v


### PR DESCRIPTION
Upgrade to latest npm.

I'm able to use npm 5.6.0 or 6.1.0, but not any versions in between due to https://github.com/npm/npm/issues/19989. Seems good to upgrade to the latest anyway!