### PR TITLE
add video codecs to firefox images

### DIFF
--- a/browsers/node10.16.0-chrome77-ff71/Dockerfile
+++ b/browsers/node10.16.0-chrome77-ff71/Dockerfile
@@ -18,6 +18,14 @@ RUN wget --no-verbose -O /tmp/firefox.tar.bz2 https://download-installer.cdn.moz
   rm /tmp/firefox.tar.bz2 && \
   ln -fs /opt/firefox/firefox /usr/bin/firefox
 
+# add codecs needed for video playback in firefox 
+# https://github.com/cypress-io/cypress-docker-images/issues/150
+RUN apt-get install apt-transport-https -y && \
+curl https://download.videolan.org/pub/debian/videolan-apt.asc | apt-key add - && \
+echo 'deb https://download.videolan.org/pub/debian/stable ./' | tee /etc/apt/sources.list.d/libdvdcss.list && \
+apt-get update && \
+apt-get install mplayer2 -y
+
 # Upgrade NPM and Yarn
 RUN npm i -g npm
 RUN npm i -g yarn

--- a/browsers/node12.8.1-chrome78-ff70/Dockerfile
+++ b/browsers/node12.8.1-chrome78-ff70/Dockerfile
@@ -2,6 +2,14 @@ FROM cypress/browsers:node12.13.0-chrome78-ff70
 
 USER root
 
+# add codecs needed for video playback in firefox 
+# https://github.com/cypress-io/cypress-docker-images/issues/150
+RUN apt-get install apt-transport-https -y && \
+curl https://download.videolan.org/pub/debian/videolan-apt.asc | apt-key add - && \
+echo 'deb https://download.videolan.org/pub/debian/stable ./' | tee /etc/apt/sources.list.d/libdvdcss.list && \
+apt-get update && \
+apt-get install mplayer2 -y
+
 # install desired node version
 # see: https://github.com/nodejs/docker-node/blob/bd2ecff0929173daa8e6099d59097f24718d428e/10/jessie/Dockerfile
 ENV NODE_VERSION 12.8.1


### PR DESCRIPTION
add video codecs to existing firefox images that are missing them.

Couldn't add codecs to `browsers/node12.13.0-chrome78-ff70` since that image builds chrome, which needs to remain cached from my understanding