### PR TITLE
add libgbm-dev to 8.0.0 base image

### DIFF
--- a/base/8.0.0/Dockerfile
+++ b/base/8.0.0/Dockerfile
@@ -19,6 +19,7 @@ RUN apt-get update && \
   libgtk-3-0 \
   libnotify-dev \
   libgconf-2-4 \
+  libgbm-dev \
   libnss3 \
   libxss1 \
   libasound2 \


### PR DESCRIPTION
to fix https://circleci.com/gh/cypress-io/cypress/377914?utm_campaign=vcs-integration-link&utm_medium=referral&utm_source=github-build-link

on https://github.com/cypress-io/cypress/pull/7791

@bahmutov since this is an update to an existing image, will it need to be manually uploaded to docker hub?