### PR TITLE
Add Node 12.14.0 and Chrome 79 with Firefox 71

### DIFF
--- a/browsers/node12.14.0-chrome79-ff71/Dockerfile
+++ b/browsers/node12.14.0-chrome79-ff71/Dockerfile
@@ -1,0 +1,48 @@
+FROM cypress/base:12.14.0
+
+USER root
+
+RUN node --version
+RUN echo "force new chrome here!"
+
+# install Chromebrowser
+RUN \
+  wget -q -O - https://dl-ssl.google.com/linux/linux_signing_key.pub | apt-key add - && \
+  echo "deb http://dl.google.com/linux/chrome/deb/ stable main" > /etc/apt/sources.list.d/google.list
+RUN apt-get update
+# disabled dbus install - could not get it to install
+# but tested an example project, and Chrome seems to run fine
+# RUN apt-get install -y dbus-x11
+RUN apt-get install -y google-chrome-stable
+RUN rm -rf /var/lib/apt/lists/*
+
+# "fake" dbus address to prevent errors
+# https://github.com/SeleniumHQ/docker-selenium/issues/87
+ENV DBUS_SESSION_BUS_ADDRESS=/dev/null
+
+# Add zip utility - it comes in very handy
+RUN apt-get update && apt-get install -y zip
+
+# install Firefox browser
+ARG FIREFOX_VERSION=71.0
+RUN wget --no-verbose -O /tmp/firefox.tar.bz2 https://download-installer.cdn.mozilla.net/pub/firefox/releases/$FIREFOX_VERSION/linux-x86_64/en-US/firefox-$FIREFOX_VERSION.tar.bz2 \
+  && tar -C /opt -xjf /tmp/firefox.tar.bz2 \
+  && rm /tmp/firefox.tar.bz2 \
+  && ln -fs /opt/firefox/firefox /usr/bin/firefox
+
+# versions of local tools
+RUN echo  " node version:    $(node -v) \n" \
+  "npm version:     $(npm -v) \n" \
+  "yarn version:    $(yarn -v) \n" \
+  "debian version:  $(cat /etc/debian_version) \n" \
+  "Chrome version:  $(google-chrome --version) \n" \
+  "Firefox version: $(firefox --version) \n" \
+  "git version:     $(git --version) \n"
+
+# a few environment variables to make NPM installs easier
+# good colors for most applications
+ENV TERM xterm
+# avoid million NPM install messages
+ENV npm_config_loglevel warn
+# allow installing when the main user is root
+ENV npm_config_unsafe_perm true

--- a/browsers/node12.14.0-chrome79-ff71/README.md
+++ b/browsers/node12.14.0-chrome79-ff71/README.md
@@ -1,0 +1,25 @@
+# cypress/browsers:node12.14.0-chrome79-ff71
+
+A complete image with all operating system dependencies for Cypress and Chrome 77 browser
+
+[Dockerfile](Dockerfile)
+
+```text
+node version:    v12.14.0
+npm version:     6.13.4
+yarn version:    1.21.1
+debian version:  9.11
+Chrome version:  Google Chrome 79.0.3945.86
+Firefox version: Mozilla Firefox 71.0
+git version:     git version 2.11.0
+```
+
+**Note:** this image uses the `root` user. You might want to switch to non-root
+user like `node` when running this container for security.
+
+
+node version:    v12.14.0
+ npm version:     6.13.4
+ yarn version:    1.21.1
+ debian version:  9.11
+ user:            root

--- a/browsers/node12.14.0-chrome79-ff71/build.sh
+++ b/browsers/node12.14.0-chrome79-ff71/build.sh
@@ -1,0 +1,6 @@
+set e+x
+
+LOCAL_NAME=cypress/browsers:node12.14.0-chrome79-ff71
+
+echo "Building $LOCAL_NAME"
+docker build -t $LOCAL_NAME .


### PR DESCRIPTION
This PR adds Node `12.14.0` and current stable versions of Chrome `79.0.3945.86` (see [here](https://chromereleases.googleblog.com/2019/12/stable-channel-update-for-chrome-os.html)) and Firefox `71.0` (see [there](https://www.mozilla.org/en-US/firefox/71.0/releasenotes/)).