### PR TITLE
add cypress/base:8.16.0 image with Chinese fonts

### DIFF
--- a/base/8.16.0/Dockerfile
+++ b/base/8.16.0/Dockerfile
@@ -1,0 +1,43 @@
+FROM node:8.16.0
+
+# install Cypress OS dependencies
+# but do not install recommended libs and clean temp files
+#
+# note:
+#   Gtk2 for Cypress < 3.3.0
+#   Gtk3 for Cypress >= 3.3.0
+RUN apt-get update && \
+  apt-get install --no-install-recommends -y \
+  libgtk2.0-0 \
+  libgtk-3-0 \
+  libnotify-dev \
+  libgconf-2-4 \
+  libnss3 \
+  libxss1 \
+  libasound2 \
+  libxtst6 \
+  xauth \
+  xvfb \
+  # install Chinese fonts
+  # this list was copied from https://github.com/jim3ma/docker-leanote
+  fonts-arphic-bkai00mp \
+  fonts-arphic-bsmi00lp \
+  fonts-arphic-gbsn00lp \
+  fonts-arphic-gkai00mp \
+  fonts-arphic-ukai \
+  fonts-arphic-uming \
+  ttf-wqy-zenhei \
+  ttf-wqy-microhei \
+  xfonts-wqy \
+  # clean up
+  && rm -rf /var/lib/apt/lists/*
+
+RUN npm install -g npm@6.9.0
+RUN npm install -g yarn@1.16.0
+
+# versions of local tools
+RUN echo  " node version:    $(node -v) \n" \
+  "npm version:     $(npm -v) \n" \
+  "yarn version:    $(yarn -v) \n" \
+  "debian version:  $(cat /etc/debian_version) \n" \
+  "user:            $(whoami) \n"

--- a/base/8.16.0/README.md
+++ b/base/8.16.0/README.md
@@ -1,0 +1,14 @@
+# cypress/base:8.16.0
+
+Includes Chinese fonts, see [Dockerfile](Dockerfile)
+
+## Example
+
+Sample Dockerfile
+
+```
+FROM cypress/base:8.16.0
+RUN npm install --save-dev cypress
+RUN $(npm bin)/cypress verify
+RUN $(npm bin)/cypress run
+```

--- a/base/8.16.0/build.sh
+++ b/base/8.16.0/build.sh
@@ -1,0 +1,7 @@
+set e+x
+
+# build image with Cypress dependencies
+LOCAL_NAME=cypress/base:8.16.0
+
+echo "Building $LOCAL_NAME"
+docker build -t $LOCAL_NAME .

--- a/base/README.md
+++ b/base/README.md
@@ -6,13 +6,14 @@ Each tag is in a sub folder, named after Node version or OS it is built on.
 
 Image `cypress/base:8` is tagged [`latest`](https://hub.docker.com/r/cypress/base/tags/)
 
-Name + Tag | Node | Operating System | Link | NPM version | Yarn version
---- | --- | --- | --- | --- | ---
+Name + Tag | Node | Operating System | Link | NPM version | Yarn version | Notes
+--- | --- | --- | --- | --- | --- | ---
 cypress/base:6 | 6 | Debian | [/6](6) | 3.10.10 | 1.6.0
 cypress/base:8 | 8 | Debian | [/8](8) | 6.4.1 | 1.9.4
 cypress/base:8.2.1 | 8.2.1 | Debian | [/8.2.1](8.2.1) | 5.3.0 | 1.12.3
 cypress/base:8.9.3 | 8.9.3 | Debian | [/8.9.3](8.9.3) | 5.5.1 | 1.12.3
 cypress/base:8.15.1 | 8.15.1 | Debian | [/8.15.1](8.15.1) | 6.9.0 | 1.15.2
+cypress/base:8.16.0 | 8.16.0 | Debian | [/8.16.0](8.16.0) | 6.9.0 | 1.16.0 | [1](#note1)
 cypress/base:10 | 10 | Debian | [/10](10) | 6.4.1 | 1.9.4
 cypress/base:10.15.3 | 10.15.3 | Debian | [/10.15.3](10.15.3) | 6.9.0 | 1.15.2
 cypress/base:11.13.0 | 11.13.0 | Debian | [/11.13.0](11.13.0) | 6.9.0 | 1.15.2
@@ -20,7 +21,7 @@ cypress/base:12.1.0 | 12.1.0 | Debian | [/12.1.0](12.1.0) | 6.9.0 | 1.15.2
 cypress/base:centos7 | 6 | CentOS | [/centos7](centos7) | 3.10.10 | 🚫
 cypress/base:ubuntu16 | 6 | Ubuntu | [/ubuntu16](ubuntu16) | 3.10.10 | 🚫
 
-**note** Cypress no longer supports Node v0.12.x. Using 4.x, 6.x images is not recommended, and we do not plan to release new versions of Cypress tested on Node v4. See [End-of-Life Releases](https://github.com/nodejs/Release#end-of-life-releases).
+⚠️ Cypress no longer supports Node v0.12.x. Using 4.x, 6.x images is not recommended, and we do not plan to release new versions of Cypress tested on Node v4. See [End-of-Life Releases](https://github.com/nodejs/Release#end-of-life-releases).
 
 ## Information
 
@@ -37,3 +38,8 @@ nvm ls-remote
   v10.15.2   (LTS: Dubnium)
   v10.15.3   (Latest LTS: Dubnium)
 ```
+
+## Notes
+
+<div id="note1">
+**1:** image `cypress/base:8.16.0` includes fonts with Chinese characters


### PR DESCRIPTION
- closes #109
```
 node version:    v8.16.0 
 npm version:     6.9.0 
 yarn version:    1.16.0 
 debian version:  9.9 
 user:            root
```
```
8.16.0: digest: sha256:a23ec1a30c3335a80ed2eb177ab9f03dce42ffd9a3968bf9628c14358c1c11a8 size: 2854
```