### PR TITLE
Add node12.8.1-chrome78-ff70

### DIFF
--- a/browsers/README.md
+++ b/browsers/README.md
@@ -11,6 +11,7 @@ Name + Tag | Base image | Chrome | Firefox
 [cypress/browsers:node8.9.3-npm6.10.1-chrome75](./node8.9.3-npm6.10.1-chrome75) | `cypress/base:8.9.3-npm-6.10.1` | `75.0.3770.100` | 🚫
 [cypress/browsers:node12.4.0-chrome76](./node12.4.0-chrome76) | `cypress/base:12.4.0` | `76.0.3809.87` | 🚫
 [cypress/browsers:node12.6.0-chrome75](./node12.6.0-chrome75) | `cypress/base:12.6.0` | `75.0.3770.100` | 🚫
+[cypress/browsers:node12.8.1-chrome78-ff70](./node12.8.1-chrome78-ff70) | `cypress/browsers:node12.13.0-chrome78-ff70` | `78.0.3904.97` | `70.0.1`
 [cypress/browsers:node12.13.0-chrome78-ff70](./node12.13.0-chrome78-ff70) | `cypress/base:12.13.0` | `78.0.3904.97` | `70.0.1`
 
 Other images:

--- a/browsers/node12.8.1-chrome78-ff70/Dockerfile
+++ b/browsers/node12.8.1-chrome78-ff70/Dockerfile
@@ -1,0 +1,56 @@
+FROM cypress/browsers:node12.13.0-chrome78-ff70
+
+USER root
+
+# install desired node version
+# see: https://github.com/nodejs/docker-node/blob/bd2ecff0929173daa8e6099d59097f24718d428e/10/jessie/Dockerfile
+ENV NODE_VERSION 12.8.1
+RUN rm /usr/local/bin/node /usr/local/bin/nodejs
+RUN ARCH= && dpkgArch="$(dpkg --print-architecture)" \
+  && case "${dpkgArch##*-}" in \
+    amd64) ARCH='x64';; \
+    ppc64el) ARCH='ppc64le';; \
+    s390x) ARCH='s390x';; \
+    arm64) ARCH='arm64';; \
+    armhf) ARCH='armv7l';; \
+    i386) ARCH='x86';; \
+    *) echo "unsupported architecture"; exit 1 ;; \
+  esac \
+  && set -ex \
+  && curl -fsSLO --compressed "https://nodejs.org/dist/v$NODE_VERSION/node-v$NODE_VERSION-linux-$ARCH.tar.xz" \
+  && curl -fsSLO --compressed "https://nodejs.org/dist/v$NODE_VERSION/SHASUMS256.txt.asc" \
+  && gpg --batch --decrypt --output SHASUMS256.txt SHASUMS256.txt.asc \
+  && grep " node-v$NODE_VERSION-linux-$ARCH.tar.xz\$" SHASUMS256.txt | sha256sum -c - \
+  && tar -xJf "node-v$NODE_VERSION-linux-$ARCH.tar.xz" -C /usr/local --strip-components=1 --no-same-owner \
+  && rm "node-v$NODE_VERSION-linux-$ARCH.tar.xz" SHASUMS256.txt.asc SHASUMS256.txt \
+  && ln -s /usr/local/bin/node /usr/local/bin/nodejs
+
+# "fake" dbus address to prevent errors
+# https://github.com/SeleniumHQ/docker-selenium/issues/87
+ENV DBUS_SESSION_BUS_ADDRESS=/dev/null
+
+# Add zip utility - it comes in very handy
+RUN apt-get update && apt-get install -y zip
+
+RUN npm i -g npm@6.10.3 yarn@1.17.3
+
+# Install xauth for Cypress development work
+RUN apt-get install -y xauth
+RUN xauth version
+
+# versions of local tools
+RUN echo  " node version:    $(node -v) \n" \
+          "npm version:     $(npm -v) \n" \
+          "yarn version:    $(yarn -v) \n" \
+          "debian version:  $(cat /etc/debian_version) \n" \
+          "Chrome version:  $(google-chrome --version) \n" \
+          "Firefox version: $(firefox -v) \n" \
+          "git version:     $(git --version) \n"
+
+# a few environment variables to make NPM installs easier
+# good colors for most applications
+ENV TERM xterm
+# avoid million NPM install messages
+ENV npm_config_loglevel warn
+# allow installing when the main user is root
+ENV npm_config_unsafe_perm true

--- a/browsers/node12.8.1-chrome78-ff70/README.md
+++ b/browsers/node12.8.1-chrome78-ff70/README.md
@@ -1,0 +1,15 @@
+# cypress/browsers:node12.8.1-chrome78-ff70
+
+A complete image with all operating system dependencies for Cypress along with Chrome 78 and Firefox 70
+
+[Dockerfile](Dockerfile)
+
+```text
+ node version:    v12.8.1
+ npm version:     6.10.3
+ yarn version:    1.17.3
+ debian version:  9.11
+ Chrome version:  Google Chrome 78.0.3904.97
+ Firefox version: Mozilla Firefox 70.0.1
+ git version:     git version 2.11.0
+```

--- a/browsers/node12.8.1-chrome78-ff70/build.sh
+++ b/browsers/node12.8.1-chrome78-ff70/build.sh
@@ -1,0 +1,6 @@
+set e+x
+
+LOCAL_NAME=cypress/browsers:node12.8.1-chrome78-ff70
+
+echo "Building $LOCAL_NAME"
+docker build -t $LOCAL_NAME .


### PR DESCRIPTION
For the Electron 7.x upgrade.

```
 node version:    v12.8.1 
 npm version:     6.10.3 
 yarn version:    1.17.3 
 debian version:  9.11 
 Chrome version:  Google Chrome 78.0.3904.97  
 Firefox version: Mozilla Firefox 70.0.1 
 git version:     git version 2.11.0 
```