### PR TITLE
add cypress/browsers:node8.9.3-npm6.10.1-chrome76-ff-68

### DIFF
--- a/browsers/README.md
+++ b/browsers/README.md
@@ -18,6 +18,7 @@ Other images:
 - Node 8 + Chrome 67 [/chrome67](chrome67)
 - Node 8.2.1 + Chrome 73 [/node8.2.1-chrome73](node8.2.1-chrome73)
 - Node 8.9.3 + Chrome 73 [/node8.9.3-chrome73](node8.9.3-chrome73)
+- Node 8.9.3 + Chrome 76 + Firefox 68 [/node8.9.3-npm6.10.1-chrome76-ff68](node8.9.3-npm6.10.1-chrome76-ff68)
 - Node 8.15.1 + Chrome 73 [/node8.15.1-chrome73](node8.15.1-chrome73)
 - Node 10 + Chrome 69 [/chrome69](chrome69)
 - Node 10.2.1 + Chrome 74 [/node10.2.1-chrome74](node10.2.1-chrome74)

--- a/browsers/node8.9.3-npm6.10.1-chrome76-ff68/Dockerfile
+++ b/browsers/node8.9.3-npm6.10.1-chrome76-ff68/Dockerfile
@@ -1,0 +1,44 @@
+FROM cypress/base:8.9.3-npm-6.10.1
+
+ARG FIREFOX_VERSION=68.0.2
+
+USER root
+
+RUN node --version
+RUN echo "force new chrome here"
+
+# install Chromebrowser
+RUN \
+  wget -q -O - https://dl-ssl.google.com/linux/linux_signing_key.pub | apt-key add - &&
+  echo "deb http://dl.google.com/linux/chrome/deb/ stable main" >/etc/apt/sources.list.d/google.list
+RUN apt-get update
+# disabled dbus install - could not get it to install
+# but tested an example project, and Chrome seems to run fine
+# RUN apt-get install -y dbus-x11
+RUN apt-get install -y google-chrome-stable
+RUN rm -rf /var/lib/apt/lists/*
+
+# "fake" dbus address to prevent errors
+# https://github.com/SeleniumHQ/docker-selenium/issues/87
+ENV DBUS_SESSION_BUS_ADDRESS=/dev/null
+
+# install Firefox browser
+RUN wget --no-verbose -O /tmp/firefox.tar.bz2 https://download-installer.cdn.mozilla.net/pub/firefox/releases/$FIREFOX_VERSION/linux-x86_64/en-US/firefox-$FIREFOX_VERSION.tar.bz2 &&
+  tar -C /opt -xjf /tmp/firefox.tar.bz2 &&
+  rm /tmp/firefox.tar.bz2 &&
+  ln -fs /opt/firefox/firefox /usr/bin/firefox
+
+# Add zip utility - it comes in very handy
+RUN apt-get update && apt-get install -y zip
+
+# Add zip utility - it comes in very handy
+RUN apt-get update && apt-get install -y zip
+
+# versions of local tools
+RUN echo " node version:    $(node -v) \n" \
+  "npm version:     $(npm -v) \n" \
+  "yarn version:    $(yarn -v) \n" \
+  "debian version:  $(cat /etc/debian_version) \n" \
+  "Chrome version:  $(google-chrome --version) \n" \
+  "Firefox version:  $(firefox --version) \n" \
+  "git version:     $(git --version) \n"

--- a/browsers/node8.9.3-npm6.10.1-chrome76-ff68/Dockerfile
+++ b/browsers/node8.9.3-npm6.10.1-chrome76-ff68/Dockerfile
@@ -31,9 +31,6 @@ RUN wget --no-verbose -O /tmp/firefox.tar.bz2 https://download-installer.cdn.moz
 # Add zip utility - it comes in very handy
 RUN apt-get update && apt-get install -y zip
 
-# Add zip utility - it comes in very handy
-RUN apt-get update && apt-get install -y zip
-
 # versions of local tools
 RUN echo " node version:    $(node -v) \n" \
   "npm version:     $(npm -v) \n" \

--- a/browsers/node8.9.3-npm6.10.1-chrome76-ff68/Dockerfile
+++ b/browsers/node8.9.3-npm6.10.1-chrome76-ff68/Dockerfile
@@ -9,7 +9,7 @@ RUN echo "force new chrome here"
 
 # install Chromebrowser
 RUN \
-  wget -q -O - https://dl-ssl.google.com/linux/linux_signing_key.pub | apt-key add - &&
+  wget -q -O - https://dl-ssl.google.com/linux/linux_signing_key.pub | apt-key add - && \
   echo "deb http://dl.google.com/linux/chrome/deb/ stable main" >/etc/apt/sources.list.d/google.list
 RUN apt-get update
 # disabled dbus install - could not get it to install
@@ -23,9 +23,9 @@ RUN rm -rf /var/lib/apt/lists/*
 ENV DBUS_SESSION_BUS_ADDRESS=/dev/null
 
 # install Firefox browser
-RUN wget --no-verbose -O /tmp/firefox.tar.bz2 https://download-installer.cdn.mozilla.net/pub/firefox/releases/$FIREFOX_VERSION/linux-x86_64/en-US/firefox-$FIREFOX_VERSION.tar.bz2 &&
-  tar -C /opt -xjf /tmp/firefox.tar.bz2 &&
-  rm /tmp/firefox.tar.bz2 &&
+RUN wget --no-verbose -O /tmp/firefox.tar.bz2 https://download-installer.cdn.mozilla.net/pub/firefox/releases/$FIREFOX_VERSION/linux-x86_64/en-US/firefox-$FIREFOX_VERSION.tar.bz2 && \
+  tar -C /opt -xjf /tmp/firefox.tar.bz2 && \
+  rm /tmp/firefox.tar.bz2 && \
   ln -fs /opt/firefox/firefox /usr/bin/firefox
 
 # Add zip utility - it comes in very handy
@@ -37,5 +37,5 @@ RUN echo " node version:    $(node -v) \n" \
   "yarn version:    $(yarn -v) \n" \
   "debian version:  $(cat /etc/debian_version) \n" \
   "Chrome version:  $(google-chrome --version) \n" \
-  "Firefox version:  $(firefox --version) \n" \
+  "Firefox version: $(firefox --version) \n" \
   "git version:     $(git --version) \n"

--- a/browsers/node8.9.3-npm6.10.1-chrome76-ff68/README.md
+++ b/browsers/node8.9.3-npm6.10.1-chrome76-ff68/README.md
@@ -1,4 +1,4 @@
-# cypress/browsers:node8.9.3-npm6.10.1-chrome76-ff-68
+# cypress/browsers:node8.9.3-npm6.10.1-chrome76-ff68
 
 A complete image with:
 - all operating system dependencies for Cypress
@@ -12,7 +12,7 @@ A complete image with:
 If you want to build your image
 
 ```
-FROM cypress/browsers:node8.9.3-npm6.10.1-chrome76-ff-68
+FROM cypress/browsers:node8.9.3-npm6.10.1-chrome76-ff68
 RUN npm i cypress
 RUN $(npm bin)/cypress run --browser chrome
 ```

--- a/browsers/node8.9.3-npm6.10.1-chrome76-ff68/README.md
+++ b/browsers/node8.9.3-npm6.10.1-chrome76-ff68/README.md
@@ -1,0 +1,21 @@
+# cypress/browsers:node8.9.3-npm6.10.1-chrome76-ff-68
+
+A complete image with:
+- all operating system dependencies for Cypress
+- Chrome 76 browser
+- Firefox 68 browser
+
+[Dockerfile](Dockerfile)
+
+## Example
+
+If you want to build your image
+
+```
+FROM cypress/browsers:node8.9.3-npm6.10.1-chrome76-ff-68
+RUN npm i cypress
+RUN $(npm bin)/cypress run --browser chrome
+```
+
+This image uses the `root` user. You might want to switch to non-root
+user when running this container for security.

--- a/browsers/node8.9.3-npm6.10.1-chrome76-ff68/build.sh
+++ b/browsers/node8.9.3-npm6.10.1-chrome76-ff68/build.sh
@@ -1,6 +1,6 @@
 set e+x
 
-LOCAL_NAME=cypress/browsers:node8.9.3-npm6.10.1-chrome76-ff-68
+LOCAL_NAME=cypress/browsers:node8.9.3-npm6.10.1-chrome76-ff68
 
 echo "Building $LOCAL_NAME"
 docker build -t $LOCAL_NAME .

--- a/browsers/node8.9.3-npm6.10.1-chrome76-ff68/build.sh
+++ b/browsers/node8.9.3-npm6.10.1-chrome76-ff68/build.sh
@@ -1,0 +1,6 @@
+set e+x
+
+LOCAL_NAME=cypress/browsers:node8.9.3-npm6.10.1-chrome76-ff-68
+
+echo "Building $LOCAL_NAME"
+docker build -t $LOCAL_NAME .


### PR DESCRIPTION
Pushed `cypress/browsers:node8.9.3-npm6.10.1-chrome76-ff68`

```
 node version:    v8.9.3 
 npm version:     6.10.1 
 yarn version:    1.17.3 
 debian version:  8.10 
 Chrome version:  Google Chrome 76.0.3809.132  
 Firefox version: Mozilla Firefox 68.0.2 
 git version:     git version 2.1.4
```