### PR TITLE
Validate ff better

### DIFF
--- a/browsers/node10.16.3-chrome80-ff73/Dockerfile
+++ b/browsers/node10.16.3-chrome80-ff73/Dockerfile
@@ -1,0 +1,60 @@
+FROM cypress/base:10.16.3
+
+USER root
+
+RUN node --version
+RUN echo "force new chrome here!"
+
+# Chrome dependencies
+RUN apt-get update
+RUN apt-get install -y fonts-liberation libappindicator3-1 xdg-utils
+
+# install Chrome browser
+ENV CHROME_VERSION 80.0.3987.116
+RUN wget -O /usr/src/google-chrome-stable_current_amd64.deb "http://dl.google.com/linux/chrome/deb/pool/main/g/google-chrome-stable/google-chrome-stable_${CHROME_VERSION}-1_amd64.deb" && \
+  dpkg -i /usr/src/google-chrome-stable_current_amd64.deb ; \
+  apt-get install -f -y && \
+  rm -f /usr/src/google-chrome-stable_current_amd64.deb
+RUN google-chrome --version
+
+# "fake" dbus address to prevent errors
+# https://github.com/SeleniumHQ/docker-selenium/issues/87
+ENV DBUS_SESSION_BUS_ADDRESS=/dev/null
+
+# disable shared memory X11 affecting Cypress v4 and Chrome
+# https://github.com/cypress-io/cypress-docker-images/issues/270
+ENV QT_X11_NO_MITSHM=1
+ENV _X11_NO_MITSHM=1
+ENV _MITSHM=0
+
+# Add zip utility - it comes in very handy
+RUN apt-get update && apt-get install -y zip
+
+# add codecs needed for video playback in firefox
+# https://github.com/cypress-io/cypress-docker-images/issues/150
+RUN apt-get install mplayer -y
+
+# install Firefox browser
+ARG FIREFOX_VERSION=73.0.1
+RUN wget --no-verbose -O /tmp/firefox.tar.bz2 https://download-installer.cdn.mozilla.net/pub/firefox/releases/$FIREFOX_VERSION/linux-x86_64/en-US/firefox-$FIREFOX_VERSION.tar.bz2 \
+  && tar -C /opt -xjf /tmp/firefox.tar.bz2 \
+  && rm /tmp/firefox.tar.bz2 \
+  && ln -fs /opt/firefox/firefox /usr/bin/firefox
+
+# versions of local tools
+RUN echo  " node version:    $(node -v) \n" \
+  "npm version:     $(npm -v) \n" \
+  "yarn version:    $(yarn -v) \n" \
+  "debian version:  $(cat /etc/debian_version) \n" \
+  "Chrome version:  $(google-chrome --version) \n" \
+  "Firefox version: $(firefox --version) \n" \
+  "git version:     $(git --version) \n" \
+  "whoami:          $(whoami) \n"
+
+# a few environment variables to make NPM installs easier
+# good colors for most applications
+ENV TERM xterm
+# avoid million NPM install messages
+ENV npm_config_loglevel warn
+# allow installing when the main user is root
+ENV npm_config_unsafe_perm true

--- a/browsers/node10.16.3-chrome80-ff73/README.md
+++ b/browsers/node10.16.3-chrome80-ff73/README.md
@@ -1,0 +1,19 @@
+# cypress/browsers:node10.16.3-chrome80-ff73
+
+A complete image with all operating system dependencies for Cypress, Chrome, and Firefox
+
+[Dockerfile](Dockerfile)
+
+```text
+node version:    v10.16.3
+npm version:     6.14.1
+yarn version:    1.22.0
+debian version:  10.1
+Chrome version:  Google Chrome 80.0.3987.116
+Firefox version: Mozilla Firefox 73.0.1
+git version:     git version 2.20.1
+whoami:          root
+```
+
+**Note:** this image uses the `root` user. You might want to switch to non-root
+user like `node` when running this container for security.

--- a/browsers/node10.16.3-chrome80-ff73/build.sh
+++ b/browsers/node10.16.3-chrome80-ff73/build.sh
@@ -1,0 +1,6 @@
+set e+x
+
+LOCAL_NAME=cypress/browsers:node10.16.3-chrome80-ff73
+
+echo "Building $LOCAL_NAME"
+docker build -t $LOCAL_NAME .

--- a/circle.yml
+++ b/circle.yml
@@ -135,11 +135,11 @@ commands:
             RUN npm install --save-dev cypress
             RUN ./node_modules/.bin/cypress verify
             RUN npx @bahmutov/cly init
-            RUN if [[ << parameters.imageName >> = *"-chrome"* ]]; then \
-              ./node_modules/.bin/cypress run --browser chrome \
+            RUN if [[ << parameters.imageName >> = *"-chrome"* ]]; then
+              ./node_modules/.bin/cypress run --browser chrome
             fi
-            RUN if [[ << parameters.imageName >> = *"-ff"* ]]; then \
-              ./node_modules/.bin/cypress run --browser firefox \
+            RUN if [[ << parameters.imageName >> = *"-ff"* ]]; then
+              ./node_modules/.bin/cypress run --browser firefox
             fi
             EOF
 

--- a/circle.yml
+++ b/circle.yml
@@ -86,6 +86,10 @@ commands:
       chromeVersion:
         type: string
         description: Chrome version to expect in the base image, starts with "Google Chrome XX"
+      firefoxVersion:
+        type: string
+        default: ''
+        description: Firefox version to expect in the base image, starts with "Mozilla Firefox XX"
     steps:
       - run:
           name: confirm image has Chrome << parameters.chromeVersion >>
@@ -219,6 +223,10 @@ jobs:
       chromeVersion:
         type: string
         description: Chrome version to expect in the base image, starts with "Google Chrome XX"
+      firefoxVersion:
+        type: string
+        default: ''
+        description: Firefox version to expect in the base image, starts with "Mozilla Firefox XX"
     steps:
       - checkout
       - halt-if-docker-image-exists:
@@ -228,10 +236,10 @@ jobs:
           command: |
             docker build -t << parameters.dockerName >>:<< parameters.dockerTag >> .
           working_directory: browsers/<< parameters.dockerTag >>
-
       - test-browser-image:
           imageName: << parameters.dockerName >>:<< parameters.dockerTag >>
           chromeVersion: << parameters.chromeVersion >>
+          firefoxVersion: << parameters.firefoxVersion >>
       - halt-on-branch
       - docker-push:
           imageName: << parameters.dockerName >>:<< parameters.dockerTag >>
@@ -388,6 +396,7 @@ workflows:
           name: "browsers chrome65-ff57"
           dockerTag: "chrome65-ff57"
           chromeVersion: "Google Chrome 65"
+          firefoxVersion: "Mozilla Firefox 57"
       - build-browser-image:
           name: "browsers chrome67"
           dockerTag: "chrome67"
@@ -396,6 +405,7 @@ workflows:
           name: "browsers chrome67-ff57"
           dockerTag: "chrome67-ff57"
           chromeVersion: "Google Chrome 67"
+          firefoxVersion: "Mozilla Firefox 57"
       - build-browser-image:
           name: "browsers chrome69"
           dockerTag: "chrome69"
@@ -416,6 +426,12 @@ workflows:
           name: "browsers node10.16.0-chrome77-ff71"
           dockerTag: "node10.16.0-chrome77-ff71"
           chromeVersion: "Google Chrome 77"
+          firefoxVersion: "Mozilla Firefox 71"
+      - build-browser-image:
+          name: "browsers node10.16.3-chrome80-ff73"
+          dockerTag: "node10.16.3-chrome80-ff73"
+          chromeVersion: "Google Chrome 80"
+          firefoxVersion: "Mozilla Firefox 73"
       - build-browser-image:
           name: "browsers node10.2.1-chrome74"
           dockerTag: "node10.2.1-chrome74"
@@ -432,6 +448,7 @@ workflows:
           name: "browsers node12.0.0-chrome73-ff68"
           dockerTag: "node12.0.0-chrome73-ff68"
           chromeVersion: "Google Chrome 73"
+          firefoxVersion: "Mozilla Firefox 68"
       - build-browser-image:
           name: "browsers node12.0.0-chrome75"
           dockerTag: "node12.0.0-chrome75"
@@ -440,22 +457,27 @@ workflows:
           name: "browsers node12.13.0-chrome78-ff70"
           dockerTag: "node12.13.0-chrome78-ff70"
           chromeVersion: "Google Chrome 78"
+          firefoxVersion: "Mozilla Firefox 70"
       - build-browser-image:
           name: "browsers node12.13.0-chrome78-ff70-brave78"
           dockerTag: "node12.13.0-chrome78-ff70-brave78"
           chromeVersion: "Google Chrome 78"
+          firefoxVersion: "Mozilla Firefox 70"
       - build-browser-image:
           name: "browsers node12.13.0-chrome80-ff73"
           dockerTag: "node12.13.0-chrome80-ff73"
           chromeVersion: "Google Chrome 80"
+          firefoxVersion: "Mozilla Firefox 73"
       - build-browser-image:
           name: "browsers node12.14.0-chrome79-ff71"
           dockerTag: "node12.14.0-chrome79-ff71"
           chromeVersion: "Google Chrome 79"
+          firefoxVersion: "Mozilla Firefox 71"
       - build-browser-image:
           name: "browsers node12.16.1-chrome80-ff73"
           dockerTag: "node12.16.1-chrome80-ff73"
           chromeVersion: "Google Chrome 80"
+          firefoxVersion: "Mozilla Firefox 73"
       - build-browser-image:
           name: "browsers node12.4.0-chrome76"
           dockerTag: "node12.4.0-chrome76"
@@ -472,22 +494,27 @@ workflows:
           name: "browsers node12.8.1-chrome78-ff70"
           dockerTag: "node12.8.1-chrome78-ff70"
           chromeVersion: "Google Chrome 78"
+          firefoxVersion: "Mozilla Firefox 70"
       - build-browser-image:
           name: "browsers node12.8.1-chrome80-ff72"
           dockerTag: "node12.8.1-chrome80-ff72"
           chromeVersion: "Google Chrome 80"
+          firefoxVersion: "Mozilla Firefox 72"
       - build-browser-image:
           name: "browsers node13.1.0-chrome78-ff70"
           dockerTag: "node13.1.0-chrome78-ff70"
           chromeVersion: "Google Chrome 78"
+          firefoxVersion: "Mozilla Firefox 70"
       - build-browser-image:
           name: "browsers node13.3.0-chrome79-ff70"
           dockerTag: "node13.3.0-chrome79-ff70"
           chromeVersion: "Google Chrome 79"
+          firefoxVersion: "Mozilla Firefox 70"
       - build-browser-image:
           name: "browsers node13.6.0-chrome80-ff72"
           dockerTag: "node13.6.0-chrome80-ff72"
           chromeVersion: "Google Chrome 80"
+          firefoxVersion: "Mozilla Firefox 72"
       - build-browser-image:
           name: "browsers node8.15.1-chrome73"
           dockerTag: "node8.15.1-chrome73"
@@ -508,6 +535,7 @@ workflows:
           name: "browsers node8.9.3-npm6.10.1-chrome76-ff68"
           dockerTag: "node8.9.3-npm6.10.1-chrome76-ff68"
           chromeVersion: "Google Chrome 76"
+          firefoxVersion: "Mozilla Firefox 68"
 
   build-included-images:
     jobs:

--- a/circle.yml
+++ b/circle.yml
@@ -135,9 +135,17 @@ commands:
             RUN npm install --save-dev cypress
             RUN ./node_modules/.bin/cypress verify
             RUN npx @bahmutov/cly init
-            RUN if [[ << parameters.imageName >> = *"-chrome"* ]]; then ./node_modules/.bin/cypress run --browser chrome; fi
-            RUN if [[ << parameters.imageName >> = *"-ff"* ]]; then ./node_modules/.bin/cypress run --browser firefox; fi
             EOF
+
+      - when:
+          condition: << parameters.chromeVersion >>
+          steps:
+          - run: docker run cypress/test ./node_modules/.bin/cypress run --browser chrome
+
+      - when:
+          condition: << parameters.firefoxVersion >>
+          steps:
+          - run: docker run cypress/test ./node_modules/.bin/cypress run --browser firefox
 
   test-included-image:
     description: Testing Docker image with Cypress pre-installed

--- a/circle.yml
+++ b/circle.yml
@@ -135,12 +135,8 @@ commands:
             RUN npm install --save-dev cypress
             RUN ./node_modules/.bin/cypress verify
             RUN npx @bahmutov/cly init
-            RUN if [[ << parameters.imageName >> = *"-chrome"* ]]; then
-              ./node_modules/.bin/cypress run --browser chrome
-            fi
-            RUN if [[ << parameters.imageName >> = *"-ff"* ]]; then
-              ./node_modules/.bin/cypress run --browser firefox
-            fi
+            RUN if [[ << parameters.imageName >> = *"-chrome"* ]]; then ./node_modules/.bin/cypress run --browser chrome; fi
+            RUN if [[ << parameters.imageName >> = *"-ff"* ]]; then ./node_modules/.bin/cypress run --browser firefox; fi
             EOF
 
   test-included-image:

--- a/circle.yml
+++ b/circle.yml
@@ -125,7 +125,6 @@ commands:
       - run:
           name: test image << parameters.imageName >>
           no_output_timeout: '3m'
-          # for now assuming Chrome, in the future can pass browser name as a parameter
           command: |
             docker build -t cypress/test -\<<EOF
             FROM << parameters.imageName >>
@@ -137,15 +136,26 @@ commands:
             RUN npx @bahmutov/cly init
             EOF
 
+      - run:
+          name: Test built-in Electron browser
+          no_output_timeout: '1m'
+          command: docker run cypress/test ./node_modules/.bin/cypress run
+
       - when:
           condition: << parameters.chromeVersion >>
           steps:
-          - run: docker run cypress/test ./node_modules/.bin/cypress run --browser chrome
+          - run:
+              name: Test << parameters.chromeVersion >>
+              no_output_timeout: '1m'
+              command: docker run cypress/test ./node_modules/.bin/cypress run --browser chrome
 
       - when:
           condition: << parameters.firefoxVersion >>
           steps:
-          - run: docker run cypress/test ./node_modules/.bin/cypress run --browser firefox
+          - run:
+              name: Test << parameters.firefoxVersion >>
+              no_output_timeout: '1m'
+              command: docker run cypress/test ./node_modules/.bin/cypress run --browser firefox
 
   test-included-image:
     description: Testing Docker image with Cypress pre-installed

--- a/circle.yml
+++ b/circle.yml
@@ -105,6 +105,23 @@ commands:
               echo "Expected << parameters.chromeVersion >> and got $version"
               exit 1
             fi
+
+      - when:
+          condition: << parameters.firefoxVersion >>
+          steps:
+          - run:
+              name: confirm the image has Firefox << parameters.firefoxVersion >>
+              command: |
+                version=$(docker run << parameters.imageName >> firefox --version)
+                if [[ "$version" =~ ^"<< parameters.firefoxVersion >>" ]]; then
+                  echo "Image has the expected version of Firefox << parameters.firefoxVersion >>"
+                  echo "found $version"
+                else
+                  echo "Problem: image has unexpected Firefox version"
+                  echo "Expected << parameters.firefoxVersion >> and got $version"
+                  exit 1
+                fi
+
       - run:
           name: test image << parameters.imageName >>
           no_output_timeout: '3m'

--- a/generate-config.js
+++ b/generate-config.js
@@ -114,6 +114,23 @@ commands:
               echo "Expected << parameters.chromeVersion >> and got $version"
               exit 1
             fi
+
+      - when:
+          condition: << parameters.firefoxVersion >>
+          steps:
+          - run:
+              name: confirm the image has Firefox << parameters.firefoxVersion >>
+              command: |
+                version=$(docker run << parameters.imageName >> firefox --version)
+                if [[ "$version" =~ ^"<< parameters.firefoxVersion >>" ]]; then
+                  echo "Image has the expected version of Firefox << parameters.firefoxVersion >>"
+                  echo "found $version"
+                else
+                  echo "Problem: image has unexpected Firefox version"
+                  echo "Expected << parameters.firefoxVersion >> and got $version"
+                  exit 1
+                fi
+
       - run:
           name: test image << parameters.imageName >>
           no_output_timeout: '3m'

--- a/generate-config.js
+++ b/generate-config.js
@@ -134,7 +134,6 @@ commands:
       - run:
           name: test image << parameters.imageName >>
           no_output_timeout: '3m'
-          # for now assuming Chrome, in the future can pass browser name as a parameter
           command: |
             docker build -t cypress/test -\\<<EOF
             FROM << parameters.imageName >>
@@ -146,15 +145,26 @@ commands:
             RUN npx @bahmutov/cly init
             EOF
 
+      - run:
+          name: Test built-in Electron browser
+          no_output_timeout: '1m'
+          command: docker run cypress/test ./node_modules/.bin/cypress run
+
       - when:
           condition: << parameters.chromeVersion >>
           steps:
-          - run: docker run cypress/test ./node_modules/.bin/cypress run --browser chrome
+          - run:
+              name: Test << parameters.chromeVersion >>
+              no_output_timeout: '1m'
+              command: docker run cypress/test ./node_modules/.bin/cypress run --browser chrome
 
       - when:
           condition: << parameters.firefoxVersion >>
           steps:
-          - run: docker run cypress/test ./node_modules/.bin/cypress run --browser firefox
+          - run:
+              name: Test << parameters.firefoxVersion >>
+              no_output_timeout: '1m'
+              command: docker run cypress/test ./node_modules/.bin/cypress run --browser firefox
 
   test-included-image:
     description: Testing Docker image with Cypress pre-installed

--- a/generate-config.js
+++ b/generate-config.js
@@ -144,9 +144,17 @@ commands:
             RUN npm install --save-dev cypress
             RUN ./node_modules/.bin/cypress verify
             RUN npx @bahmutov/cly init
-            RUN if [[ << parameters.imageName >> = *"-chrome"* ]]; then ./node_modules/.bin/cypress run --browser chrome; fi
-            RUN if [[ << parameters.imageName >> = *"-ff"* ]]; then ./node_modules/.bin/cypress run --browser firefox; fi
             EOF
+
+      - when:
+          condition: << parameters.chromeVersion >>
+          steps:
+          - run: docker run cypress/test ./node_modules/.bin/cypress run --browser chrome
+
+      - when:
+          condition: << parameters.firefoxVersion >>
+          steps:
+          - run: docker run cypress/test ./node_modules/.bin/cypress run --browser firefox
 
   test-included-image:
     description: Testing Docker image with Cypress pre-installed

--- a/generate-config.js
+++ b/generate-config.js
@@ -144,12 +144,8 @@ commands:
             RUN npm install --save-dev cypress
             RUN ./node_modules/.bin/cypress verify
             RUN npx @bahmutov/cly init
-            RUN if [[ << parameters.imageName >> = *"-chrome"* ]]; then
-              ./node_modules/.bin/cypress run --browser chrome
-            fi
-            RUN if [[ << parameters.imageName >> = *"-ff"* ]]; then
-              ./node_modules/.bin/cypress run --browser firefox
-            fi
+            RUN if [[ << parameters.imageName >> = *"-chrome"* ]]; then ./node_modules/.bin/cypress run --browser chrome; fi
+            RUN if [[ << parameters.imageName >> = *"-ff"* ]]; then ./node_modules/.bin/cypress run --browser firefox; fi
             EOF
 
   test-included-image:

--- a/generate-config.js
+++ b/generate-config.js
@@ -144,11 +144,11 @@ commands:
             RUN npm install --save-dev cypress
             RUN ./node_modules/.bin/cypress verify
             RUN npx @bahmutov/cly init
-            RUN if [[ << parameters.imageName >> = *"-chrome"* ]]; then \\
-              ./node_modules/.bin/cypress run --browser chrome \\
+            RUN if [[ << parameters.imageName >> = *"-chrome"* ]]; then
+              ./node_modules/.bin/cypress run --browser chrome
             fi
-            RUN if [[ << parameters.imageName >> = *"-ff"* ]]; then \\
-              ./node_modules/.bin/cypress run --browser firefox \\
+            RUN if [[ << parameters.imageName >> = *"-ff"* ]]; then
+              ./node_modules/.bin/cypress run --browser firefox
             fi
             EOF
 


### PR DESCRIPTION
- if the browsers image has `-ffYY` name, then validate Firefox with version `YY...` is installed
- run Cypress tests inside a test Docker image using Electron browser, then Chrome (if installed), then Firefox (if installed)