### PR TITLE
Reduce image sizes

### DIFF
--- a/base/10/Dockerfile
+++ b/base/10/Dockerfile
@@ -1,14 +1,16 @@
 FROM node:10.13
 
 RUN apt-get update && \
-  apt-get install -y \
+  apt-get install --no-install-recommends -y \
     libgtk2.0-0 \
     libnotify-dev \
     libgconf-2-4 \
     libnss3 \
     libxss1 \
     libasound2 \
-    xvfb
+    libxtst6 \
+    xvfb && \
+    rm -rf /var/lib/apt/lists/*
 
 # versions of local tools
 RUN node -v

--- a/base/4/Dockerfile
+++ b/base/4/Dockerfile
@@ -1,11 +1,13 @@
 FROM node:4.8.4
 
 RUN apt-get update && \
-  apt-get install -y \
+  apt-get install --no-install-recommends -y \
     libgtk2.0-0 \
     libnotify-dev \
     libgconf-2-4 \
     libnss3 \
     libxss1 \
     libasound2 \
-    xvfb
+    libxtst6 \
+    xvfb && \
+    rm -rf /var/lib/apt/lists/*

--- a/base/6/Dockerfile
+++ b/base/6/Dockerfile
@@ -1,14 +1,16 @@
 FROM node:6.14
 
 RUN apt-get update && \
-  apt-get install -y \
+  apt-get install --no-install-recommends -y \
     libgtk2.0-0 \
     libnotify-dev \
     libgconf-2-4 \
     libnss3 \
     libxss1 \
     libasound2 \
-    xvfb
+    libxtst6 \
+    xvfb && \
+    rm -rf /var/lib/apt/lists/*
 
 # versions of local tools
 RUN node -v

--- a/base/8/Dockerfile
+++ b/base/8/Dockerfile
@@ -1,14 +1,16 @@
 FROM node:8.12
 
 RUN apt-get update && \
-  apt-get install -y \
+  apt-get install --no-install-recommends -y \
     libgtk2.0-0 \
     libnotify-dev \
     libgconf-2-4 \
     libnss3 \
     libxss1 \
     libasound2 \
-    xvfb
+    libxtst6 \
+    xvfb && \
+    rm -rf /var/lib/apt/lists/*
 
 RUN npm install -g npm@6.4.1
 

--- a/base/ubuntu16/Dockerfile
+++ b/base/ubuntu16/Dockerfile
@@ -1,31 +1,32 @@
 FROM ubuntu:16.04
 
 RUN apt-get update && \
-  apt-get install -y apt-transport-https curl
+  apt-get install --no-install-recommends -y \
+    apt-transport-https \
+    ca-certificates \
+    curl && \
+  rm -rf /var/lib/apt/lists/*
 
 RUN touch /etc/apt/sources.list.d/nodesource.list
 RUN echo "deb https://deb.nodesource.com/node_6.x xenial main" > /etc/apt/sources.list.d/nodesource.list
 RUN echo "deb-src https://deb.nodesource.com/node_6.x xenial main" >> /etc/apt/sources.list.d/nodesource.list
 
 RUN curl -s https://deb.nodesource.com/gpgkey/nodesource.gpg.key | apt-key add -
-RUN apt-get update
 
 # Should install Node 6
-RUN apt-get install -y nodejs
-
 # Install Git client
-RUN apt-get update && apt-get install -y git
-RUN git --version
-
-# Install Cypress dependencies (separate commands to avoid time outs)
-RUN apt-get install -y \
-    libgtk2.0-0
-RUN apt-get install -y \
-    libnotify-dev
-RUN apt-get install -y \
+RUN apt-get update && \
+  apt-get install --no-install-recommends -y \
+    nodejs \
+    git \
+    libgtk2.0-0 \
+    libnotify-dev \
     libgconf-2-4 \
     libnss3 \
-    libxss1
-RUN apt-get install -y \
+    libxss1 \
     libasound2 \
-    xvfb
+    libxtst6 \
+    xvfb && \
+    rm -rf /var/lib/apt/lists/*
+
+RUN git --version

--- a/browsers/chrome63-ff57/Dockerfile
+++ b/browsers/chrome63-ff57/Dockerfile
@@ -12,7 +12,10 @@ RUN \
   wget -q -O - https://dl-ssl.google.com/linux/linux_signing_key.pub | apt-key add - && \
   echo "deb http://dl.google.com/linux/chrome/deb/ stable main" > /etc/apt/sources.list.d/google.list && \
   apt-get update && \
-  apt-get install -y dbus-x11 google-chrome-stable && \
+  apt-get install --no-install-recommends -y \
+    dbus-x11 \
+    google-chrome-stable \
+    zip && \
   rm -rf /var/lib/apt/lists/*
 
 # "fake" dbus address to prevent errors
@@ -24,9 +27,6 @@ RUN wget --no-verbose -O /tmp/firefox.tar.bz2 https://download-installer.cdn.moz
   && tar -C /opt -xjf /tmp/firefox.tar.bz2 \
   && rm /tmp/firefox.tar.bz2 \
   && ln -fs /opt/firefox/firefox /usr/bin/firefox
-
-# Add zip utility - it comes in very handy
-RUN apt-get update && apt-get install -y zip
 
 # versions of local tools
 RUN google-chrome --version

--- a/browsers/chrome65-ff57/Dockerfile
+++ b/browsers/chrome65-ff57/Dockerfile
@@ -12,7 +12,10 @@ RUN \
   wget -q -O - https://dl-ssl.google.com/linux/linux_signing_key.pub | apt-key add - && \
   echo "deb http://dl.google.com/linux/chrome/deb/ stable main" > /etc/apt/sources.list.d/google.list && \
   apt-get update && \
-  apt-get install -y dbus-x11 google-chrome-stable && \
+  apt-get install --no-install-recommends -y \
+    dbus-x11 \
+    google-chrome-stable \
+    zip && \
   rm -rf /var/lib/apt/lists/*
 
 # "fake" dbus address to prevent errors
@@ -24,9 +27,6 @@ RUN wget --no-verbose -O /tmp/firefox.tar.bz2 https://download-installer.cdn.moz
   && tar -C /opt -xjf /tmp/firefox.tar.bz2 \
   && rm /tmp/firefox.tar.bz2 \
   && ln -fs /opt/firefox/firefox /usr/bin/firefox
-
-# Add zip utility - it comes in very handy
-RUN apt-get update && apt-get install -y zip
 
 # versions of local tools
 RUN google-chrome --version

--- a/browsers/chrome67-ff57/Dockerfile
+++ b/browsers/chrome67-ff57/Dockerfile
@@ -12,7 +12,10 @@ RUN \
   wget -q -O - https://dl-ssl.google.com/linux/linux_signing_key.pub | apt-key add - && \
   echo "deb http://dl.google.com/linux/chrome/deb/ stable main" > /etc/apt/sources.list.d/google.list && \
   apt-get update && \
-  apt-get install -y dbus-x11 google-chrome-stable && \
+  apt-get install --no-install-recommends -y \
+    dbus-x11 \
+    google-chrome-stable \
+    zip && \
   rm -rf /var/lib/apt/lists/*
 
 # "fake" dbus address to prevent errors
@@ -24,9 +27,6 @@ RUN wget --no-verbose -O /tmp/firefox.tar.bz2 https://download-installer.cdn.moz
   && tar -C /opt -xjf /tmp/firefox.tar.bz2 \
   && rm /tmp/firefox.tar.bz2 \
   && ln -fs /opt/firefox/firefox /usr/bin/firefox
-
-# Add zip utility - it comes in very handy
-RUN apt-get update && apt-get install -y zip
 
 # versions of local tools
 RUN node -v

--- a/browsers/chrome67/Dockerfile
+++ b/browsers/chrome67/Dockerfile
@@ -10,15 +10,15 @@ RUN \
   wget -q -O - https://dl-ssl.google.com/linux/linux_signing_key.pub | apt-key add - && \
   echo "deb http://dl.google.com/linux/chrome/deb/ stable main" > /etc/apt/sources.list.d/google.list && \
   apt-get update && \
-  apt-get install -y dbus-x11 google-chrome-stable && \
+  apt-get install --no-install-recommends -y \
+    dbus-x11 \
+    google-chrome-stable \
+    zip && \
   rm -rf /var/lib/apt/lists/*
 
 # "fake" dbus address to prevent errors
 # https://github.com/SeleniumHQ/docker-selenium/issues/87
 ENV DBUS_SESSION_BUS_ADDRESS=/dev/null
-
-# Add zip utility - it comes in very handy
-RUN apt-get update && apt-get install -y zip
 
 # versions of local tools
 RUN node -v

--- a/browsers/chrome69/Dockerfile
+++ b/browsers/chrome69/Dockerfile
@@ -10,15 +10,15 @@ RUN \
   wget -q -O - https://dl-ssl.google.com/linux/linux_signing_key.pub | apt-key add - && \
   echo "deb http://dl.google.com/linux/chrome/deb/ stable main" > /etc/apt/sources.list.d/google.list && \
   apt-get update && \
-  apt-get install -y dbus-x11 google-chrome-stable && \
+  apt-get install --no-install-recommends -y \
+    dbus-x11 \
+    google-chrome-stable \
+    zip && \
   rm -rf /var/lib/apt/lists/*
 
 # "fake" dbus address to prevent errors
 # https://github.com/SeleniumHQ/docker-selenium/issues/87
 ENV DBUS_SESSION_BUS_ADDRESS=/dev/null
-
-# Add zip utility - it comes in very handy
-RUN apt-get update && apt-get install -y zip
 
 # versions of local tools
 RUN node -v


### PR DESCRIPTION
Suggesting a few changes that should reduce the image sizes, by not installing "recommended" dependencies (only required ones) and ensuring the apt-get package lists are consistently purged.

Is a test suite available for these images?