### PR TITLE
build cypress/included 3.3.0 image

### DIFF
--- a/included/3.2.0/test.sh
+++ b/included/3.2.0/test.sh
@@ -1,6 +1,0 @@
-set e+x
-
-LOCAL_NAME=cypress/test
-
-echo "Running tests against $LOCAL_NAME"
-docker run -it -v $PWD/src:/test -w /test $LOCAL_NAME

--- a/included/3.3.0/Dockerfile
+++ b/included/3.3.0/Dockerfile
@@ -1,0 +1,24 @@
+FROM cypress/base:12.1.0
+
+# avoid too many progress messages
+# https://github.com/cypress-io/cypress/issues/1243
+ENV CI=1
+ARG CYPRESS_VERSION="3.3.0"
+
+RUN echo "whoami: $(whoami)"
+RUN npm config -g set user $(whoami)
+RUN npm install -g "cypress@${CYPRESS_VERSION}"
+RUN cypress verify
+
+# Cypress cache and installed version
+RUN cypress cache path
+RUN cypress cache list
+
+# versions of local tools
+RUN echo  " node version:    $(node -v) \n" \
+  "npm version:     $(npm -v) \n" \
+  "yarn version:    $(yarn -v) \n" \
+  "debian version:  $(cat /etc/debian_version) \n" \
+  "user:            $(whoami) \n"
+
+ENTRYPOINT ["cypress", "run"]

--- a/included/3.3.0/README.md
+++ b/included/3.3.0/README.md
@@ -1,0 +1,9 @@
+# cypress/included:3.3.0
+
+Read [Run Cypress with a single Docker command](https://www.cypress.io/blog/2019/05/02/run-cypress-with-a-single-docker-command/)
+
+```shell
+$ docker run -it -v $PWD:/e2e -w /e2e --entrypoint cypress cypress/included:3.3.0 --version
+Cypress package version: 3.3.0
+Cypress binary version: 3.3.0
+```

--- a/included/3.3.0/build.sh
+++ b/included/3.3.0/build.sh
@@ -1,0 +1,6 @@
+set e+x
+
+LOCAL_NAME=cypress/included:3.3.0
+
+echo "Building $LOCAL_NAME"
+docker build -t $LOCAL_NAME .

--- a/included/README.md
+++ b/included/README.md
@@ -5,6 +5,7 @@ Docker image with operating system and Cypress installed globally.
 Name + Tag | OS image
 --- | ---
 [cypress/included:3.2.0](3.2.0) | `cypress/base:12.1.0`
+[cypress/included:3.3.0](3.3.0) | `cypress/base:12.1.0`
 
 This image should be enough to run Cypress tests headlessly or in the interactive mode with a single Docker command like this:
 
@@ -13,3 +14,24 @@ $ docker run -it -v $PWD:/e2e -w /e2e cypress/included:3.2.0
 ```
 
 For more information, read [Run Cypress with a single Docker command](https://www.cypress.io/blog/2019/05/02/run-cypress-with-a-single-docker-command/) and [End-to-End Testing Web Apps: The Painless Way](https://mtlynch.io/painless-web-app-testing/)
+
+## Building and testing
+
+To build a new image, clone an existing folder, update version strings and build the Docker image locally. Then test it by creating a new project and running headless tests. For example:
+
+```shell
+cd /tmp
+mkdir test
+cd test
+npm init --yes
+npm i -D cypress
+npx @bahmutov/cly init
+rm -rf package-lock.json package.json node_modules
+docker run -it -v $PWD:/e2e -w /e2e cypress/included:3.3.0
+```
+
+The tests should finish successfully using local image. Now push the image to the Docker hub
+
+```shell
+docker push cypress/included:3.3.0
+```


### PR DESCRIPTION
- closes #115 

```
 node version:    v12.1.0 
 npm version:     6.9.0 
 yarn version:    1.15.2 
 debian version:  9.8 
 user:            root

3.3.0: digest: sha256:ab3ec8dd2746723861bddfb76c58a9931c85df1a5080b5f8d1634d9516d1fa5e size: 3058
```