### PR TITLE
add note about shared memory

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,6 +56,18 @@ In that case run install with `npm install --unsafe-perm` flag, or set an enviro
 npm_config_unsafe_perm: true
 ```
 
+### Blank screen in Chrome
+
+When running headed tests with X11 forwarding in Cypress v4 you might see blank Chrome screen. Try disabling memory sharing by setting the following environment variables
+
+```
+export QT_X11_NO_MITSHM=1
+export _X11_NO_MITSHM=1
+export _MITSHM=0
+```
+
+See [issue #270](https://github.com/cypress-io/cypress-docker-images/issues/270)
+
 ## Contributing
 
 See [CONTRIBUTING.md](CONTRIBUTING.md)

--- a/generate-included-image.js
+++ b/generate-included-image.js
@@ -43,6 +43,12 @@ FROM ${baseImageTag}
 # https://github.com/cypress-io/cypress/issues/1243
 ENV CI=1
 
+# disable shared memory X11 affecting Cypress v4 and Chrome
+# https://github.com/cypress-io/cypress-docker-images/issues/270
+ENV QT_X11_NO_MITSHM=1
+ENV _X11_NO_MITSHM=1
+ENV _MITSHM=0
+
 # should be root user
 RUN echo "whoami: $(whoami)"
 RUN npm config -g set user $(whoami)


### PR DESCRIPTION
- close #270 
- `cypress/included` images will have 3 env variables set

we should also set these variables for the new `/browsers` images