### PR TITLE
Add base 11.13.0 image and with Chrome 73

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,6 +23,7 @@ Name + Tag | Node | Operating System | Dependences | Browsers
 [cypress/base:ubuntu16](base/ubuntu16) | 6 | Ubuntu | ✅ | 🚫
 [cypress/browsers:chrome67](browsers/chrome67) | 8 | Debian | ✅ | Chrome 67
 [cypress/browsers:node8.15.1-chrome73](browsers/node8.15.1-chrome73) | 8.15.1 | Debian | ✅ | Chrome 73
+[cypress/browsers:node11.13.0-chrome73](browsers/node11.13.0-chrome73) | 11.13.0 | Debian | ✅ | Chrome 73
 [cypress/browsers:chrome69](browsers/chrome69) | 10 | Debian | ✅ | Chrome 69
 [cypress/browsers:chrome67-ff57](browsers/chrome67-ff57) | 8 | Debian | ✅ | Chrome 67, FF 57
 

--- a/base/11.13.0/Dockerfile
+++ b/base/11.13.0/Dockerfile
@@ -1,0 +1,21 @@
+FROM node:11.13.0
+
+RUN apt-get update && \
+  apt-get install --no-install-recommends -y \
+    libgtk2.0-0 \
+    libnotify-dev \
+    libgconf-2-4 \
+    libnss3 \
+    libxss1 \
+    libasound2 \
+    xvfb && \
+    rm -rf /var/lib/apt/lists/*
+
+RUN npm install -g npm@6.9.0
+RUN npm install -g yarn@1.15.2
+
+# versions of local tools
+RUN echo  " node version:    $(node -v) \n" \
+          "npm version:     $(npm -v) \n" \
+          "yarn verison:    $(yarn -v) \n" \
+          "debian version:  $(cat /etc/debian_version) \n"

--- a/base/11.13.0/Dockerfile
+++ b/base/11.13.0/Dockerfile
@@ -8,6 +8,7 @@ RUN apt-get update && \
     libnss3 \
     libxss1 \
     libasound2 \
+    libxtst6 \
     xvfb && \
     rm -rf /var/lib/apt/lists/*
 

--- a/base/11.13.0/README.md
+++ b/base/11.13.0/README.md
@@ -1,0 +1,20 @@
+# cypress/base:11.13.0
+
+Size
+
+```
+$ docker images cypress/base:11.13.0
+REPOSITORY          TAG                 IMAGE ID            SIZE
+cypress/base        11.13.0             ae05bb9eae5f        969MB
+```
+
+## Example
+
+Sample Dockerfile
+
+```
+FROM cypress/base:11.13.0
+RUN npm install --save-dev cypress
+RUN $(npm bin)/cypress verify
+RUN $(npm bin)/cypress run
+```

--- a/base/11.13.0/README.md
+++ b/base/11.13.0/README.md
@@ -3,9 +3,8 @@
 Size
 
 ```
-$ docker images cypress/base:11.13.0
-REPOSITORY          TAG                 IMAGE ID            SIZE
-cypress/base        11.13.0             ae05bb9eae5f        969MB
+$ docker images --format "{{.Tag}} {{.Size}}" cypress/base:11.13.0
+11.13.0 969MB
 ```
 
 ## Example

--- a/base/11.13.0/build.sh
+++ b/base/11.13.0/build.sh
@@ -1,0 +1,7 @@
+set e+x
+
+# build image with Cypress dependencies
+LOCAL_NAME=cypress/base:11.13.0
+
+echo "Building $LOCAL_NAME"
+docker build -t $LOCAL_NAME .

--- a/base/README.md
+++ b/base/README.md
@@ -15,6 +15,7 @@ cypress/base:8.2.1 | 8.2.1 | Debian | [/8.2.1](8.2.1) | 5.3.0 | 1.12.3
 cypress/base:8.15.1 | 8.15.1 | Debian | [/8.15.1](8.15.1) | 6.9.0 | 1.15.2
 cypress/base:10 | 10 | Debian | [/10](10) | 6.4.1 | 1.9.4
 cypress/base:10.15.3 | 10.15.3 | Debian | [/10.15.3](10.15.3) | 6.9.0 | 1.15.2
+cypress/base:11.13.0 | 11.13.0 | Debian | [/11.13.0](11.13.0) | 6.9.0 | 1.15.2
 cypress/base:centos7 | 6 | CentOS | [/centos7](centos7) | 3.10.10 | 🚫
 cypress/base:ubuntu16 | 6 | Ubuntu | [/ubuntu16](ubuntu16) | 3.10.10 | 🚫
 

--- a/browsers/node11.13.0-chrome73/Dockerfile
+++ b/browsers/node11.13.0-chrome73/Dockerfile
@@ -1,0 +1,37 @@
+FROM cypress/base:11.13.0
+
+USER root
+
+RUN node --version
+RUN echo "force new chrome here"
+
+# install Chromebrowser
+RUN \
+  wget -q -O - https://dl-ssl.google.com/linux/linux_signing_key.pub | apt-key add - && \
+  echo "deb http://dl.google.com/linux/chrome/deb/ stable main" > /etc/apt/sources.list.d/google.list && \
+  apt-get update && \
+  apt-get install -y dbus-x11 google-chrome-stable && \
+  rm -rf /var/lib/apt/lists/*
+
+# "fake" dbus address to prevent errors
+# https://github.com/SeleniumHQ/docker-selenium/issues/87
+ENV DBUS_SESSION_BUS_ADDRESS=/dev/null
+
+# Add zip utility - it comes in very handy
+RUN apt-get update && apt-get install -y zip
+
+# versions of local tools
+RUN echo  " node version:    $(node -v) \n" \
+          "npm version:     $(npm -v) \n" \
+          "yarn verison:    $(yarn -v) \n" \
+          "debian version:  $(cat /etc/debian_version) \n" \
+          "Chrome version:  $(google-chrome --version) \n" \
+          "git version:     $(git --version) \n"
+
+# a few environment variables to make NPM installs easier
+# good colors for most applications
+ENV TERM xterm
+# avoid million NPM install messages
+ENV npm_config_loglevel warn
+# allow installing when the main user is root
+ENV npm_config_unsafe_perm true

--- a/browsers/node11.13.0-chrome73/README.md
+++ b/browsers/node11.13.0-chrome73/README.md
@@ -1,0 +1,25 @@
+# cypress/browsers:node11.13.0-chrome73
+
+A complete image with all operating system dependencies for Cypress and Chrome 73 browser
+
+[Dockerfile](Dockerfile)
+
+Size
+
+```bash
+$ docker images --format "{{.Tag}} {{.Size}}" cypress/browsers:node11.13.0-chrome73
+node11.13.0-chrome73 1.28GB
+```
+
+## Example
+
+If you want to build your image
+
+```
+FROM cypress/browsers:node11.13.0-chrome73
+RUN npm i cypress
+RUN $(npm bin)/cypress run --browser chrome
+```
+
+This image uses the `root` user. You might want to switch to non-root
+user when running this container for security.

--- a/browsers/node11.13.0-chrome73/build.sh
+++ b/browsers/node11.13.0-chrome73/build.sh
@@ -1,0 +1,6 @@
+set e+x
+
+LOCAL_NAME=cypress/browsers:node11.13.0-chrome73
+
+echo "Building $LOCAL_NAME"
+docker build -t $LOCAL_NAME .


### PR DESCRIPTION
- temp image for people who need Node 11
- checking reduced size flags when building Docker image
```
 node version:    v11.13.0 
 npm version:     6.9.0 
 yarn verison:    1.15.2 
 debian version:  9.8
```

- built `cypress/browsers:node11.13.0-chrome73` on top of that
```
 node version:    v11.13.0 
 npm version:     6.9.0 
 yarn verison:    1.15.2 
 debian version:  9.8 
 Chrome version:  Google Chrome 73.0.3683.103  
 git version:     git version 2.11.0
```

- closes #86 