### PR TITLE
built Docker image with Brave browser v78

### DIFF
--- a/browsers/README.md
+++ b/browsers/README.md
@@ -33,5 +33,6 @@ Other images:
 - Node 12.0.0 + Chrome 73 + Firefox 68 [/node12.0.0-chrome73-ff68](node12.0.0-chrome73-ff68)
 - Node 12.0.0 + Chrome 75 [/node12.0.0-chrome75](node12.0.0-chrome75)
 - Node 12.6.0 + Chrome 77 [/node12.6.0-chrome77](node12.6.0-chrome77)
+- [/node12.13.0-chrome78-ff70-brave78](node12.13.0-chrome78-ff70-brave78)
 
 We only provide browsers for `Debian`, but you can use our base images and build your own. See Cypress [Docker documentation](https://on.cypress.io/docker).

--- a/browsers/node12.13.0-chrome78-ff70-brave78/Dockerfile
+++ b/browsers/node12.13.0-chrome78-ff70-brave78/Dockerfile
@@ -1,0 +1,23 @@
+FROM cypress/browsers:node12.13.0-chrome78-ff70
+
+# should be root user to install
+RUN whoami
+RUN node --version
+
+# install Brave browser
+# https://brave-browser.readthedocs.io/en/latest/installing-brave.html#linux
+RUN apt install apt-transport-https curl -y
+RUN curl -s https://brave-browser-apt-release.s3.brave.com/brave-core.asc | apt-key --keyring /etc/apt/trusted.gpg.d/brave-browser-release.gpg add -
+RUN echo "deb [arch=amd64] https://brave-browser-apt-release.s3.brave.com/ trusty main" | tee /etc/apt/sources.list.d/brave-browser-release-trusty.list
+RUN apt update -y
+RUN apt install brave-browser -y
+
+# versions of local tools
+RUN echo  " node version:    $(node -v) \n" \
+  "npm version:     $(npm -v) \n" \
+  "yarn version:    $(yarn -v) \n" \
+  "debian version:  $(cat /etc/debian_version) \n" \
+  "git version:     $(git --version) \n" \
+  "Chrome version:  $(google-chrome --version) \n" \
+  "Firefox version: $(firefox --version) \n" \
+  "Brave version:   $(brave-browser --version) \n"

--- a/browsers/node12.13.0-chrome78-ff70-brave78/README.md
+++ b/browsers/node12.13.0-chrome78-ff70-brave78/README.md
@@ -1,0 +1,18 @@
+# cypress/browsers:node12.13.0-chrome78-ff70
+
+A complete image with all operating system dependencies for Cypress and Chrome 77 browser
+
+[Dockerfile](Dockerfile)
+
+```text
+node version:    v12.13.0
+npm version:     6.13.0
+yarn version:    1.19.1
+debian version:  9.11
+Chrome version:  Google Chrome 78.0.3904.97
+Firefox version: Mozilla Firefox 70.0.1
+git version:     git version 2.11.0
+```
+
+**Note:** this image uses the `root` user. You might want to switch to non-root
+user like `node` when running this container for security.

--- a/browsers/node12.13.0-chrome78-ff70-brave78/README.md
+++ b/browsers/node12.13.0-chrome78-ff70-brave78/README.md
@@ -1,6 +1,4 @@
-# cypress/browsers:node12.13.0-chrome78-ff70
-
-A complete image with all operating system dependencies for Cypress and Chrome 77 browser
+# cypress/browsers:node12.13.0-chrome78-ff70-brave78
 
 [Dockerfile](Dockerfile)
 
@@ -9,9 +7,10 @@ node version:    v12.13.0
 npm version:     6.13.0
 yarn version:    1.19.1
 debian version:  9.11
+git version:     git version 2.11.0
 Chrome version:  Google Chrome 78.0.3904.97
 Firefox version: Mozilla Firefox 70.0.1
-git version:     git version 2.11.0
+Brave version:   Brave Browser 78.1.0.0
 ```
 
 **Note:** this image uses the `root` user. You might want to switch to non-root

--- a/browsers/node12.13.0-chrome78-ff70-brave78/build.sh
+++ b/browsers/node12.13.0-chrome78-ff70-brave78/build.sh
@@ -1,0 +1,6 @@
+set e+x
+
+LOCAL_NAME=cypress/browsers:node12.13.0-chrome78-ff70-brave78
+
+echo "Building $LOCAL_NAME"
+docker build -t $LOCAL_NAME .


### PR DESCRIPTION
Example building image with all browsers: Chrome, Firefox and Brave

```
 node version:    v12.13.0 
 npm version:     6.13.0 
 yarn version:    1.19.1 
 debian version:  9.11 
 git version:     git version 2.11.0 
 Chrome version:  Google Chrome 78.0.3904.97  
 Firefox version: Mozilla Firefox 70.0.1 
 Brave version:   Brave Browser 78.1.0.0
```