### PR TITLE
add cypress/base:8.2.1 docker image

### DIFF
--- a/base/8.2.1/Dockerfile
+++ b/base/8.2.1/Dockerfile
@@ -1,0 +1,87 @@
+# take same base as 8.15.1 Docker file
+# https://github.com/nodejs/docker-node/blob/de76fb48b532d6be012098dc3538bd15329a27d0/8/jessie/Dockerfile
+FROM buildpack-deps:jessie
+
+RUN groupadd --gid 1000 node \
+  && useradd --uid 1000 --gid node --shell /bin/bash --create-home node
+
+ENV NODE_VERSION 8.2.1
+
+RUN ARCH= && dpkgArch="$(dpkg --print-architecture)" \
+  && case "${dpkgArch##*-}" in \
+    amd64) ARCH='x64';; \
+    ppc64el) ARCH='ppc64le';; \
+    s390x) ARCH='s390x';; \
+    arm64) ARCH='arm64';; \
+    armhf) ARCH='armv7l';; \
+    i386) ARCH='x86';; \
+    *) echo "unsupported architecture"; exit 1 ;; \
+  esac \
+  # gpg keys listed at https://github.com/nodejs/node#release-keys
+  && set -ex \
+  && for key in \
+    94AE36675C464D64BAFA68DD7434390BDBE9B9C5 \
+    FD3A5288F042B6850C66B31F09FE44734EB7990E \
+    71DCFD284A79C3B38668286BC97EC7A07EDE3FC1 \
+    DD8F2338BAE7501E3DD5AC78C273792F7D83545D \
+    C4F0DFFF4E8C1A8236409D08E73BC641CC11F4C8 \
+    B9AE9905FFD7803F25714661B63B535A4C206CA9 \
+    77984A986EBC2AA786BC0F66B01FBB92821C587A \
+    8FCCA13FEF1D0C2E91008E09770F7A9A5AE15600 \
+    4ED778F539E3634C779C87C6D7062848A1AB005C \
+    A48C2BEE680E841632CD4E44F07496B3EB3C1762 \
+    B9E2F5981AA6E0CD28160D9FF13993A75599653C \
+  ; do \
+    gpg --batch --keyserver hkp://p80.pool.sks-keyservers.net:80 --recv-keys "$key" || \
+    gpg --batch --keyserver hkp://ipv4.pool.sks-keyservers.net --recv-keys "$key" || \
+    gpg --batch --keyserver hkp://pgp.mit.edu:80 --recv-keys "$key" ; \
+  done \
+  && curl -fsSLO --compressed "https://nodejs.org/dist/v$NODE_VERSION/node-v$NODE_VERSION-linux-$ARCH.tar.xz" \
+  && curl -fsSLO --compressed "https://nodejs.org/dist/v$NODE_VERSION/SHASUMS256.txt.asc" \
+  && gpg --batch --decrypt --output SHASUMS256.txt SHASUMS256.txt.asc \
+  && grep " node-v$NODE_VERSION-linux-$ARCH.tar.xz\$" SHASUMS256.txt | sha256sum -c - \
+  && tar -xJf "node-v$NODE_VERSION-linux-$ARCH.tar.xz" -C /usr/local --strip-components=1 --no-same-owner \
+  && rm "node-v$NODE_VERSION-linux-$ARCH.tar.xz" SHASUMS256.txt.asc SHASUMS256.txt \
+  && ln -s /usr/local/bin/node /usr/local/bin/nodejs
+
+ENV YARN_VERSION 1.12.3
+
+RUN set -ex \
+  && for key in \
+    6A010C5166006599AA17F08146C2130DFD2497F5 \
+  ; do \
+    gpg --batch --keyserver hkp://p80.pool.sks-keyservers.net:80 --recv-keys "$key" || \
+    gpg --batch --keyserver hkp://ipv4.pool.sks-keyservers.net --recv-keys "$key" || \
+    gpg --batch --keyserver hkp://pgp.mit.edu:80 --recv-keys "$key" ; \
+  done \
+  && curl -fsSLO --compressed "https://yarnpkg.com/downloads/$YARN_VERSION/yarn-v$YARN_VERSION.tar.gz" \
+  && curl -fsSLO --compressed "https://yarnpkg.com/downloads/$YARN_VERSION/yarn-v$YARN_VERSION.tar.gz.asc" \
+  && gpg --batch --verify yarn-v$YARN_VERSION.tar.gz.asc yarn-v$YARN_VERSION.tar.gz \
+  && mkdir -p /opt \
+  && tar -xzf yarn-v$YARN_VERSION.tar.gz -C /opt/ \
+  && ln -s /opt/yarn-v$YARN_VERSION/bin/yarn /usr/local/bin/yarn \
+  && ln -s /opt/yarn-v$YARN_VERSION/bin/yarnpkg /usr/local/bin/yarnpkg \
+  && rm yarn-v$YARN_VERSION.tar.gz.asc yarn-v$YARN_VERSION.tar.gz
+
+# CMD [ "node" ]
+
+# install Cypress OS dependencies
+
+RUN apt-get update && \
+  apt-get install -y \
+    libgtk2.0-0 \
+    libnotify-dev \
+    libgconf-2-4 \
+    libnss3 \
+    libxss1 \
+    libasound2 \
+    xvfb
+
+# RUN npm install -g npm@6.9.0
+# RUN npm install -g yarn
+
+# versions of local tools
+RUN echo  " node version:    $(node -v) \n" \
+          "npm version:     $(npm -v) \n" \
+          "yarn verison:    $(yarn -v) \n" \
+          "debian version:  $(cat /etc/debian_version) \n"

--- a/base/8.2.1/README.md
+++ b/base/8.2.1/README.md
@@ -1,0 +1,12 @@
+# cypress/base:8.2.1
+
+## Example
+
+Sample Dockerfile
+
+```
+FROM cypress/base:8.2.1
+RUN npm install --save-dev cypress
+RUN $(npm bin)/cypress verify
+RUN $(npm bin)/cypress run
+```

--- a/base/8.2.1/build.sh
+++ b/base/8.2.1/build.sh
@@ -1,0 +1,7 @@
+set e+x
+
+# build image with Cypress dependencies
+LOCAL_NAME=cypress/base:8.2.1
+
+echo "Building $LOCAL_NAME"
+docker build -t $LOCAL_NAME .

--- a/base/README.md
+++ b/base/README.md
@@ -11,6 +11,7 @@ Name + Tag | Node | Operating System | Link | NPM version | Yarn version
 cypress/base:4 | 4 | Debian | [/4](4) | 2.15.11 | 0.24.4
 cypress/base:6 | 6 | Debian | [/6](6) | 3.10.10 | 1.6.0
 cypress/base:8 | 8 | Debian | [/8](8) | 6.4.1 | 1.9.4
+cypress/base:8.2.1 | 8.2.1 | Debian | [/8.2.1](8.2.1) | 5.3.0 | 1.12.3
 cypress/base:8.15.1 | 8.15.1 | Debian | [/8.15.1](8.15.1) | 6.9.0 | 1.15.2
 cypress/base:10 | 10 | Debian | [/10](10) | 6.4.1 | 1.9.4
 cypress/base:10.15.3 | 10.15.3 | Debian | [/10.15.3](10.15.3) | 6.9.0 | 1.15.2

--- a/browsers/README.md
+++ b/browsers/README.md
@@ -8,6 +8,7 @@ Image `cypress/browsers:chrome69` is tagged [`latest`](https://hub.docker.com/r/
 - Node 8 + Chrome 65 + Firefox 57 [/chrome65-ff57](chrome65-ff57)
 - Node 8 + Chrome 67 + Firefox 57 [/chrome67-ff57](chrome67-ff57)
 - Node 8 + Chrome 67 [/chrome67](chrome67)
+- Node 8.2.1 + Chrome 73 [/node8.2.1-chrome73](node8.2.1-chrome73)
 - Node 8.15.1 + Chrome 73 [/node8.15.1-chrome73](node8.15.1-chrome73)
 - Node 10 + Chrome 69 [/chrome69](chrome69)
 

--- a/browsers/node8.2.1-chrome73/Dockerfile
+++ b/browsers/node8.2.1-chrome73/Dockerfile
@@ -1,0 +1,37 @@
+FROM cypress/base:8.2.1
+
+USER root
+
+RUN node --version
+RUN echo "force new chrome here"
+
+# install Chromebrowser
+RUN \
+  wget -q -O - https://dl-ssl.google.com/linux/linux_signing_key.pub | apt-key add - && \
+  echo "deb http://dl.google.com/linux/chrome/deb/ stable main" > /etc/apt/sources.list.d/google.list && \
+  apt-get update && \
+  apt-get install -y dbus-x11 google-chrome-stable && \
+  rm -rf /var/lib/apt/lists/*
+
+# "fake" dbus address to prevent errors
+# https://github.com/SeleniumHQ/docker-selenium/issues/87
+ENV DBUS_SESSION_BUS_ADDRESS=/dev/null
+
+# Add zip utility - it comes in very handy
+RUN apt-get update && apt-get install -y zip
+
+# versions of local tools
+RUN echo  " node version:    $(node -v) \n" \
+          "npm version:     $(npm -v) \n" \
+          "yarn verison:    $(yarn -v) \n" \
+          "debian version:  $(cat /etc/debian_version) \n" \
+          "Chrome version:  $(google-chrome --version) \n" \
+          "git version:     $(git --version) \n"
+
+# a few environment variables to make NPM installs easier
+# good colors for most applications
+ENV TERM xterm
+# avoid million NPM install messages
+ENV npm_config_loglevel warn
+# allow installing when the main user is root
+ENV npm_config_unsafe_perm true

--- a/browsers/node8.2.1-chrome73/README.md
+++ b/browsers/node8.2.1-chrome73/README.md
@@ -1,0 +1,20 @@
+# cypress/browsers:node8.2.1-chrome73
+
+A complete image with all operating system dependencies for Cypress and Chrome 73 browser
+
+[Dockerfile](Dockerfile)
+
+Note: this image is mostly used for internal building and testing of Cypress test runner v3.3.x
+
+## Example
+
+If you want to build your image
+
+```
+FROM cypress/browsers:node8.2.1-chrome73
+RUN npm i cypress
+RUN $(npm bin)/cypress run --browser chrome
+```
+
+This image uses the `root` user. You might want to switch to non-root
+user when running this container for security.

--- a/browsers/node8.2.1-chrome73/build.sh
+++ b/browsers/node8.2.1-chrome73/build.sh
@@ -1,0 +1,6 @@
+set e+x
+
+LOCAL_NAME=cypress/browsers:node8.2.1-chrome73
+
+echo "Building $LOCAL_NAME"
+docker build -t $LOCAL_NAME .


### PR DESCRIPTION
- closes #96 

Adding `cypress/base:8.2.1` image for testing Cypress 3.2.x

```
 node version:    v8.2.1 
 npm version:     5.3.0 
 yarn verison:    1.12.3 
 debian version:  8.11
```

Adding `cypress/browsers:node8.2.1-chrome73` image built on top of `cypress/base:8.2.1`

```
 node version:    v8.2.1 
 npm version:     5.3.0 
 yarn verison:    1.12.3 
 debian version:  8.11 
 Chrome version:  Google Chrome 73.0.3683.86  
 git version:     git version 2.1.4
```