### PR TITLE
Add cypress/browsers:node12.0.0-chrome73

### DIFF
--- a/browsers/README.md
+++ b/browsers/README.md
@@ -26,6 +26,7 @@ Other images:
 - Node 10.16.0 + Chrome 76 [/node10.16.0-chrome75](node10.16.0-chrome76)
 - Node 10.16.0 + Chrome 77 [/node10.16.0-chrome77](node10.16.0-chrome77)
 - Node 11.13.0 + Chrome 73 [/node11.13.0-chrome73](node11.13.0-chrome73)
+- Node 12.0.0 + Chrome 73 [/node12.0.0-chrome73](node12.0.0-chrome73)
 - Node 12.0.0 + Chrome 75 [/node12.0.0-chrome75](node12.0.0-chrome75)
 - Node 12.6.0 + Chrome 77 [/node12.6.0-chrome77](node12.6.0-chrome77)
 

--- a/browsers/node12.0.0-chrome73/Dockerfile
+++ b/browsers/node12.0.0-chrome73/Dockerfile
@@ -1,0 +1,52 @@
+# since this was created well after Chrome 73 was published, must be based off existing snapshot of Chrome 73
+FROM cypress/browsers:node11.13.0-chrome73
+
+USER root
+
+# install desired node version
+# see: https://github.com/nodejs/docker-node/blob/bd2ecff0929173daa8e6099d59097f24718d428e/10/jessie/Dockerfile
+ENV NODE_VERSION 12.0.0
+RUN rm /usr/local/bin/node /usr/local/bin/nodejs
+RUN ARCH= && dpkgArch="$(dpkg --print-architecture)" \
+  && case "${dpkgArch##*-}" in \
+    amd64) ARCH='x64';; \
+    ppc64el) ARCH='ppc64le';; \
+    s390x) ARCH='s390x';; \
+    arm64) ARCH='arm64';; \
+    armhf) ARCH='armv7l';; \
+    i386) ARCH='x86';; \
+    *) echo "unsupported architecture"; exit 1 ;; \
+  esac \
+  && set -ex \
+  && curl -fsSLO --compressed "https://nodejs.org/dist/v$NODE_VERSION/node-v$NODE_VERSION-linux-$ARCH.tar.xz" \
+  && curl -fsSLO --compressed "https://nodejs.org/dist/v$NODE_VERSION/SHASUMS256.txt.asc" \
+  && gpg --batch --decrypt --output SHASUMS256.txt SHASUMS256.txt.asc \
+  && grep " node-v$NODE_VERSION-linux-$ARCH.tar.xz\$" SHASUMS256.txt | sha256sum -c - \
+  && tar -xJf "node-v$NODE_VERSION-linux-$ARCH.tar.xz" -C /usr/local --strip-components=1 --no-same-owner \
+  && rm "node-v$NODE_VERSION-linux-$ARCH.tar.xz" SHASUMS256.txt.asc SHASUMS256.txt \
+  && ln -s /usr/local/bin/node /usr/local/bin/nodejs
+
+# "fake" dbus address to prevent errors
+# https://github.com/SeleniumHQ/docker-selenium/issues/87
+ENV DBUS_SESSION_BUS_ADDRESS=/dev/null
+
+# Add zip utility - it comes in very handy
+RUN apt-get update && apt-get install -y zip
+
+RUN npm i -g npm@6.10.3 yarn@1.17.3
+
+# versions of local tools
+RUN echo  " node version:    $(node -v) \n" \
+          "npm version:     $(npm -v) \n" \
+          "yarn version:    $(yarn -v) \n" \
+          "debian version:  $(cat /etc/debian_version) \n" \
+          "Chrome version:  $(google-chrome --version) \n" \
+          "git version:     $(git --version) \n"
+
+# a few environment variables to make NPM installs easier
+# good colors for most applications
+ENV TERM xterm
+# avoid million NPM install messages
+ENV npm_config_loglevel warn
+# allow installing when the main user is root
+ENV npm_config_unsafe_perm true

--- a/browsers/node12.0.0-chrome73/README.md
+++ b/browsers/node12.0.0-chrome73/README.md
@@ -1,0 +1,36 @@
+# cypress/browsers:node12.0.0-chrome73
+
+A complete image with all operating system dependencies for Cypress and Chrome 73 browser
+
+[Dockerfile](Dockerfile)
+
+## Versions
+
+```
+node version:    v12.0.0
+npm version:     6.10.3
+yarn version:    1.17.3
+debian version:  9.8
+Chrome version:  Google Chrome 73.0.3683.103
+git version:     git version 2.11.0
+```
+
+## Size
+
+```bash
+$ docker images --format "{{.Tag}} {{.Size}}" cypress/browsers:node12.0.0-chrome73
+node12.0.0-chrome73 1.39GB
+```
+
+## Example
+
+If you want to build your image
+
+```
+FROM cypress/browsers:node12.0.0-chrome73
+RUN npm i cypress
+RUN $(npm bin)/cypress run --browser chrome
+```
+
+This image uses the `root` user. You might want to switch to non-root
+user when running this container for security.

--- a/browsers/node12.0.0-chrome73/build.sh
+++ b/browsers/node12.0.0-chrome73/build.sh
@@ -1,0 +1,6 @@
+set e+x
+
+LOCAL_NAME=cypress/browsers:node12.0.0-chrome73
+
+echo "Building $LOCAL_NAME"
+docker build -t $LOCAL_NAME .


### PR DESCRIPTION
Matching version for Electron 5.0.10 (https://github.com/cypress-io/cypress/pull/4720)