### PR TITLE
Docker image with Chrome 77 and Node 12.6.0

### DIFF
--- a/browsers/README.md
+++ b/browsers/README.md
@@ -26,5 +26,6 @@ Other images:
 - Node 10.16.0 + Chrome 76 [/node10.16.0-chrome75](node10.16.0-chrome76)
 - Node 11.13.0 + Chrome 73 [/node11.13.0-chrome73](node11.13.0-chrome73)
 - Node 12.0.0 + Chrome 75 [/node12.0.0-chrome75](node12.0.0-chrome75)
+- Node 12.6.0 + Chrome 77 [/node12.6.0-chrome77](node12.6.0-chrome77)
 
 We only provide browsers for `Debian`, but you can use our base images and build your own. See Cypress [Docker documentation](https://on.cypress.io/docker).

--- a/browsers/node12.6.0-chrome77/Dockerfile
+++ b/browsers/node12.6.0-chrome77/Dockerfile
@@ -1,0 +1,32 @@
+FROM cypress/base:12.6.0
+
+USER root
+
+RUN node --version
+RUN echo "force new chrome here"
+
+# install Chromebrowser
+RUN \
+  wget -q -O - https://dl-ssl.google.com/linux/linux_signing_key.pub | apt-key add - && \
+  echo "deb http://dl.google.com/linux/chrome/deb/ stable main" > /etc/apt/sources.list.d/google.list
+RUN apt-get update
+# disabled dbus install - could not get it to install
+# but tested an example project, and Chrome seems to run fine
+# RUN apt-get install -y dbus-x11
+RUN apt-get install -y google-chrome-stable
+RUN rm -rf /var/lib/apt/lists/*
+
+# "fake" dbus address to prevent errors
+# https://github.com/SeleniumHQ/docker-selenium/issues/87
+ENV DBUS_SESSION_BUS_ADDRESS=/dev/null
+
+# Add zip utility - it comes in very handy
+RUN apt-get update && apt-get install -y zip
+
+# versions of local tools
+RUN echo  " node version:    $(node -v) \n" \
+  "npm version:     $(npm -v) \n" \
+  "yarn version:    $(yarn -v) \n" \
+  "debian version:  $(cat /etc/debian_version) \n" \
+  "Chrome version:  $(google-chrome --version) \n" \
+  "git version:     $(git --version) \n"

--- a/browsers/node12.6.0-chrome77/README.md
+++ b/browsers/node12.6.0-chrome77/README.md
@@ -1,0 +1,18 @@
+# cypress/browsers:node12.6.0-chrome77
+
+A complete image with all operating system dependencies for Cypress and Chrome 76 browser
+
+[Dockerfile](Dockerfile)
+
+## Example
+
+If you want to build your image
+
+```
+FROM cypress/browsers:node12.6.0-chrome77
+RUN npm i cypress
+RUN $(npm bin)/cypress run --browser chrome
+```
+
+This image uses the `root` user. You might want to switch to non-root
+user when running this container for security.

--- a/browsers/node12.6.0-chrome77/build.sh
+++ b/browsers/node12.6.0-chrome77/build.sh
@@ -1,0 +1,6 @@
+set e+x
+
+LOCAL_NAME=cypress/browsers:node12.6.0-chrome77
+
+echo "Building $LOCAL_NAME"
+docker build -t $LOCAL_NAME .


### PR DESCRIPTION
I've built and tested this docker image containing Chrome 77.0.3865.90 and Node 12.6.0.

The image is not pushed to the Docker hub yet. Do we need the reviewers to approve this PR before pushing?