### PR TITLE
add cypress/included:3.2.0 image

### DIFF
--- a/included/Dockerfile
+++ b/included/Dockerfile
@@ -1,0 +1,24 @@
+FROM cypress/base:12.1.0
+
+# avoid too many progress messages
+# https://github.com/cypress-io/cypress/issues/1243
+ENV CI=1
+ARG CYPRESS_VERSION="3.2.0"
+
+RUN echo "whoami: $(whoami)"
+RUN npm config -g set user $(whoami)
+RUN npm install -g "cypress@${CYPRESS_VERSION}"
+RUN cypress verify
+
+# Cypress cache and installed version
+RUN cypress cache path
+RUN cypress cache list
+
+# versions of local tools
+RUN echo  " node version:    $(node -v) \n" \
+  "npm version:     $(npm -v) \n" \
+  "yarn version:    $(yarn -v) \n" \
+  "debian version:  $(cat /etc/debian_version) \n" \
+  "user:            $(whoami) \n"
+
+ENTRYPOINT ["cypress", "run"]

--- a/included/README.md
+++ b/included/README.md
@@ -1,0 +1,1 @@
+# cypress/included

--- a/included/build.sh
+++ b/included/build.sh
@@ -1,0 +1,6 @@
+set e+x
+
+LOCAL_NAME=cypress/included:3.2.0
+
+echo "Building $LOCAL_NAME"
+docker build -t $LOCAL_NAME .

--- a/included/test.sh
+++ b/included/test.sh
@@ -1,0 +1,6 @@
+set e+x
+
+LOCAL_NAME=cypress/test
+
+echo "Running tests against $LOCAL_NAME"
+docker run -it -v $PWD/src:/test -w /test $LOCAL_NAME


### PR DESCRIPTION
- full image with Cypress pre-installed, based on `cypress/base:12.1.0`

```
3.2.0: digest: sha256:9c7aab130b0e681bda3ac94c437af47d844e9dbfda377de7ff32640b4364d17f size: 3057
```