### PR TITLE
Add included:3.3.2

### DIFF
--- a/included/3.3.2/Dockerfile
+++ b/included/3.3.2/Dockerfile
@@ -1,0 +1,24 @@
+FROM cypress/base:12.1.0
+
+# avoid too many progress messages
+# https://github.com/cypress-io/cypress/issues/1243
+ENV CI=1
+ARG CYPRESS_VERSION="3.3.2"
+
+RUN echo "whoami: $(whoami)"
+RUN npm config -g set user $(whoami)
+RUN npm install -g "cypress@${CYPRESS_VERSION}"
+RUN cypress verify
+
+# Cypress cache and installed version
+RUN cypress cache path
+RUN cypress cache list
+
+# versions of local tools
+RUN echo  " node version:    $(node -v) \n" \
+  "npm version:     $(npm -v) \n" \
+  "yarn version:    $(yarn -v) \n" \
+  "debian version:  $(cat /etc/debian_version) \n" \
+  "user:            $(whoami) \n"
+
+ENTRYPOINT ["cypress", "run"]

--- a/included/3.3.2/README.md
+++ b/included/3.3.2/README.md
@@ -1,0 +1,9 @@
+# cypress/included:3.3.2
+
+Read [Run Cypress with a single Docker command](https://www.cypress.io/blog/2019/05/02/run-cypress-with-a-single-docker-command/)
+
+```shell
+$ docker run -it -v $PWD:/e2e -w /e2e --entrypoint cypress cypress/included:3.3.2 --version
+Cypress package version: 3.3.2
+Cypress binary version: 3.3.2
+```

--- a/included/3.3.2/build.sh
+++ b/included/3.3.2/build.sh
@@ -1,0 +1,6 @@
+set e+x
+
+LOCAL_NAME=cypress/included:3.3.2
+
+echo "Building $LOCAL_NAME"
+docker build -t $LOCAL_NAME .

--- a/test/Dockerfile
+++ b/test/Dockerfile
@@ -11,7 +11,7 @@ ENV CI=1
 RUN npm init --yes
 
 # install either a specific version of Cypress
-RUN npm install --save-dev cypress@3.3.1
+RUN npm install --save-dev cypress@3.3.2
 # or install a beta version of Cypress using environment variables
 # ENV CYPRESS_INSTALL_BINARY=https://cdn.cypress.io/beta/binary/3.3.0/linux64/circle-develop-40502cbfb7b934afce0a7b1dba4141dab4adb202-100529/cypress.zip
 # RUN npm install https://cdn.cypress.io/beta/npm/3.3.0/circle-develop-40502cbfb7b934afce0a7b1dba4141dab4adb202-100527/cypress.tgz


### PR DESCRIPTION
This PR adds the included image for cypress 3.3.2

Temporarily available on dockerhub as: tdamsma/included:3.3.2