### PR TITLE
add latest centos7 based on Node 12.4.0

### DIFF
--- a/base/README.md
+++ b/base/README.md
@@ -21,6 +21,7 @@ cypress/base:10.16.0 | 10.16.0 | Debian | [/10.16.0](10.16.0) | 6.9.0 | 1.16.0
 cypress/base:11.13.0 | 11.13.0 | Debian | [/11.13.0](11.13.0) | 6.9.0 | 1.15.2
 cypress/base:12.1.0 | 12.1.0 | Debian | [/12.1.0](12.1.0) | 6.9.0 | 1.15.2
 cypress/base:centos7 | 6 | CentOS | [/centos7](centos7) | 3.10.10 | 🚫
+cypress/base:centos7-12.4.0 | 12.4.0 | CentOS | [/centos7](centos7) | 6.9.0 | 🚫
 cypress/base:ubuntu16 | 6 | Ubuntu | [/ubuntu16](ubuntu16) | 3.10.10 | 🚫
 
 ⚠️ Cypress no longer supports Node v0.12.x. Using 4.x, 6.x images is not recommended, and we do not plan to release new versions of Cypress tested on Node v4. See [End-of-Life Releases](https://github.com/nodejs/Release#end-of-life-releases).

--- a/base/centos7-12.4.0/Dockerfile
+++ b/base/centos7-12.4.0/Dockerfile
@@ -1,0 +1,45 @@
+FROM centos:7
+
+# To find which package provides missing dependency, for example libXss.so
+#   yum whatprovides libXss*
+# and then install displayed answer like
+#   yum install -y libXScrnSaver*
+
+# install commands taken from
+# https://tecadmin.net/install-latest-nodejs-and-npm-on-centos/
+RUN yum install -y gcc-c++ make
+RUN curl -sL https://rpm.nodesource.com/setup_12.x | bash -
+
+# Install Node
+RUN yum install -y nodejs
+RUN node -v
+RUN npm -v
+
+# Install dependencies
+RUN yum install -y xorg-x11-server-Xvfb
+RUN yum install -y xorg-x11-xauth
+# note:
+#   Gtk2 for Cypress < 3.3.0
+#   Gtk3 for Cypress >= 3.3.0
+RUN yum install -y gtk2-2.24*
+RUN yum install -y gtk3-3.22*
+RUN yum install -y libXtst*
+# provides libXss
+RUN yum install -y libXScrnSaver*
+# provides libgconf-2
+RUN yum install -y GConf2*
+# provides libasound
+RUN yum install -y alsa-lib*
+
+RUN npm install yarn -g
+
+# there is some dependency I cannot figure out missing
+# which gets installed when installing "git*"
+RUN yum install -y git*
+
+# versions of local tools
+RUN echo  " node version:    $(node -v) \n" \
+  "npm version:     $(npm -v) \n" \
+  "yarn version:    $(yarn -v) \n" \
+  "centOS version:  $(cat /etc/centos-release) \n" \
+  "user:            $(whoami) \n"

--- a/base/centos7-12.4.0/README.md
+++ b/base/centos7-12.4.0/README.md
@@ -1,0 +1,14 @@
+# cypress/base:centos7
+
+This image was built to resolve [issue #18](https://github.com/cypress-io/cypress-docker-images/issues/18)
+
+## Example
+
+Sample Dockerfile
+
+```
+FROM cypress/base:centos7
+RUN npm install --save-dev cypress
+RUN $(npm bin)/cypress verify
+RUN $(npm bin)/cypress run
+```

--- a/base/centos7-12.4.0/build.sh
+++ b/base/centos7-12.4.0/build.sh
@@ -1,0 +1,7 @@
+set e+x
+
+# build image with Cypress dependencies
+LOCAL_NAME=cypress/base:centos7-12.4.0
+
+echo "Building $LOCAL_NAME"
+docker build -t $LOCAL_NAME .

--- a/test/Dockerfile
+++ b/test/Dockerfile
@@ -1,4 +1,5 @@
-FROM cypress/base:10.16.0
+FROM cypress/base:centos7-12.4.0
+# FROM cypress/base:10.16.0
 # FROM cypress/browsers:node8.9.3-chrome73
 
 # avoid too many progress messages


### PR DESCRIPTION
Add image `cypress/base:centos7-12.4.0`

```
node version:    v12.4.0
npm version:     6.9.0
yarn version:    1.16.0
centOS version:  CentOS Linux release 7.6.1810 (Core) 
user:            root
```