### PR TITLE
Node LTS updates and chrome71

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,8 +20,9 @@ Name + Tag | Node | Operating System | Dependences | Browsers
 [cypress/base:centos7](base/centos7) | 6 | CentOS | ✅ | 🚫
 [cypress/base:ubuntu16](base/ubuntu16) | 6 | Ubuntu | ✅ | 🚫
 [cypress/browsers:chrome67](browsers/chrome67) | 8 | Debian | ✅ | Chrome 67
-[cypress/browsers:chrome69](browsers/chrome69) | 10 | Debian | ✅ | Chrome 69
 [cypress/browsers:chrome67-ff57](browsers/chrome67-ff57) | 8 | Debian | ✅ | Chrome 67, FF 57
+[cypress/browsers:chrome69](browsers/chrome69) | 10 | Debian | ✅ | Chrome 69
+[cypress/browsers:chrome71](browsers/chrome71) | 10 | Debian | ✅ | Chrome 71
 
 ## Best practice
 

--- a/base/10/Dockerfile
+++ b/base/10/Dockerfile
@@ -10,8 +10,11 @@ RUN apt-get update && \
     libasound2 \
     xvfb
 
+RUN npm upgrade -g npm
+
 # versions of local tools
-RUN node -v
-# NPM version should already be pretty new (> 6.4.0)
-RUN npm -v
-RUN yarn -v
+RUN echo " node version:           $(node -v) \n" \
+  "npm version:            $(npm -v) \n" \
+  "yarn version:           $(yarn -v)  \n" \
+  "debian version:         $(cat /etc/debian_version) \n"
+

--- a/base/10/Dockerfile
+++ b/base/10/Dockerfile
@@ -1,4 +1,4 @@
-FROM node:10.13
+FROM node:10.15
 
 RUN apt-get update && \
   apt-get install -y \

--- a/base/6/Dockerfile
+++ b/base/6/Dockerfile
@@ -1,4 +1,4 @@
-FROM node:6.14
+FROM node:6.16
 
 RUN apt-get update && \
   apt-get install -y \

--- a/base/6/Dockerfile
+++ b/base/6/Dockerfile
@@ -11,6 +11,7 @@ RUN apt-get update && \
     xvfb
 
 # versions of local tools
-RUN node -v
-RUN npm -v
-RUN yarn -v
+RUN echo " node version:           $(node -v) \n" \
+  "npm version:            $(npm -v) \n" \
+  "yarn version:           $(yarn -v)  \n" \
+  "debian version:         $(cat /etc/debian_version) \n"

--- a/base/8/Dockerfile
+++ b/base/8/Dockerfile
@@ -1,4 +1,4 @@
-FROM node:8.12
+FROM node:8.15
 
 RUN apt-get update && \
   apt-get install -y \

--- a/base/8/Dockerfile
+++ b/base/8/Dockerfile
@@ -10,9 +10,10 @@ RUN apt-get update && \
     libasound2 \
     xvfb
 
-RUN npm install -g npm@6.4.1
+RUN npm upgrade -g npm
 
 # versions of local tools
-RUN node -v
-RUN npm -v
-RUN yarn -v
+RUN echo " node version:           $(node -v) \n" \
+  "npm version:            $(npm -v) \n" \
+  "yarn version:           $(yarn -v)  \n" \
+  "debian version:         $(cat /etc/debian_version) \n"

--- a/base/README.md
+++ b/base/README.md
@@ -8,9 +8,9 @@ Image `cypress/base:8` is tagged [`latest`](https://hub.docker.com/r/cypress/bas
 Name + Tag | Node | Operating System | Link | NPM version | Yarn version
 --- | --- | --- | --- | --- | ---
 cypress/base:4 | 4 | Debian | [/4](4) | 2.15.11 | 0.24.4
-cypress/base:6 | 6 | Debian | [/6](6) | 3.10.10 | 1.6.0
-cypress/base:8 | 8 | Debian | [/8](8) | 6.4.1 | 1.9.4
-cypress/base:10 | 10 | Debian | [/10](10) | 6.4.1 | 1.9.4
+cypress/base:6 | 6.16.0 | Debian 9.6 | [/6](6) | 3.10.10 | 1.12.3
+cypress/base:8 | 8.15.0 | Debian 9.6 | [/8](8) | 6.6.0 | 1.12.3
+cypress/base:10 | 10.15.0 | Debian 9.6 | [/10](10) | 6.6.0 | 1.12.3
 cypress/base:centos7 | 6 | CentOS | [/centos7](centos7) | 3.10.10 | 🚫
 cypress/base:ubuntu16 | 6 | Ubuntu | [/ubuntu16](ubuntu16) | 3.10.10 | 🚫
 

--- a/browsers/README.md
+++ b/browsers/README.md
@@ -2,12 +2,13 @@
 
 > Image with all dependencies and a browser
 
-Image `cypress/browsers:chrome69` is tagged [`latest`](https://hub.docker.com/r/cypress/browsers/tags/)
+Image `cypress/browsers:chrome71` is tagged [`latest`](https://hub.docker.com/r/cypress/browsers/tags/)
 
 - Node 6 + Chrome 63 + Firefox 57 [/chrome63-ff57](chrome63-ff57)
 - Node 8 + Chrome 65 + Firefox 57 [/chrome65-ff57](chrome65-ff57)
 - Node 8 + Chrome 67 + Firefox 57 [/chrome67-ff57](chrome67-ff57)
 - Node 8 + Chrome 67 [/chrome67](chrome67)
 - Node 10 + Chrome 69 [/chrome69](chrome69)
+- Node 10 + Chrome 71 [/chrome71](chrome71)
 
 See Cypress on CI using these images [here](https://on.cypress.io/docker)

--- a/browsers/chrome71/Dockerfile
+++ b/browsers/chrome71/Dockerfile
@@ -1,0 +1,38 @@
+FROM cypress/base:10
+
+USER root
+
+RUN node --version
+RUN echo "force new chrome here"
+
+# install Chromebrowser
+RUN \
+  wget -q -O - https://dl-ssl.google.com/linux/linux_signing_key.pub | apt-key add - && \
+  echo "deb http://dl.google.com/linux/chrome/deb/ stable main" > /etc/apt/sources.list.d/google.list && \
+  apt-get update && \
+  apt-get install -y dbus-x11 google-chrome-stable && \
+  rm -rf /var/lib/apt/lists/*
+
+# "fake" dbus address to prevent errors
+# https://github.com/SeleniumHQ/docker-selenium/issues/87
+ENV DBUS_SESSION_BUS_ADDRESS=/dev/null
+
+# Add zip utility - it comes in very handy
+RUN apt-get update && apt-get install -y zip
+
+# versions of local tools
+RUN echo " node version:           $(node -v) \n" \
+  "npm version:            $(npm -v) \n" \
+  "yarn version:           $(yarn -v)  \n" \
+  "google-chrome version:  $(google-chrome --version) \n" \
+  "zip version:            $(zip --version | grep "This is Zip") \n" \
+  "git version:            $(git --version) \n" \
+  "debian version:         $(cat /etc/debian_version) \n"
+
+# a few environment variables to make NPM installs easier
+# good colors for most applications
+ENV TERM xterm
+# avoid million NPM install messages
+ENV npm_config_loglevel warn
+# allow installing when the main user is root
+ENV npm_config_unsafe_perm true

--- a/browsers/chrome71/README.md
+++ b/browsers/chrome71/README.md
@@ -1,0 +1,28 @@
+# cypress/browsers:chrome71
+
+A complete image with all dependencies for Cypress included browsers Chrome 71
+
+[Dockerfile](Dockerfile)
+```
+ node version:           v10.15.0
+ npm version:            6.4.1
+ yarn version:           1.12.3
+ google-chrome version:  Google Chrome 71.0.3578.98
+ zip version:            This is Zip 3.0 (July 5th 2008), by Info-ZIP.
+ git version:            git version 2.11.0
+ debian version:         9.6
+```
+
+
+## Example
+
+If you want to build your image
+
+```
+FROM cypress/browsers:chrome71
+RUN npm i cypress
+RUN $(npm bin)/cypress run --browser chrome
+```
+
+This image uses the `root` user. You might want to switch to non-root
+user when running this container for security.

--- a/browsers/chrome71/build.sh
+++ b/browsers/chrome71/build.sh
@@ -1,0 +1,6 @@
+set e+x
+
+LOCAL_NAME=cypress/browsers:chrome71
+
+echo "Building $LOCAL_NAME"
+docker build -t $LOCAL_NAME .


### PR DESCRIPTION
This PR includes the following:
- Added Chrome 71 browser image
- Updated base images for current LTS version (6, 8, and 10). 
- Made listing of tool versions in the container a little cleaner...like so:
```
 node version:           v10.15.0
 npm version:            6.6.0
 yarn version:           1.12.3
 debian version:         9.6
```