### PR TITLE
Initial pass at adding base:12-alpine image

### DIFF
--- a/base/12-alpine/Dockerfile
+++ b/base/12-alpine/Dockerfile
@@ -1,0 +1,31 @@
+FROM node:12-alpine
+
+RUN apk update && \
+  apk add \
+  gtk+3.0 \
+  libnotify-dev \
+  gconf \
+  nss \
+  alsa-lib \
+  libxtst \
+  xauth \
+  xvfb
+
+
+RUN npm install -g npm@latest
+RUN npm install -g -f yarn@latest
+
+# a few environment variables to make NPM installs easier
+# good colors for most applications
+ENV TERM xterm
+# avoid million NPM install messages
+ENV npm_config_loglevel warn
+# allow installing when the main user is root
+ENV npm_config_unsafe_perm true
+
+# versions of local tools
+RUN echo  " node version:    $(node -v) \n" \
+  "npm version:     $(npm -v) \n" \
+  "yarn version:    $(yarn -v) \n" \
+  "debian version:  $(cat /etc/debian_version) \n" \
+  "user:            $(whoami) \n"

--- a/base/12-alpine/README.md
+++ b/base/12-alpine/README.md
@@ -1,0 +1,12 @@
+# cypress/base:12-alpine
+
+## Example
+
+Sample Dockerfile
+
+```
+FROM cypress/base:12-alpine
+RUN npm install --save-dev cypress
+RUN $(npm bin)/cypress verify
+RUN $(npm bin)/cypress run
+```

--- a/base/12-alpine/build.sh
+++ b/base/12-alpine/build.sh
@@ -1,0 +1,7 @@
+set e+x
+
+# build image with Cypress dependencies
+LOCAL_NAME=cypress/base:12-alpine
+
+echo "Building $LOCAL_NAME"
+docker build -t $LOCAL_NAME .


### PR DESCRIPTION
**Note: I have absolutely 0 experience with alpine linux, package management etc.**

I made an initial pass at getting Cypress ready for Node-Alpine, but need some help: Alpine Linux doesn't have `apt-get`, so we need to use `apk` instead. I tried to find compatible packages in `apk`, but failed miserably 🙈 .

Would love help with this.

Closes #110 

Feel free to open an MR against [`StevenLangbroek:feat/node-alpine`](https://github.com/StevenLangbroek/cypress-docker-images/tree/feat/node-alpine) 🙇 