### PR TITLE
Add browser image with node 12.13.0 with chrome 78 and ff 70

### DIFF
--- a/browsers/README.md
+++ b/browsers/README.md
@@ -6,11 +6,12 @@
 
 Image `cypress/browsers:chrome69` is tagged [`latest`](https://hub.docker.com/r/cypress/browsers/tags/)
 
-Name + Tag | Base image | Chrome
---- | --- | ---
-[cypress/browsers:node8.9.3-npm6.10.1-chrome75](./node8.9.3-npm6.10.1-chrome75) | `cypress/base:8.9.3-npm-6.10.1` | `75.0.3770.100`
-[cypress/browsers:node12.4.0-chrome76](./node12.4.0-chrome76) | `cypress/base:12.4.0` | `76.0.3809.87`
-[cypress/browsers:node12.6.0-chrome75](./node12.6.0-chrome75) | `cypress/base:12.6.0` | `75.0.3770.100`
+Name + Tag | Base image | Chrome | Firefox
+--- | --- | --- | ---
+[cypress/browsers:node8.9.3-npm6.10.1-chrome75](./node8.9.3-npm6.10.1-chrome75) | `cypress/base:8.9.3-npm-6.10.1` | `75.0.3770.100` | 🚫
+[cypress/browsers:node12.4.0-chrome76](./node12.4.0-chrome76) | `cypress/base:12.4.0` | `76.0.3809.87` | 🚫
+[cypress/browsers:node12.6.0-chrome75](./node12.6.0-chrome75) | `cypress/base:12.6.0` | `75.0.3770.100` | 🚫
+[cypress/browsers:node12.13.0-chrome78-ff70](./node12.13.0-chrome78-ff70) | `cypress/base:12.13.0` | `78.0.3904.97` | `70.0.1`
 
 Other images:
 

--- a/browsers/node12.13.0-chrome78-ff70/Dockerfile
+++ b/browsers/node12.13.0-chrome78-ff70/Dockerfile
@@ -1,0 +1,48 @@
+FROM cypress/base:12.13.0
+
+USER root
+
+RUN node --version
+RUN echo "force new chrome here!"
+
+# install Chromebrowser
+RUN \
+  wget -q -O - https://dl-ssl.google.com/linux/linux_signing_key.pub | apt-key add - && \
+  echo "deb http://dl.google.com/linux/chrome/deb/ stable main" > /etc/apt/sources.list.d/google.list
+RUN apt-get update
+# disabled dbus install - could not get it to install
+# but tested an example project, and Chrome seems to run fine
+# RUN apt-get install -y dbus-x11
+RUN apt-get install -y google-chrome-stable
+RUN rm -rf /var/lib/apt/lists/*
+
+# "fake" dbus address to prevent errors
+# https://github.com/SeleniumHQ/docker-selenium/issues/87
+ENV DBUS_SESSION_BUS_ADDRESS=/dev/null
+
+# Add zip utility - it comes in very handy
+RUN apt-get update && apt-get install -y zip
+
+# install Firefox browser
+ARG FIREFOX_VERSION=70.0.1
+RUN wget --no-verbose -O /tmp/firefox.tar.bz2 https://download-installer.cdn.mozilla.net/pub/firefox/releases/$FIREFOX_VERSION/linux-x86_64/en-US/firefox-$FIREFOX_VERSION.tar.bz2 \
+  && tar -C /opt -xjf /tmp/firefox.tar.bz2 \
+  && rm /tmp/firefox.tar.bz2 \
+  && ln -fs /opt/firefox/firefox /usr/bin/firefox
+
+# versions of local tools
+RUN echo  " node version:    $(node -v) \n" \
+  "npm version:     $(npm -v) \n" \
+  "yarn version:    $(yarn -v) \n" \
+  "debian version:  $(cat /etc/debian_version) \n" \
+  "Chrome version:  $(google-chrome --version) \n" \
+  "Firefox version: $(firefox --version) \n" \
+  "git version:     $(git --version) \n"
+
+# a few environment variables to make NPM installs easier
+# good colors for most applications
+ENV TERM xterm
+# avoid million NPM install messages
+ENV npm_config_loglevel warn
+# allow installing when the main user is root
+ENV npm_config_unsafe_perm true

--- a/browsers/node12.13.0-chrome78-ff70/README.md
+++ b/browsers/node12.13.0-chrome78-ff70/README.md
@@ -1,0 +1,18 @@
+# cypress/browsers:node12.13.0-chrome78-ff70
+
+A complete image with all operating system dependencies for Cypress and Chrome 77 browser
+
+[Dockerfile](Dockerfile)
+
+```text
+node version:    v12.13.0
+npm version:     6.13.0
+yarn version:    1.19.1
+debian version:  9.11
+Chrome version:  Google Chrome 78.0.3904.97
+Firefox version: Mozilla Firefox 70.0.1
+git version:     git version 2.11.0
+```
+
+**Note:** this image uses the `root` user. You might want to switch to non-root
+user like `node` when running this container for security.

--- a/browsers/node12.13.0-chrome78-ff70/build.sh
+++ b/browsers/node12.13.0-chrome78-ff70/build.sh
@@ -1,0 +1,6 @@
+set e+x
+
+LOCAL_NAME=cypress/browsers:node12.13.0-chrome78-ff70
+
+echo "Building $LOCAL_NAME"
+docker build -t $LOCAL_NAME .

--- a/test/Dockerfile
+++ b/test/Dockerfile
@@ -1,7 +1,7 @@
 # FROM cypress/base:10.11.0
 # FROM cypress/base:12.4.0
 # FROM cypress/browsers:node12.6.0-chrome77
-FROM cypress/base:12.13.0
+FROM cypress/browsers:node12.13.0-chrome78-ff70
 
 RUN echo "current user: $(whoami)"
 
@@ -9,18 +9,20 @@ RUN echo "current user: $(whoami)"
 # https://github.com/cypress-io/cypress/issues/1243
 ENV CI=1
 # create package.json file
-RUN npm init --yes
+# RUN npm init --yes
 
-# install either a specific version of Cypress
-RUN npm install --save-dev cypress@3.4.1
-# or install a beta version of Cypress using environment variables
-# ENV CYPRESS_INSTALL_BINARY=https://cdn.cypress.io/beta/binary/3.3.0/linux64/circle-develop-40502cbfb7b934afce0a7b1dba4141dab4adb202-100529/cypress.zip
-# RUN npm install https://cdn.cypress.io/beta/npm/3.3.0/circle-develop-40502cbfb7b934afce0a7b1dba4141dab4adb202-100527/cypress.tgz
+# # install either a specific version of Cypress
+# RUN npm install --save-dev cypress@3.6.0
+# # or install a beta version of Cypress using environment variables
+# # ENV CYPRESS_INSTALL_BINARY=https://cdn.cypress.io/beta/binary/3.3.0/linux64/circle-develop-40502cbfb7b934afce0a7b1dba4141dab4adb202-100529/cypress.zip
+# # RUN npm install https://cdn.cypress.io/beta/npm/3.3.0/circle-develop-40502cbfb7b934afce0a7b1dba4141dab4adb202-100527/cypress.tgz
 
-RUN $(npm bin)/cypress verify
-# initialize a basic project with Cypress tests
-RUN npx @bahmutov/cly init
-# if testing a base image with just Electron use "cypress run"
-RUN $(npm bin)/cypress run
-# if testing an image with Chrome browser
-#RUN $(npm bin)/cypress run --browser chrome
+# RUN $(npm bin)/cypress verify
+# # initialize a basic project with Cypress tests
+# RUN npx @bahmutov/cly init
+# # if testing a base image with just Electron use "cypress run"
+# RUN $(npm bin)/cypress run
+# # if testing an image with Chrome browser
+# RUN $(npm bin)/cypress run --browser chrome
+
+RUN cat /etc/fonts/fonts.conf


### PR DESCRIPTION
Adding image `browsers/node12.13.0-chrome78-ff70/` with

```
 node version:    v12.13.0 
 npm version:     6.13.0 
 yarn version:    1.19.1 
 debian version:  9.11 
 Chrome version:  Google Chrome 78.0.3904.97  
 Firefox version: Mozilla Firefox 70.0.1 
 git version:     git version 2.11.0
```