### PR TITLE
another approach to give non-root user node ability to run tests

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,6 +34,8 @@ If you want to use `cypress/included` image, read [Run Cypress with a single Doc
 
 Folder [examples/included-as-non-root](examples/included-as-non-root) shows how to build a new Docker image on top of `cypress/included` image and run the tests as non-root user `node`.
 
+Folder [examples/included-as-non-root-alternative](examples/included-as-non-root-alternative) shows another approach to allow built-in non-root user `node` to run tests using `cypress/included` image.
+
 Folder [examples/included-as-non-root-mapped](examples/included-as-non-root-mapped) shows how to build a Docker image on top of `cypress/included` that runs with a non-root user that matches the id of the user on the host machine. This way, the permissions on any files created during the test run match the user's permissions on the host machine.
 
 Folder [examples/included-with-plugins](examples/included-with-plugins) shows how to use locally installed [Cypress plugins](https://on.cypress.io/plugins) while running `cypress/included` image.

--- a/examples/included-as-non-root-alternative/Dockerfile
+++ b/examples/included-as-non-root-alternative/Dockerfile
@@ -1,0 +1,26 @@
+# image has Cypress npm module installed globally in /root/.npm/node_modules
+# and Cypress binary cached in /root/.cache/Cypress folder
+FROM cypress/included:3.8.0
+
+# "root"
+RUN whoami
+# uid=0(root) gid=0(root) groups=0(root)
+# meaning root
+RUN id
+
+# give every user read access to the "/root" folder where the binary is cached
+# we really only need to worry about the top folder, fortunately
+RUN ls -la /root
+RUN chmod 755 /root
+# point Cypress at the /root/cache no matter what user account is used
+# see https://on.cypress.io/caching
+ENV CYPRESS_CACHE_FOLDER=/root/.cache/Cypress
+
+# switch to non-root user "node" that comes from Docker Node image
+USER node
+# show user effective id and group - it should be non-zero
+# meaning the current user "node" is not root
+RUN id
+# user "node" should be able to access the Cypress test runner now
+RUN ls -la /root/.cache/Cypress/*/Cypress
+RUN cat /root/.cache/Cypress/*/Cypress/binary_state.json

--- a/examples/included-as-non-root-alternative/README.md
+++ b/examples/included-as-non-root-alternative/README.md
@@ -1,0 +1,12 @@
+# Running cypress/included image as non-root (alternative)
+
+In this example, we build a new Docker image on top of `cypress/included` image, but we give all users read access to the folder `/root` where Cypress NPM package and Cypress binary are installed, see [Dockerfile](Dockerfile)
+
+As a second step, we set the environment variable `CYPRESS_CACHE_FOLDER=/root/.cache/Cypress` to ensure that every user can find the cached binary and use it to run tests.
+
+You can build the `cypress/example` image and run current tests as built-in second user `node` (comes from Node base image) with:
+
+```shell
+$ ./build.sh
+$ ./test.sh
+```

--- a/examples/included-as-non-root-alternative/build.sh
+++ b/examples/included-as-non-root-alternative/build.sh
@@ -1,0 +1,6 @@
+set e+x
+
+LOCAL_NAME=cypress/example
+
+echo "Building $LOCAL_NAME"
+docker build -t $LOCAL_NAME .

--- a/examples/included-as-non-root-alternative/src/cypress.json
+++ b/examples/included-as-non-root-alternative/src/cypress.json
@@ -1,0 +1,5 @@
+{
+  "fixturesFolder": false,
+  "pluginsFile": false,
+  "supportFile": false
+}

--- a/examples/included-as-non-root-alternative/src/cypress/integration/spec.js
+++ b/examples/included-as-non-root-alternative/src/cypress/integration/spec.js
@@ -1,0 +1,9 @@
+describe('page', () => {
+  beforeEach(() => {
+    cy.visit('index.html')
+  })
+
+  it('has h2', () => {
+    cy.contains('h2', 'test')
+  })
+})

--- a/examples/included-as-non-root-alternative/src/index.html
+++ b/examples/included-as-non-root-alternative/src/index.html
@@ -1,0 +1,4 @@
+<body>
+<h2>A test</h2>
+<p>This is a test page</p>
+</body>

--- a/examples/included-as-non-root-alternative/test.sh
+++ b/examples/included-as-non-root-alternative/test.sh
@@ -1,0 +1,15 @@
+set e+x
+
+LOCAL_NAME=cypress/example
+
+echo "Running tests against $LOCAL_NAME"
+echo "Running as a non-root user 'node'"
+
+# print the docker command before running
+set -x
+# if you want to see diagnostic messages add argument -e DEBUG=cypress:cli
+docker run -it -v $PWD/src:/test -w /test -u node $LOCAL_NAME
+
+# for exploration
+# docker run -it -v $PWD/src:/test -w /test -u node \
+  # --entrypoint /bin/bash $LOCAL_NAME


### PR DESCRIPTION
- chmod a+r on `/root` folder gives any user read permissions to use globally installed Cypress NPM module
- setting environment variable `CYPRESS_CACHE_FOLDER=/root/.cache/Cypress` forces other users to use the pre-installed binary in the root, rather than in `~/.cache`

I think this might be the future approach for making new `cypress/included` images that does not run as root by default