### PR TITLE
Add cypress/browsers:node12.16.1-chrome80-ff73

### DIFF
--- a/browsers/README.md
+++ b/browsers/README.md
@@ -12,6 +12,7 @@ Name + Tag | Base image | Chrome | Firefox
 [cypress/browsers:node12.6.0-chrome75](./node12.6.0-chrome75) | `cypress/base:12.6.0` | `75.0.3770.100` | 🚫
 [cypress/browsers:node12.8.1-chrome78-ff70](./node12.8.1-chrome78-ff70) | `cypress/browsers:node12.13.0-chrome78-ff70` | `78.0.3904.97` | `70.0.1`
 [cypress/browsers:node12.13.0-chrome78-ff70](./node12.13.0-chrome78-ff70) | `cypress/base:12.13.0` | `78.0.3904.97` | `70.0.1`
+[cypress/browsers:node12.16.1-chrome80-ff73](./node12.16.1-chrome80-ff73) | `cypress/base:12.16.1` | `80.0.3987.122` | `73.0.1`
 [cypress/browsers:node12.8.1-chrome80-ff72](./node12.8.1-chrome80-ff72) | `cypress/base:node12.8.1` | `80.0.3987.87` | `72.0.2`
 [cypress/browsers:node13.6.0-chrome80-ff72](./node13.6.0-chrome80-ff72) | `cypress/base:13.6.0` | `80.0.3987.87` | `72.0.2`
 

--- a/browsers/node12.16.1-chrome80-ff73/Dockerfile
+++ b/browsers/node12.16.1-chrome80-ff73/Dockerfile
@@ -1,0 +1,48 @@
+FROM cypress/base:12.16.1
+
+USER root
+
+RUN node --version
+RUN echo "force new chrome here!"
+
+# install Chromebrowser
+RUN \
+  wget -q -O - https://dl-ssl.google.com/linux/linux_signing_key.pub | apt-key add - && \
+  echo "deb http://dl.google.com/linux/chrome/deb/ stable main" > /etc/apt/sources.list.d/google.list
+RUN apt-get update
+# disabled dbus install - could not get it to install
+# but tested an example project, and Chrome seems to run fine
+# RUN apt-get install -y dbus-x11
+RUN apt-get install -y google-chrome-stable
+RUN rm -rf /var/lib/apt/lists/*
+
+# "fake" dbus address to prevent errors
+# https://github.com/SeleniumHQ/docker-selenium/issues/87
+ENV DBUS_SESSION_BUS_ADDRESS=/dev/null
+
+# Add zip utility - it comes in very handy
+RUN apt-get update && apt-get install -y zip
+
+# install Firefox browser
+ARG FIREFOX_VERSION=73.0.1
+RUN wget --no-verbose -O /tmp/firefox.tar.bz2 https://download-installer.cdn.mozilla.net/pub/firefox/releases/$FIREFOX_VERSION/linux-x86_64/en-US/firefox-$FIREFOX_VERSION.tar.bz2 \
+  && tar -C /opt -xjf /tmp/firefox.tar.bz2 \
+  && rm /tmp/firefox.tar.bz2 \
+  && ln -fs /opt/firefox/firefox /usr/bin/firefox
+
+# versions of local tools
+RUN echo  " node version:    $(node -v) \n" \
+  "npm version:     $(npm -v) \n" \
+  "yarn version:    $(yarn -v) \n" \
+  "debian version:  $(cat /etc/debian_version) \n" \
+  "Chrome version:  $(google-chrome --version) \n" \
+  "Firefox version: $(firefox --version) \n" \
+  "git version:     $(git --version) \n"
+
+# a few environment variables to make NPM installs easier
+# good colors for most applications
+ENV TERM xterm
+# avoid million NPM install messages
+ENV npm_config_loglevel warn
+# allow installing when the main user is root
+ENV npm_config_unsafe_perm true

--- a/browsers/node12.16.1-chrome80-ff73/README.md
+++ b/browsers/node12.16.1-chrome80-ff73/README.md
@@ -1,0 +1,19 @@
+# cypress/browsers:node12.16.1-chrome80-ff73
+
+A complete image with all operating system dependencies for Cypress, Chrome
+80 and Firefox 73 browsers.
+
+[Dockerfile](Dockerfile)
+
+```text
+node version:    v12.16.1
+npm version:     6.14.1
+yarn version:    1.22.0
+debian version:  9.11
+Chrome version:  Google Chrome 80
+Firefox version: Mozilla Firefox 73.0.1
+git version:     git version 2.11.0
+```
+
+**Note:** this image uses the `root` user. You might want to switch to non-root
+user like `node` when running this container for security.

--- a/browsers/node12.16.1-chrome80-ff73/build.sh
+++ b/browsers/node12.16.1-chrome80-ff73/build.sh
@@ -1,0 +1,6 @@
+set e+x
+
+LOCAL_NAME=cypress/browsers:node12.16.1-chrome80-ff73
+
+echo "Building $LOCAL_NAME"
+docker build -t $LOCAL_NAME .

--- a/circle.yml
+++ b/circle.yml
@@ -445,6 +445,10 @@ workflows:
           dockerTag: "node12.14.0-chrome79-ff71"
           chromeVersion: "Google Chrome 79"
       - build-browser-image:
+          name: "browsers node12.16.1-chrome80-ff73"
+          dockerTag: "node12.16.1-chrome80-ff73"
+          chromeVersion: "Google Chrome 80"
+      - build-browser-image:
           name: "browsers node12.4.0-chrome76"
           dockerTag: "node12.4.0-chrome76"
           chromeVersion: "Google Chrome 76"


### PR DESCRIPTION
Adds a new docker file to utilize node version 12.16.1 for Chrome and Firefox browsers.