### PR TITLE
add node12.13.0-chrome80-ff74

### DIFF
--- a/browsers/README.md
+++ b/browsers/README.md
@@ -12,6 +12,7 @@ Name + Tag | Base image | Chrome | Firefox
 [cypress/browsers:node12.6.0-chrome75](./node12.6.0-chrome75) | `cypress/base:12.6.0` | `75.0.3770.100` | 🚫
 [cypress/browsers:node12.8.1-chrome78-ff70](./node12.8.1-chrome78-ff70) | `cypress/browsers:node12.13.0-chrome78-ff70` | `78.0.3904.97` | `70.0.1`
 [cypress/browsers:node12.13.0-chrome78-ff70](./node12.13.0-chrome78-ff70) | `cypress/base:12.13.0` | `78.0.3904.97` | `70.0.1`
+[cypress/browsers:node12.13.0-chrome80-ff74](./node12.13.0-chrome80-ff74) | `node:12.13.0-buster` | `80.0.3987.116` | `74.0`
 [cypress/browsers:node12.16.1-chrome80-ff73](./node12.16.1-chrome80-ff73) | `cypress/base:12.16.1` | `80.0.3987.122` | `73.0.1`
 [cypress/browsers:node12.8.1-chrome80-ff72](./node12.8.1-chrome80-ff72) | `cypress/base:node12.8.1` | `80.0.3987.87` | `72.0.2`
 [cypress/browsers:node13.6.0-chrome80-ff72](./node13.6.0-chrome80-ff72) | `cypress/base:13.6.0` | `80.0.3987.87` | `72.0.2`

--- a/browsers/node12.13.0-chrome80-ff74/Dockerfile
+++ b/browsers/node12.13.0-chrome80-ff74/Dockerfile
@@ -1,0 +1,98 @@
+FROM node:12.13.0-buster
+
+RUN apt-get update && \
+  apt-get install --no-install-recommends -y \
+  libgtk2.0-0 \
+  libgtk-3-0 \
+  libnotify-dev \
+  libgconf-2-4 \
+  libnss3 \
+  libxss1 \
+  libasound2 \
+  libxtst6 \
+  xauth \
+  xvfb \
+  # install Chinese fonts
+  # this list was copied from https://github.com/jim3ma/docker-leanote
+  fonts-arphic-bkai00mp \
+  fonts-arphic-bsmi00lp \
+  fonts-arphic-gbsn00lp \
+  fonts-arphic-gkai00mp \
+  fonts-arphic-ukai \
+  fonts-arphic-uming \
+  ttf-wqy-zenhei \
+  ttf-wqy-microhei \
+  xfonts-wqy \
+  # clean up
+  && rm -rf /var/lib/apt/lists/*
+
+RUN npm install -g npm@latest
+RUN npm install --force -g yarn@latest
+
+# a few environment variables to make NPM installs easier
+# good colors for most applications
+ENV TERM xterm
+# avoid million NPM install messages
+ENV npm_config_loglevel warn
+# allow installing when the main user is root
+ENV npm_config_unsafe_perm true
+
+# versions of local tools
+RUN echo  " node version:    $(node -v) \n" \
+  "npm version:     $(npm -v) \n" \
+  "yarn version:    $(yarn -v) \n" \
+  "debian version:  $(cat /etc/debian_version) \n" \
+  "user:            $(whoami) \n"
+
+USER root
+
+RUN node --version
+RUN echo "force new chrome here!"
+
+# Chrome dependencies
+RUN apt-get update
+RUN apt-get install -y fonts-liberation libappindicator3-1 xdg-utils
+
+# install Chrome browser
+ENV CHROME_VERSION 80.0.3987.116
+RUN wget -O /usr/src/google-chrome-stable_current_amd64.deb "http://dl.google.com/linux/chrome/deb/pool/main/g/google-chrome-stable/google-chrome-stable_${CHROME_VERSION}-1_amd64.deb" && \
+  dpkg -i /usr/src/google-chrome-stable_current_amd64.deb ; \
+  apt-get install -f -y && \
+  rm -f /usr/src/google-chrome-stable_current_amd64.deb
+RUN google-chrome --version
+
+# "fake" dbus address to prevent errors
+# https://github.com/SeleniumHQ/docker-selenium/issues/87
+ENV DBUS_SESSION_BUS_ADDRESS=/dev/null
+
+# Add zip utility - it comes in very handy
+RUN apt-get update && apt-get install -y zip
+
+# add codecs needed for video playback in firefox
+# https://github.com/cypress-io/cypress-docker-images/issues/150
+RUN apt-get install mplayer -y
+
+# install Firefox browser
+ARG FIREFOX_VERSION=74.0
+RUN wget --no-verbose -O /tmp/firefox.tar.bz2 https://download-installer.cdn.mozilla.net/pub/firefox/releases/$FIREFOX_VERSION/linux-x86_64/en-US/firefox-$FIREFOX_VERSION.tar.bz2 \
+  && tar -C /opt -xjf /tmp/firefox.tar.bz2 \
+  && rm /tmp/firefox.tar.bz2 \
+  && ln -fs /opt/firefox/firefox /usr/bin/firefox
+
+# versions of local tools
+RUN echo  " node version:    $(node -v) \n" \
+  "npm version:     $(npm -v) \n" \
+  "yarn version:    $(yarn -v) \n" \
+  "debian version:  $(cat /etc/debian_version) \n" \
+  "Chrome version:  $(google-chrome --version) \n" \
+  "Firefox version: $(firefox --version) \n" \
+  "git version:     $(git --version) \n" \
+  "whoami:          $(whoami) \n"
+
+# a few environment variables to make NPM installs easier
+# good colors for most applications
+ENV TERM xterm
+# avoid million NPM install messages
+ENV npm_config_loglevel warn
+# allow installing when the main user is root
+ENV npm_config_unsafe_perm true

--- a/browsers/node12.13.0-chrome80-ff74/README.md
+++ b/browsers/node12.13.0-chrome80-ff74/README.md
@@ -1,0 +1,19 @@
+# cypress/browsers:node12.13.0-chrome80-ff74
+
+A complete image with all operating system dependencies for Cypress, Chrome, and Firefox
+
+[Dockerfile](Dockerfile)
+
+```text
+node version:    v12.13.0
+npm version:     6.14.2
+yarn version:    1.22.4
+debian version:  10.1
+Chrome version:  Google Chrome 80.0.3987.116
+Firefox version: Mozilla Firefox 74.0
+git version:     git version 2.20.1
+whoami:          root
+```
+
+**Note:** this image uses the `root` user. You might want to switch to non-root
+user like `node` when running this container for security.

--- a/browsers/node12.13.0-chrome80-ff74/build.sh
+++ b/browsers/node12.13.0-chrome80-ff74/build.sh
@@ -1,0 +1,6 @@
+set e+x
+
+LOCAL_NAME=cypress/browsers:node12.13.0-chrome80-ff74
+
+echo "Building $LOCAL_NAME"
+docker build -t $LOCAL_NAME .

--- a/circle.yml
+++ b/circle.yml
@@ -500,6 +500,11 @@ workflows:
           chromeVersion: "Google Chrome 80"
           firefoxVersion: "Mozilla Firefox 73"
       - build-browser-image:
+          name: "browsers node12.13.0-chrome80-ff74"
+          dockerTag: "node12.13.0-chrome80-ff74"
+          chromeVersion: "Google Chrome 80"
+          firefoxVersion: "Mozilla Firefox 74"
+      - build-browser-image:
           name: "browsers node12.14.0-chrome79-ff71"
           dockerTag: "node12.14.0-chrome79-ff71"
           chromeVersion: "Google Chrome 79"


### PR DESCRIPTION
`node12.13.0-chrome80-ff73` is based on Debian Stretch (which cypress/base:12.13.0 is based on), but we need Debian Buster for cypress-io/cypress#6555