### PR TITLE
Add updated note about Node.js support to reflect 4.0 updates

### DIFF
--- a/base/README.md
+++ b/base/README.md
@@ -44,7 +44,11 @@ cypress/base:ubuntu16-12.13.1 | 12.13.1 | Ubuntu | [/ubuntu16-12.13.1](ubuntu16-
 cypress/base:ubuntu18-node12.14.1 | 12.14.1 | Ubuntu 18.04.3 | [ubuntu18-node12.14.1](ubuntu18-node12.14.1) | 6.13.6 | 1.21.1
 cypress/base:ubuntu19-node12.14.1 | 12.14.1 | Ubuntu 19.0.4 | [ubuntu19-node12.14.1](ubuntu19-node12.14.1) | 6.13.6 | 1.21.1
 
-⚠️ Cypress no longer supports Node v0.12.x. Using 4.x, 6.x images is not recommended, and we do not plan to release new versions of Cypress tested on Node v4. See [End-of-Life Releases](https://github.com/nodejs/Release#end-of-life-releases).
+## ⚠️ Node.js Support
+
+Cypress 4.0+ no longer supports Node.js versions below 8.0.0. See our [Migration Guide](https://on.cypress.io/migration-guide#Node-js-8-support).
+
+Using 6.x images is not recommended, and we do not plan to release new versions of Cypress tested on Node.js below 8.0.0.
 
 ## Information
 


### PR DESCRIPTION
Update the note about Node.js support since our min supported version has changed since 4.0 release