### PR TITLE
Add cypress/base:12.0.0, cypress/browsers:12.0.0-chrome75

### DIFF
--- a/base/12.0.0/Dockerfile
+++ b/base/12.0.0/Dockerfile
@@ -29,7 +29,7 @@ RUN apt-get update && \
   # clean up
   && rm -rf /var/lib/apt/lists/*
 
-RUN npm install -g npm@6.9.0
+RUN npm install -g npm@6.10.0
 RUN npm install -g yarn@1.16.0
 
 # a few environment variables to make NPM installs easier

--- a/base/12.0.0/Dockerfile
+++ b/base/12.0.0/Dockerfile
@@ -1,0 +1,48 @@
+FROM node:12.0.0
+
+## https://superuser.com/a/1423685/458816
+RUN printf "deb http://archive.debian.org/debian/ jessie main\ndeb-src http://archive.debian.org/debian/ jessie main\ndeb http://security.debian.org jessie/updates main\ndeb-src http://security.debian.org jessie/updates main" > /etc/apt/sources.list
+
+RUN apt-get update && \
+  apt-get install --no-install-recommends -y \
+  libgtk2.0-0 \
+  libgtk-3-0 \
+  libnotify-dev \
+  libgconf-2-4 \
+  libnss3 \
+  libxss1 \
+  libasound2 \
+  libxtst6 \
+  xauth \
+  xvfb \
+  # install Chinese fonts
+  # this list was copied from https://github.com/jim3ma/docker-leanote
+  fonts-arphic-bkai00mp \
+  fonts-arphic-bsmi00lp \
+  fonts-arphic-gbsn00lp \
+  fonts-arphic-gkai00mp \
+  fonts-arphic-ukai \
+  fonts-arphic-uming \
+  ttf-wqy-zenhei \
+  ttf-wqy-microhei \
+  xfonts-wqy \
+  # clean up
+  && rm -rf /var/lib/apt/lists/*
+
+RUN npm install -g npm@6.9.0
+RUN npm install -g yarn@1.16.0
+
+# a few environment variables to make NPM installs easier
+# good colors for most applications
+ENV TERM xterm
+# avoid million NPM install messages
+ENV npm_config_loglevel warn
+# allow installing when the main user is root
+ENV npm_config_unsafe_perm true
+
+# versions of local tools
+RUN echo  " node version:    $(node -v) \n" \
+  "npm version:     $(npm -v) \n" \
+  "yarn version:    $(yarn -v) \n" \
+  "debian version:  $(cat /etc/debian_version) \n" \
+  "user:            $(whoami) \n"

--- a/base/12.0.0/README.md
+++ b/base/12.0.0/README.md
@@ -1,0 +1,12 @@
+# cypress/base:12.0.0
+
+## Example
+
+Sample Dockerfile
+
+```
+FROM cypress/base:12.0.0
+RUN npm install --save-dev cypress
+RUN $(npm bin)/cypress verify
+RUN $(npm bin)/cypress run
+```

--- a/base/12.0.0/build.sh
+++ b/base/12.0.0/build.sh
@@ -1,0 +1,7 @@
+set e+x
+
+# build image with Cypress dependencies
+LOCAL_NAME=cypress/base:12.0.0
+
+echo "Building $LOCAL_NAME"
+docker build -t $LOCAL_NAME .

--- a/base/README.md
+++ b/base/README.md
@@ -20,7 +20,7 @@ cypress/base:10.11.0 | 10.11.0 | Debian | [/10.11.0](10.11.0) | 6.9.0 | 1.16.0 |
 cypress/base:10.15.3 | 10.15.3 | Debian | [/10.15.3](10.15.3) | 6.9.0 | 1.15.2
 cypress/base:10.16.0 | 10.16.0 | Debian | [/10.16.0](10.16.0) | 6.9.0 | 1.16.0
 cypress/base:11.13.0 | 11.13.0 | Debian | [/11.13.0](11.13.0) | 6.9.0 | 1.15.2
-cypress/base:12.0.0 | 12.0.0 | Debian | [/12.0.0](12.0.0) | 6.9.0 | 1.16.0
+cypress/base:12.0.0 | 12.0.0 | Debian | [/12.0.0](12.0.0) | 6.10.0 | 1.16.0
 cypress/base:12.1.0 | 12.1.0 | Debian | [/12.1.0](12.1.0) | 6.9.0 | 1.15.2
 cypress/base:centos7 | 6 | CentOS | [/centos7](centos7) | 3.10.10 | 🚫
 cypress/base:centos7-12.4.0 | 12.4.0 | CentOS | [/centos7](centos7) | 6.9.0 | 1.16.0

--- a/base/README.md
+++ b/base/README.md
@@ -20,6 +20,7 @@ cypress/base:10.11.0 | 10.11.0 | Debian | [/10.11.0](10.11.0) | 6.9.0 | 1.16.0 |
 cypress/base:10.15.3 | 10.15.3 | Debian | [/10.15.3](10.15.3) | 6.9.0 | 1.15.2
 cypress/base:10.16.0 | 10.16.0 | Debian | [/10.16.0](10.16.0) | 6.9.0 | 1.16.0
 cypress/base:11.13.0 | 11.13.0 | Debian | [/11.13.0](11.13.0) | 6.9.0 | 1.15.2
+cypress/base:12.0.0 | 12.0.0 | Debian | [/12.0.0](12.0.0) | 6.9.0 | 1.16.0
 cypress/base:12.1.0 | 12.1.0 | Debian | [/12.1.0](12.1.0) | 6.9.0 | 1.15.2
 cypress/base:centos7 | 6 | CentOS | [/centos7](centos7) | 3.10.10 | 🚫
 cypress/base:centos7-12.4.0 | 12.4.0 | CentOS | [/centos7](centos7) | 6.9.0 | 1.16.0

--- a/browsers/README.md
+++ b/browsers/README.md
@@ -15,5 +15,6 @@ Image `cypress/browsers:chrome69` is tagged [`latest`](https://hub.docker.com/r/
 - Node 10.2.1 + Chrome 74 [/node10.2.1-chrome74](node10.2.1-chrome74)
 - Node 10.11.0 + Chrome 75 [/node10.11.0-chrome75](node10.11.0-chrome75)
 - Node 11.13.0 + Chrome 73 [/node11.13.0-chrome73](node11.13.0-chrome73)
+- Node 12.0.0 + Chrome 75 [/node12.0.0-chrome75](node12.0.0-chrome75)
 
 We only provide browsers for `Debian`, but you can use our base images and build your own. See Cypress [Docker documentation](https://on.cypress.io/docker).

--- a/browsers/node12.0.0-chrome75/Dockerfile
+++ b/browsers/node12.0.0-chrome75/Dockerfile
@@ -1,0 +1,29 @@
+FROM cypress/base:12.0.0
+
+USER root
+
+RUN node --version
+RUN echo "force new chrome here"
+
+# install Chromebrowser
+RUN \
+  wget -q -O - https://dl-ssl.google.com/linux/linux_signing_key.pub | apt-key add - && \
+  echo "deb http://dl.google.com/linux/chrome/deb/ stable main" > /etc/apt/sources.list.d/google.list && \
+  apt-get update && \
+  apt-get install -y dbus-x11 google-chrome-stable && \
+  rm -rf /var/lib/apt/lists/*
+
+# "fake" dbus address to prevent errors
+# https://github.com/SeleniumHQ/docker-selenium/issues/87
+ENV DBUS_SESSION_BUS_ADDRESS=/dev/null
+
+# Add zip utility - it comes in very handy
+RUN apt-get update && apt-get install -y zip
+
+# versions of local tools
+RUN echo  " node version:    $(node -v) \n" \
+  "npm version:     $(npm -v) \n" \
+  "yarn version:    $(yarn -v) \n" \
+  "debian version:  $(cat /etc/debian_version) \n" \
+  "Chrome version:  $(google-chrome --version) \n" \
+  "git version:     $(git --version) \n"

--- a/browsers/node12.0.0-chrome75/Dockerfile
+++ b/browsers/node12.0.0-chrome75/Dockerfile
@@ -8,10 +8,13 @@ RUN echo "force new chrome here"
 # install Chromebrowser
 RUN \
   wget -q -O - https://dl-ssl.google.com/linux/linux_signing_key.pub | apt-key add - && \
-  echo "deb http://dl.google.com/linux/chrome/deb/ stable main" > /etc/apt/sources.list.d/google.list && \
-  apt-get update && \
-  apt-get install -y dbus-x11 google-chrome-stable && \
-  rm -rf /var/lib/apt/lists/*
+  echo "deb http://dl.google.com/linux/chrome/deb/ stable main" > /etc/apt/sources.list.d/google.list
+RUN apt-get update
+# disabled dbus install - could not get it to install
+# but tested an example project, and Chrome seems to run fine
+# RUN apt-get install -y dbus-x11
+RUN apt-get install -y google-chrome-stable
+RUN rm -rf /var/lib/apt/lists/*
 
 # "fake" dbus address to prevent errors
 # https://github.com/SeleniumHQ/docker-selenium/issues/87

--- a/browsers/node12.0.0-chrome75/README.md
+++ b/browsers/node12.0.0-chrome75/README.md
@@ -1,0 +1,20 @@
+# cypress/browsers:node12.0.0-chrome75
+
+A complete image with all operating system dependencies for Cypress and Chrome 75 browser
+
+[Dockerfile](Dockerfile)
+
+Note: this image is mostly used for internal building and testing of Cypress test runner v3.3.x
+
+## Example
+
+If you want to build your image
+
+```
+FROM cypress/browsers:node12.0.0-chrome75
+RUN npm i cypress
+RUN $(npm bin)/cypress run --browser chrome
+```
+
+This image uses the `root` user. You might want to switch to non-root
+user when running this container for security.

--- a/browsers/node12.0.0-chrome75/build.sh
+++ b/browsers/node12.0.0-chrome75/build.sh
@@ -1,0 +1,6 @@
+set e+x
+
+LOCAL_NAME=cypress/browsers:node12.0.0-chrome75
+
+echo "Building $LOCAL_NAME"
+docker build -t $LOCAL_NAME .

--- a/test/Dockerfile
+++ b/test/Dockerfile
@@ -1,6 +1,6 @@
 # FROM cypress/base:10.11.0
-# FROM cypress/base:10.16.0
-FROM cypress/browsers:node10.11.0-chrome75
+FROM cypress/base:12.0.0
+# FROM cypress/browsers:node10.11.0-chrome75
 
 RUN echo "current user: $(whoami)"
 
@@ -22,4 +22,4 @@ RUN npx @bahmutov/cly init
 # if testing a base image with just Electron use "cypress run"
 RUN $(npm bin)/cypress run
 # if testing an image with Chrome browser
-RUN $(npm bin)/cypress run --browser chrome
+# RUN $(npm bin)/cypress run --browser chrome

--- a/test/Dockerfile
+++ b/test/Dockerfile
@@ -1,6 +1,6 @@
 # FROM cypress/base:10.11.0
-FROM cypress/base:12.0.0
-# FROM cypress/browsers:node10.11.0-chrome75
+# FROM cypress/base:12.0.0
+FROM cypress/browsers:node12.0.0-chrome75
 
 RUN echo "current user: $(whoami)"
 
@@ -22,4 +22,4 @@ RUN npx @bahmutov/cly init
 # if testing a base image with just Electron use "cypress run"
 RUN $(npm bin)/cypress run
 # if testing an image with Chrome browser
-# RUN $(npm bin)/cypress run --browser chrome
+RUN $(npm bin)/cypress run --browser chrome


### PR DESCRIPTION
Add 2 new docker images to match the Node version for Electron 5.x:

* cypress/base:12.0.0
* cypress/browsers:12.0.0-chrome74