### PR TITLE
Add codecs to node12.8.1-chrome80-ff72

### DIFF
--- a/browsers/node12.8.1-chrome80-ff72/Dockerfile
+++ b/browsers/node12.8.1-chrome80-ff72/Dockerfile
@@ -24,6 +24,14 @@ ENV DBUS_SESSION_BUS_ADDRESS=/dev/null
 # Add zip utility - it comes in very handy
 RUN apt-get update && apt-get install -y zip
 
+# add codecs needed for video playback in firefox
+# https://github.com/cypress-io/cypress-docker-images/issues/150
+RUN apt-get install apt-transport-https -y && \
+curl https://download.videolan.org/pub/debian/videolan-apt.asc | apt-key add - && \
+echo 'deb https://download.videolan.org/pub/debian/stable ./' | tee /etc/apt/sources.list.d/libdvdcss.list && \
+apt-get update && \
+apt-get install mplayer2 -y
+
 # install Firefox browser
 ARG FIREFOX_VERSION=72.0.2
 RUN wget --no-verbose -O /tmp/firefox.tar.bz2 https://download-installer.cdn.mozilla.net/pub/firefox/releases/$FIREFOX_VERSION/linux-x86_64/en-US/firefox-$FIREFOX_VERSION.tar.bz2 \


### PR DESCRIPTION
https://github.com/cypress-io/cypress/pull/6428 is failing because this image does not have the required codecs for FF to play video