### PR TITLE
Add slim build support

### DIFF
--- a/slim/10-4.0.2/Dockerfile
+++ b/slim/10-4.0.2/Dockerfile
@@ -1,0 +1,25 @@
+FROM node:10-slim
+
+RUN apt-get update && \
+    apt-get install --no-install-recommends -y \
+        libgtk2.0-0 \
+        libgtk-3-0 \
+        libnotify-dev \
+        libgconf-2-4 \
+        libnss3 \
+        libxss1 \
+        libasound2 \
+        libxtst6 \
+        xauth \
+        xvfb \
+        wget \
+        unzip && \
+    mkdir -p ~/.cache/Cypress/4.0.2/Cypress && \
+    wget -O /tmp/z.$$ http://download.cypress.io/desktop/4.0.2?platform=linux && \
+    unzip -d ~/.cache/Cypress/4.0.2/ /tmp/z.$$ && \
+    rm /tmp/z.$$ && \
+    chmod +x ~/.cache/Cypress/4.0.2/Cypress/Cypress && \
+    apt-get purge -y \
+        wget \
+        unzip && \
+    rm -rf /var/lib/apt/lists/*


### PR DESCRIPTION
### Motivation

I was trying to use Alpine (node:10-alpine ~25mb), but after spending some time fighting with Glibc I saw that you are already aware that it does not seem to be possible. This was discussed here on #110 and #206.

The second-best option for me is slim images. While node:10 (the base image for cypress/base) is based on the full Debian (~330mb), there are node images available that come from Debian slim (45mb).

### Additional info
I am also including the Cypress binaries. Although it makes the image much heavier, the binary will have to be downloaded anyway. 

In my opinion, this is essential for proper CI. Downloading cypress after the application code is transferred to the container (with npm/yarn) adds time to the build that is not needed. Even if the image gets much heavier with Cypress already in it, it saves time in the end.

When using CIs that are based on docker, it is essential to build a docker image also for cypress. By using this image with slim and cypress already installed, I was able to reduce my build times by 50% (from 10 minutes to 5)

### Proposed image naming

`cypress/slim:10-4.0.2`

### Sizing

```
$ DOCKER_BUILDKIT=1 docker build -t cypress/slim:10-4.0.2 .
[+] Building 152.0s (6/6) FINISHED                                                                                                                                                                                                                                                          
 => [internal] load .dockerignore                                                                                                                                                                                                                                                      0.0s
 => => transferring context: 2B                                                                                                                                                                                                                                                        0.0s
 => [internal] load build definition from Dockerfile                                                                                                                                                                                                                                   0.1s
 => => transferring dockerfile: 744B                                                                                                                                                                                                                                                   0.0s
 => [internal] load metadata for docker.io/library/node:10-slim                                                                                                                                                                                                                       11.3s
 => CACHED [1/2] FROM docker.io/library/node:10-slim@sha256:ce0b8ec37c669bb12da1683a265a2aa6f85cdd7a692d959f7c48e8c26cc37585                                                                                                                                                           0.0s
 => [2/2] RUN apt-get update &&     apt-get install --no-install-recommends -y         libgtk2.0-0         libgtk-3-0         libnotify-dev         libgconf-2-4         libnss3         libxss1         libasound2         libxtst6         xauth         xvfb         wget         132.1s
 => exporting to image                                                                                                                                                                                                                                                                 8.4s
 => => exporting layers                                                                                                                                                                                                                                                                8.4s
 => => writing image sha256:4b18f200e840dca65ccab68f4882ae5c893c856716b7ee1cf3283ecf47728361                                                                                                                                                                                           0.0s 
 => => naming to docker.io/cypress/slim:10-4.0.2 
```

```bash
REPOSITORY                                                 TAG                     IMAGE ID            CREATED             SIZE                                                                                                                                                             
cypress/slim                                               10-4.0.2                4b18f200e840        30 seconds ago      847MB
```

### Remaining work
- [ ] Approval of the idea
- [ ] Figure out why wget on the cypress download link fails certificate
- [ ] Integration with CI
- [ ] Build for more versions