### PR TITLE
Add DockerHub badges

### DIFF
--- a/base/README.md
+++ b/base/README.md
@@ -1,5 +1,7 @@
 # cypress/base
 
+[![Docker Pulls](https://img.shields.io/docker/pulls/cypress/base.svg?maxAge=604800)](https://hub.docker.com/r/cypress/base/)
+
 Main images that include all operating system dependencies necessary to run Cypress, **but NOT the test runner itself**. See [cypress/included](../included) images if you need pre-installed Cypress in the image.
 
 Each tag is in a sub folder, named after Node version or OS it is built on.

--- a/browsers/README.md
+++ b/browsers/README.md
@@ -1,5 +1,7 @@
 # cypress/browsers
 
+[![Docker Pulls](https://img.shields.io/docker/pulls/cypress/browsers.svg?maxAge=604800)](https://hub.docker.com/r/cypress/browsers/)
+
 > Image with all operating system dependencies and a pre-installed browser, **but NOT the test runner itself**. See [cypress/included](../included) images if you need pre-installed Cypress in the image.
 
 Image `cypress/browsers:chrome69` is tagged [`latest`](https://hub.docker.com/r/cypress/browsers/tags/)

--- a/included/README.md
+++ b/included/README.md
@@ -1,5 +1,7 @@
 # cypress/included
 
+[![Docker Pulls](https://img.shields.io/docker/pulls/cypress/included.svg?maxAge=604800)](https://hub.docker.com/r/cypress/included/)
+
 Docker image with operating system and Cypress installed globally.
 
 Name + Tag | OS image


### PR DESCRIPTION
This provides a convenient link to the Docker Hub page for each image variant and displays the docker pull count.