### PR TITLE
Add ubuntu19 image

### DIFF
--- a/base/README.md
+++ b/base/README.md
@@ -40,6 +40,7 @@ cypress/base:ubuntu16 | 6 | Ubuntu | [/ubuntu16](ubuntu16) | 3.10.10 | 🚫
 cypress/base:ubuntu16-8 | 8.16.2 | Ubuntu | [/ubuntu16-8.16.2](ubuntu16-8.16.2) | 6.4.1 | 🚫
 cypress/base:ubuntu16-12.13.1 | 12.13.1 | Ubuntu | [/ubuntu16-12.13.1](ubuntu16-12.13.1) | 6.12.1 | 🚫
 cypress/base:ubuntu18-node12.14.1 | 12.14.1 | Ubuntu 18.04.3 | [ubuntu18-node12.14.1](/ubuntu18-node12.14.1) | 6.13.6 | 1.21.1
+cypress/base:ubuntu19-node12.14.1 | 12.14.1 | Ubuntu 19.0.4 | [ubuntu19-node12.14.1](/ubuntu19-node12.14.1) | 6.13.6 | 1.21.1
 
 ⚠️ Cypress no longer supports Node v0.12.x. Using 4.x, 6.x images is not recommended, and we do not plan to release new versions of Cypress tested on Node v4. See [End-of-Life Releases](https://github.com/nodejs/Release#end-of-life-releases).
 

--- a/base/ubuntu18-node12.14.1/README.md
+++ b/base/ubuntu18-node12.14.1/README.md
@@ -1,11 +1,12 @@
-# cypress/base:ubuntu16-12.13.1
+# cypress/base:ubuntu18-node12.14.1
 
-Image with Ubuntu 16 and Node 12.13.1
+Image with Ubuntu 18 and Node 12.14.1
 
 ```
-node version:    v12.13.1
-npm version:     6.12.1
-yarn version:
-debian version:  stretch/sid
+node version:    v12.14.1
+npm version:     6.13.6
+yarn version:    1.21.1
+debian version:  buster/sid
 user:            root
+git:             git version 2.17.1
 ```

--- a/base/ubuntu19-node12.14.1/Dockerfile
+++ b/base/ubuntu19-node12.14.1/Dockerfile
@@ -1,0 +1,62 @@
+FROM ubuntu:19.04
+
+RUN apt-get update && \
+  apt-get install -y apt-transport-https curl
+
+RUN curl -sL https://deb.nodesource.com/setup_12.x -o nodesource_setup.sh
+RUN bash nodesource_setup.sh
+RUN apt-get install -y nodejs
+
+# Install latest NPM and Yarn
+RUN npm install -g npm@latest
+RUN npm install -g yarn@latest
+
+# install additional native dependencies build tools
+RUN apt install -y build-essential
+
+# install Git client
+RUN apt-get install -y git
+# install unzip utility to speed up Cypress unzips
+# https://github.com/cypress-io/cypress/releases/tag/v3.8.0
+RUN apt-get install -y unzip
+
+# avoid any prompts
+ENV DEBIAN_FRONTEND noninteractive
+#install tzdata package
+RUN apt-get install -y tzdata
+# set your timezone
+RUN ln -fs /usr/share/zoneinfo/America/New_York /etc/localtime
+RUN dpkg-reconfigure --frontend noninteractive tzdata
+
+# install Cypress dependencies (separate commands to avoid time outs)
+RUN apt-get install -y \
+    libgtk2.0-0
+RUN apt-get install -y \
+    libnotify-dev
+RUN apt-get install -y \
+    libgconf-2-4 \
+    libnss3 \
+    libxss1
+RUN apt-get install -y \
+    libasound2 \
+    xvfb
+
+# a few environment variables to make NPM installs easier
+# good colors for most applications
+ENV TERM xterm
+# avoid million NPM install messages
+ENV npm_config_loglevel warn
+# allow installing when the main user is root
+ENV npm_config_unsafe_perm true
+
+# versions of local tools
+RUN echo  " node version:    $(node -v) \n" \
+  "npm version:     $(npm -v) \n" \
+  "yarn version:    $(yarn -v) \n" \
+  "debian version:  $(cat /etc/debian_version) \n" \
+  "user:            $(whoami) \n" \
+  "git:             $(git --version) \n"
+
+RUN echo "More version info"
+RUN cat /etc/lsb-release
+RUN cat /etc/os-release

--- a/base/ubuntu19-node12.14.1/README.md
+++ b/base/ubuntu19-node12.14.1/README.md
@@ -1,0 +1,22 @@
+# cypress/base:ubuntu19-node12.14.1
+
+Image with Ubuntu 19 and Node 12.14.1
+
+```
+node version:    v12.14.1
+npm version:     6.13.6
+yarn version:    1.21.1
+debian version:  buster/sid
+user:            root
+git:             git version 2.20.1
+DISTRIB_ID=Ubuntu
+DISTRIB_RELEASE=19.04
+DISTRIB_CODENAME=disco
+DISTRIB_DESCRIPTION="Ubuntu 19.04"
+NAME="Ubuntu"
+VERSION="19.04 (Disco Dingo)"
+ID=ubuntu
+ID_LIKE=debian
+PRETTY_NAME="Ubuntu 19.04"
+VERSION_ID="19.04"
+```

--- a/base/ubuntu19-node12.14.1/build.sh
+++ b/base/ubuntu19-node12.14.1/build.sh
@@ -1,0 +1,7 @@
+set e+x
+
+# build image with Cypress dependencies
+LOCAL_NAME=cypress/base:ubuntu19-node12.14.1
+
+echo "Building $LOCAL_NAME"
+docker build -t $LOCAL_NAME .

--- a/circle.yml
+++ b/circle.yml
@@ -297,6 +297,9 @@ workflows:
       - build-base-image:
           name: "base ubuntu18-node12.14.1"
           dockerTag: "ubuntu18-node12.14.1"
+      - build-base-image:
+          name: "base ubuntu19-node12.14.1"
+          dockerTag: "ubuntu19-node12.14.1"
 
   build-browser-images:
     jobs:

--- a/test/Dockerfile
+++ b/test/Dockerfile
@@ -2,7 +2,7 @@
 # FROM cypress/base:12.4.0
 # FROM cypress/browsers:node12.6.0-chrome77
 #
-FROM cypress/base:ubuntu18-node12.14.1
+FROM cypress/base:ubuntu19-node12.14.1
 
 RUN echo "current user: $(whoami)"
 RUN echo "current node: $(node -v)"


### PR DESCRIPTION
- close #212
Interesting, but Cypress v3.8.2 runs just fine there, no XVFB problem as in https://github.com/cypress-io/cypress/issues/6184