### PR TITLE
added cypress/browsers:node12.6.0-chrome75 

### DIFF
--- a/browsers/README.md
+++ b/browsers/README.md
@@ -8,6 +8,7 @@ Name + Tag | Base image | Chrome
 --- | --- | ---
 [cypress/browsers:node12.6.0-chrome75](./node12.6.0-chrome75) | `cypress/base:12.6.0` | `75.0.3770.100`
 
+Other images:
 
 - Node 6 + Chrome 63 + Firefox 57 [/chrome63-ff57](chrome63-ff57)
 - Node 8 + Chrome 65 + Firefox 57 [/chrome65-ff57](chrome65-ff57)
@@ -21,6 +22,5 @@ Name + Tag | Base image | Chrome
 - Node 10.11.0 + Chrome 75 [/node10.11.0-chrome75](node10.11.0-chrome75)
 - Node 11.13.0 + Chrome 73 [/node11.13.0-chrome73](node11.13.0-chrome73)
 - Node 12.0.0 + Chrome 75 [/node12.0.0-chrome75](node12.0.0-chrome75)
-- Node 12.6.0 + Chrome 75 [/node12.6.0-chrome75](node12.6.0-chrome75)
 
 We only provide browsers for `Debian`, but you can use our base images and build your own. See Cypress [Docker documentation](https://on.cypress.io/docker).

--- a/browsers/README.md
+++ b/browsers/README.md
@@ -4,6 +4,11 @@
 
 Image `cypress/browsers:chrome69` is tagged [`latest`](https://hub.docker.com/r/cypress/browsers/tags/)
 
+Name + Tag | Base image | Chrome
+--- | --- | ---
+[cypress/browsers:node12.6.0-chrome75](./node12.6.0-chrome75) | `cypress/base:12.6.0` | `75.0.3770.100`
+
+
 - Node 6 + Chrome 63 + Firefox 57 [/chrome63-ff57](chrome63-ff57)
 - Node 8 + Chrome 65 + Firefox 57 [/chrome65-ff57](chrome65-ff57)
 - Node 8 + Chrome 67 + Firefox 57 [/chrome67-ff57](chrome67-ff57)
@@ -16,5 +21,6 @@ Image `cypress/browsers:chrome69` is tagged [`latest`](https://hub.docker.com/r/
 - Node 10.11.0 + Chrome 75 [/node10.11.0-chrome75](node10.11.0-chrome75)
 - Node 11.13.0 + Chrome 73 [/node11.13.0-chrome73](node11.13.0-chrome73)
 - Node 12.0.0 + Chrome 75 [/node12.0.0-chrome75](node12.0.0-chrome75)
+- Node 12.6.0 + Chrome 75 [/node12.6.0-chrome75](node12.6.0-chrome75)
 
 We only provide browsers for `Debian`, but you can use our base images and build your own. See Cypress [Docker documentation](https://on.cypress.io/docker).

--- a/browsers/node12.6.0-chrome75/Dockerfile
+++ b/browsers/node12.6.0-chrome75/Dockerfile
@@ -1,0 +1,32 @@
+FROM cypress/base:12.6.0
+
+USER root
+
+RUN node --version
+RUN echo "force new chrome here"
+
+# install Chromebrowser
+RUN \
+  wget -q -O - https://dl-ssl.google.com/linux/linux_signing_key.pub | apt-key add - && \
+  echo "deb http://dl.google.com/linux/chrome/deb/ stable main" > /etc/apt/sources.list.d/google.list
+RUN apt-get update
+# disabled dbus install - could not get it to install
+# but tested an example project, and Chrome seems to run fine
+# RUN apt-get install -y dbus-x11
+RUN apt-get install -y google-chrome-stable
+RUN rm -rf /var/lib/apt/lists/*
+
+# "fake" dbus address to prevent errors
+# https://github.com/SeleniumHQ/docker-selenium/issues/87
+ENV DBUS_SESSION_BUS_ADDRESS=/dev/null
+
+# Add zip utility - it comes in very handy
+RUN apt-get update && apt-get install -y zip
+
+# versions of local tools
+RUN echo  " node version:    $(node -v) \n" \
+  "npm version:     $(npm -v) \n" \
+  "yarn version:    $(yarn -v) \n" \
+  "debian version:  $(cat /etc/debian_version) \n" \
+  "Chrome version:  $(google-chrome --version) \n" \
+  "git version:     $(git --version) \n"

--- a/browsers/node12.6.0-chrome75/README.md
+++ b/browsers/node12.6.0-chrome75/README.md
@@ -1,0 +1,18 @@
+# cypress/browsers:node12.6.0-chrome75
+
+A complete image with all operating system dependencies for Cypress and Chrome 75 browser
+
+[Dockerfile](Dockerfile)
+
+## Example
+
+If you want to build your image
+
+```
+FROM cypress/browsers:node12.6.0-chrome75
+RUN npm i cypress
+RUN $(npm bin)/cypress run --browser chrome
+```
+
+This image uses the `root` user. You might want to switch to non-root
+user when running this container for security.

--- a/browsers/node12.6.0-chrome75/build.sh
+++ b/browsers/node12.6.0-chrome75/build.sh
@@ -1,0 +1,6 @@
+set e+x
+
+LOCAL_NAME=cypress/browsers:node12.6.0-chrome75
+
+echo "Building $LOCAL_NAME"
+docker build -t $LOCAL_NAME .

--- a/included/3.4.0/Dockerfile
+++ b/included/3.4.0/Dockerfile
@@ -1,0 +1,23 @@
+FROM cypress/browsers:node12.6.0-chrome75
+
+# avoid too many progress messages
+# https://github.com/cypress-io/cypress/issues/1243
+ENV CI=1
+ARG CYPRESS_VERSION="3.4.0"
+
+RUN echo "whoami: $(whoami)"
+RUN npm config -g set user $(whoami)
+RUN npm install -g "cypress@${CYPRESS_VERSION}"
+RUN cypress verify
+
+# Cypress cache and installed version
+RUN cypress cache path
+RUN cypress cache list
+
+RUN echo  " node version:    $(node -v) \n" \
+  "npm version:     $(npm -v) \n" \
+  "yarn version:    $(yarn -v) \n" \
+  "debian version:  $(cat /etc/debian_version) \n" \
+  "user:            $(whoami) \n"
+
+ENTRYPOINT ["cypress", "run"]

--- a/included/3.4.0/README.md
+++ b/included/3.4.0/README.md
@@ -1,0 +1,18 @@
+# cypress/included:3.4.0
+
+Read [Run Cypress with a single Docker command](https://www.cypress.io/blog/2019/05/02/run-cypress-with-a-single-docker-command/)
+
+## Run tests
+
+```shell
+$ docker run -it -v $PWD:/e2e -w /e2e cypress/included:3.4.0
+# runs Cypress tests from the current folder
+```
+
+## Show Cypress version
+
+```shell
+$ docker run -it -v $PWD:/e2e -w /e2e --entrypoint cypress cypress/included:3.4.0 --version
+Cypress package version: 3.4.0
+Cypress binary version: 3.4.0
+```

--- a/included/3.4.0/build.sh
+++ b/included/3.4.0/build.sh
@@ -1,0 +1,6 @@
+set e+x
+
+LOCAL_NAME=cypress/included:3.4.0
+
+echo "Building $LOCAL_NAME"
+docker build -t $LOCAL_NAME .

--- a/included/README.md
+++ b/included/README.md
@@ -2,12 +2,13 @@
 
 Docker image with operating system and Cypress installed globally.
 
-Name + Tag | OS image
+Name + Tag | Base image
 --- | ---
 [cypress/included:3.2.0](3.2.0) | `cypress/base:12.1.0`
 [cypress/included:3.3.0](3.3.0) | `cypress/base:12.1.0`
 [cypress/included:3.3.1](3.3.1) | `cypress/base:12.1.0`
 [cypress/included:3.3.2](3.3.2) | `cypress/base:12.1.0`
+[cypress/included:3.4.0](3.4.0) | `cypress/base:12.6.0`
 
 This image should be enough to run Cypress tests headlessly or in the interactive mode with a single Docker command like this:
 

--- a/included/README.md
+++ b/included/README.md
@@ -8,7 +8,7 @@ Name + Tag | Base image
 [cypress/included:3.3.0](3.3.0) | `cypress/base:12.1.0`
 [cypress/included:3.3.1](3.3.1) | `cypress/base:12.1.0`
 [cypress/included:3.3.2](3.3.2) | `cypress/base:12.1.0`
-[cypress/included:3.4.0](3.4.0) | `cypress/base:12.6.0`
+[cypress/included:3.4.0](3.4.0) | `cypress/browsers:node12.6.0-chrome75`
 
 This image should be enough to run Cypress tests headlessly or in the interactive mode with a single Docker command like this:
 

--- a/test/Dockerfile
+++ b/test/Dockerfile
@@ -1,6 +1,6 @@
 # FROM cypress/base:10.11.0
-FROM cypress/base:12.6.0
-# FROM cypress/browsers:node12.0.0-chrome75
+# FROM cypress/base:12.6.0
+FROM cypress/browsers:node12.6.0-chrome75
 
 RUN echo "current user: $(whoami)"
 
@@ -11,7 +11,7 @@ ENV CI=1
 RUN npm init --yes
 
 # install either a specific version of Cypress
-RUN npm install --save-dev cypress@3.3.2
+RUN npm install --save-dev cypress@3.4.0
 # or install a beta version of Cypress using environment variables
 # ENV CYPRESS_INSTALL_BINARY=https://cdn.cypress.io/beta/binary/3.3.0/linux64/circle-develop-40502cbfb7b934afce0a7b1dba4141dab4adb202-100529/cypress.zip
 # RUN npm install https://cdn.cypress.io/beta/npm/3.3.0/circle-develop-40502cbfb7b934afce0a7b1dba4141dab4adb202-100527/cypress.tgz
@@ -22,4 +22,4 @@ RUN npx @bahmutov/cly init
 # if testing a base image with just Electron use "cypress run"
 RUN $(npm bin)/cypress run
 # if testing an image with Chrome browser
-# RUN $(npm bin)/cypress run --browser chrome
+RUN $(npm bin)/cypress run --browser chrome


### PR DESCRIPTION
added `cypress/browsers:node12.6.0-chrome75` image

```
 node version:    v12.6.0 
 npm version:     6.10.0 
 yarn version:    1.16.0 
 debian version:  9.9 
 Chrome version:  Google Chrome 75.0.3770.100  
 git version:     git version 2.11.0
```

added `cypress/included:3.4.0` built on top of `cypress/browsers:node12.6.0-chrome75`

```
 node version:    v12.6.0 
 npm version:     6.10.0 
 yarn version:    1.16.0 
 debian version:  9.9 
 user:            root
```

- closes #128