### PR TITLE
add Node 8.15.1 plus Chrome 73 image

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,6 +21,7 @@ Name + Tag | Node | Operating System | Dependences | Browsers
 [cypress/base:centos7](base/centos7) | 6 | CentOS | ✅ | 🚫
 [cypress/base:ubuntu16](base/ubuntu16) | 6 | Ubuntu | ✅ | 🚫
 [cypress/browsers:chrome67](browsers/chrome67) | 8 | Debian | ✅ | Chrome 67
+[cypress/browsers:node8.15.1-chrome73](browsers/node8.15.1-chrome73) | 8.15.1 | Debian | ✅ | Chrome 73
 [cypress/browsers:chrome69](browsers/chrome69) | 10 | Debian | ✅ | Chrome 69
 [cypress/browsers:chrome67-ff57](browsers/chrome67-ff57) | 8 | Debian | ✅ | Chrome 67, FF 57
 

--- a/browsers/README.md
+++ b/browsers/README.md
@@ -8,6 +8,7 @@ Image `cypress/browsers:chrome69` is tagged [`latest`](https://hub.docker.com/r/
 - Node 8 + Chrome 65 + Firefox 57 [/chrome65-ff57](chrome65-ff57)
 - Node 8 + Chrome 67 + Firefox 57 [/chrome67-ff57](chrome67-ff57)
 - Node 8 + Chrome 67 [/chrome67](chrome67)
+- Node 8.15.1 + Chrome 73 [/node8.15.1-chrome73](node8.15.1-chrome73)
 - Node 10 + Chrome 69 [/chrome69](chrome69)
 
 See Cypress on CI using these images [here](https://on.cypress.io/docker)

--- a/browsers/node8.15.1-chrome73/Dockerfile
+++ b/browsers/node8.15.1-chrome73/Dockerfile
@@ -1,0 +1,37 @@
+FROM cypress/base:8.15.1
+
+USER root
+
+RUN node --version
+RUN echo "force new chrome here"
+
+# install Chromebrowser
+RUN \
+  wget -q -O - https://dl-ssl.google.com/linux/linux_signing_key.pub | apt-key add - && \
+  echo "deb http://dl.google.com/linux/chrome/deb/ stable main" > /etc/apt/sources.list.d/google.list && \
+  apt-get update && \
+  apt-get install -y dbus-x11 google-chrome-stable && \
+  rm -rf /var/lib/apt/lists/*
+
+# "fake" dbus address to prevent errors
+# https://github.com/SeleniumHQ/docker-selenium/issues/87
+ENV DBUS_SESSION_BUS_ADDRESS=/dev/null
+
+# Add zip utility - it comes in very handy
+RUN apt-get update && apt-get install -y zip
+
+# versions of local tools
+RUN echo  " node version:    $(node -v) \n" \
+          "npm version:     $(npm -v) \n" \
+          "yarn verison:    $(yarn -v) \n" \
+          "debian version:  $(cat /etc/debian_version) \n" \
+          "Chrome version:  $(google-chrome --version) \n" \
+          "git version:     $(git --version) \n"
+
+# a few environment variables to make NPM installs easier
+# good colors for most applications
+ENV TERM xterm
+# avoid million NPM install messages
+ENV npm_config_loglevel warn
+# allow installing when the main user is root
+ENV npm_config_unsafe_perm true

--- a/browsers/node8.15.1-chrome73/README.md
+++ b/browsers/node8.15.1-chrome73/README.md
@@ -1,0 +1,18 @@
+# cypress/browsers:node8.15.1-chrome73
+
+A complete image with all operating system dependencies for Cypress and Chrome 73 browser
+
+[Dockerfile](Dockerfile)
+
+## Example
+
+If you want to build your image
+
+```
+FROM cypress/browsers:node8.15.1-chrome73
+RUN npm i cypress
+RUN $(npm bin)/cypress run --browser chrome
+```
+
+This image uses the `root` user. You might want to switch to non-root
+user when running this container for security.

--- a/browsers/node8.15.1-chrome73/build.sh
+++ b/browsers/node8.15.1-chrome73/build.sh
@@ -1,0 +1,6 @@
+set e+x
+
+LOCAL_NAME=cypress/browsers:node8.15.1-chrome73
+
+echo "Building $LOCAL_NAME"
+docker build -t $LOCAL_NAME .


### PR DESCRIPTION
- closes #90 
- closes #81 

Docker image tag `cypress/browsers:node8.15.1-chrome73`

```
 node version:    v8.15.1 
 npm version:     6.9.0 
 yarn verison:    1.15.2 
 debian version:  9.8 
 Chrome version:  Google Chrome 73.0.3683.86  
 git version:     git version 2.11.0
```