### PR TITLE
Add cypress/browsers:node10.16.0-chrome76

### DIFF
--- a/browsers/README.md
+++ b/browsers/README.md
@@ -22,6 +22,7 @@ Other images:
 - Node 10 + Chrome 69 [/chrome69](chrome69)
 - Node 10.2.1 + Chrome 74 [/node10.2.1-chrome74](node10.2.1-chrome74)
 - Node 10.11.0 + Chrome 75 [/node10.11.0-chrome75](node10.11.0-chrome75)
+- Node 10.16.0 + Chrome 76 [/node10.16.0-chrome75](node10.16.0-chrome76)
 - Node 11.13.0 + Chrome 73 [/node11.13.0-chrome73](node11.13.0-chrome73)
 - Node 12.0.0 + Chrome 75 [/node12.0.0-chrome75](node12.0.0-chrome75)
 

--- a/browsers/node10.16.0-chrome76/Dockerfile
+++ b/browsers/node10.16.0-chrome76/Dockerfile
@@ -1,0 +1,29 @@
+FROM cypress/base:10.16.0
+
+USER root
+
+RUN node --version
+RUN echo "force new chrome here"
+
+# install Chromebrowser
+RUN \
+  wget -q -O - https://dl-ssl.google.com/linux/linux_signing_key.pub | apt-key add - && \
+  echo "deb http://dl.google.com/linux/chrome/deb/ stable main" > /etc/apt/sources.list.d/google.list && \
+  apt-get update && \
+  apt-get install -y dbus-x11 google-chrome-stable && \
+  rm -rf /var/lib/apt/lists/*
+
+# "fake" dbus address to prevent errors
+# https://github.com/SeleniumHQ/docker-selenium/issues/87
+ENV DBUS_SESSION_BUS_ADDRESS=/dev/null
+
+# Add zip utility - it comes in very handy
+RUN apt-get update && apt-get install -y zip
+
+# versions of local tools
+RUN echo  " node version:    $(node -v) \n" \
+  "npm version:     $(npm -v) \n" \
+  "yarn version:    $(yarn -v) \n" \
+  "debian version:  $(cat /etc/debian_version) \n" \
+  "Chrome version:  $(google-chrome --version) \n" \
+  "git version:     $(git --version) \n"

--- a/browsers/node10.16.0-chrome76/README.md
+++ b/browsers/node10.16.0-chrome76/README.md
@@ -1,0 +1,20 @@
+# cypress/browsers:node10.16.0-chrome76
+
+A complete image with all operating system dependencies for Cypress and Chrome 76 browser
+
+[Dockerfile](Dockerfile)
+
+Note: this image is mostly used for internal building and testing of Cypress test runner v3.3.x
+
+## Example
+
+If you want to build your image
+
+```
+FROM cypress/browsers:node10.16.0-chrome76
+RUN npm i cypress
+RUN $(npm bin)/cypress run --browser chrome
+```
+
+This image uses the `root` user. You might want to switch to non-root
+user when running this container for security.

--- a/browsers/node10.16.0-chrome76/build.sh
+++ b/browsers/node10.16.0-chrome76/build.sh
@@ -1,0 +1,6 @@
+set e+x
+
+LOCAL_NAME=cypress/browsers:node10.16.0-chrome76
+
+echo "Building $LOCAL_NAME"
+docker build -t $LOCAL_NAME .


### PR DESCRIPTION
Adds a new docker file to utilize node version 10.16.0 for Chrome browsers.