### PR TITLE
Update chrome version in README

### DIFF
--- a/browsers/node12.6.0-chrome77/README.md
+++ b/browsers/node12.6.0-chrome77/README.md
@@ -1,6 +1,6 @@
 # cypress/browsers:node12.6.0-chrome77
 
-A complete image with all operating system dependencies for Cypress and Chrome 76 browser
+A complete image with all operating system dependencies for Cypress and Chrome 77 browser
 
 [Dockerfile](Dockerfile)
 


### PR DESCRIPTION
Fixing a small typo in README.  I believe this container is for 77 and not 76. 