### PR TITLE
add a browser image with Edge browser

### DIFF
--- a/browsers/README.md
+++ b/browsers/README.md
@@ -4,8 +4,8 @@
 
 > Docker image with all operating system dependencies and some pre-installed browsers, **but NOT Cypress itself**. See [cypress/included](../included) images if you need Cypress pre-installed in the image.
 
-Name + Tag | Base image | Chrome | Firefox
---- | --- | --- | ---
+Name + Tag | Base image | Chrome | Firefox | Edge
+--- | --- | --- | --- | ---
 [cypress/browsers:node8.9.3-npm6.10.1-chrome75](./node8.9.3-npm6.10.1-chrome75) | `cypress/base:8.9.3-npm-6.10.1` | `75.0.3770.100` | 🚫
 [cypress/browsers:node10.16.0-chrome77-ff71](./node10.16.0-chrome77-ff71) | `cypress/browsers:node10.16.0-chrome77` | `77.0.3865.90` | `71.0`
 [cypress/browsers:node12.4.0-chrome76](./node12.4.0-chrome76) | `cypress/base:12.4.0` | `76.0.3809.87` | 🚫
@@ -22,6 +22,7 @@ Name + Tag | Base image | Chrome | Firefox
 [cypress/browsers:node13.8.0-chrome81-ff75](./node13.8.0-chrome81-ff75) | `cypress/base:13.8.0` | `81.0.4044.113` | `75.0`
 [cypress/browsers:node14.7.0-chrome84](./node14.7.0-chrome84) | `cypress/base:14.7.0` | `84.0.4147.105` | 🚫
 [cypress/browsers:node12.14.1-chrome85-ff81](./node12.14.1-chrome85-ff81) | `cypress/base:12.14.1` | `85.0.4183.121` | `81.0`
+[cypress/browsers:node14.10.1-edge88](./node14.10.1-edge88) | `cypress/base:14.10.1` | 🚫 | 🚫 | `88.0.673.0 dev`
 
 ## Naming scheme
 

--- a/browsers/node14.10.1-edge88/Dockerfile
+++ b/browsers/node14.10.1-edge88/Dockerfile
@@ -13,6 +13,8 @@ RUN rm microsoft.gpg
 ## Install Edge
 RUN apt-get update
 RUN apt-get install -y microsoft-edge-dev
+# Add a link to the browser that allows Cypress to find it
+RUN ln -s /usr/bin/microsoft-edge /usr/bin/edge
 
 # Add zip utility - it comes in very handy
 RUN apt-get update && apt-get install -y zip
@@ -22,7 +24,7 @@ RUN echo  " node version:    $(node -v) \n" \
   "npm version:     $(npm -v) \n" \
   "yarn version:    $(yarn -v) \n" \
   "Debian version:  $(cat /etc/debian_version) \n" \
-  "Edge version:    $(microsoft-edge --version) \n" \
+  "Edge version:    $(edge --version) \n" \
   "git version:     $(git --version) \n" \
   "whoami:          $(whoami) \n"
 

--- a/browsers/node14.10.1-edge88/Dockerfile
+++ b/browsers/node14.10.1-edge88/Dockerfile
@@ -1,0 +1,35 @@
+FROM cypress/base:14.10.1
+
+USER root
+
+RUN node --version
+RUN echo "force new Edge version here!"
+
+## Setup
+RUN curl https://packages.microsoft.com/keys/microsoft.asc | gpg --dearmor > microsoft.gpg
+RUN install -o root -g root -m 644 microsoft.gpg /etc/apt/trusted.gpg.d/
+RUN sh -c 'echo "deb [arch=amd64] https://packages.microsoft.com/repos/edge stable main" > /etc/apt/sources.list.d/microsoft-edge-dev.list'
+RUN rm microsoft.gpg
+## Install Edge
+RUN apt-get update
+RUN apt-get install -y microsoft-edge-dev
+
+# Add zip utility - it comes in very handy
+RUN apt-get update && apt-get install -y zip
+
+# versions of local tools
+RUN echo  " node version:    $(node -v) \n" \
+  "npm version:     $(npm -v) \n" \
+  "yarn version:    $(yarn -v) \n" \
+  "Debian version:  $(cat /etc/debian_version) \n" \
+  "Edge version:    $(microsoft-edge --version) \n" \
+  "git version:     $(git --version) \n" \
+  "whoami:          $(whoami) \n"
+
+# a few environment variables to make NPM installs easier
+# good colors for most applications
+ENV TERM xterm
+# avoid million NPM install messages
+ENV npm_config_loglevel warn
+# allow installing when the main user is root
+ENV npm_config_unsafe_perm true

--- a/browsers/node14.10.1-edge88/README.md
+++ b/browsers/node14.10.1-edge88/README.md
@@ -1,0 +1,18 @@
+# cypress/browsers:node14.10.1-edge88
+
+A complete image with all operating system dependencies for Cypress and [Microsoft Edge browser](https://www.microsoftedgeinsider.com/en-us/download/?platform=linux-deb).
+
+[Dockerfile](Dockerfile)
+
+```text
+node versions:   v14.10.1
+npm version:     6.14.8
+yarn version:    1.22.5
+Debian version:  10.5
+Edge version:    Microsoft Edge 88.0.673.0 dev
+git version:     git version 2.20.1
+whoami:          root
+```
+
+**Note:** this image uses the `root` user. You might want to switch to non-root
+user like `node` when running this container for security.

--- a/browsers/node14.10.1-edge88/build.sh
+++ b/browsers/node14.10.1-edge88/build.sh
@@ -1,0 +1,6 @@
+set e+x
+
+LOCAL_NAME=cypress/browsers:node14.10.1-edge88
+
+echo "Building $LOCAL_NAME"
+docker build -t $LOCAL_NAME .

--- a/circle.yml
+++ b/circle.yml
@@ -188,6 +188,14 @@ commands:
               no_output_timeout: '1m'
               command: docker run cypress/test ./node_modules/.bin/cypress run --browser firefox
 
+      - when:
+          condition: << parameters.edgeVersion >>
+          steps:
+          - run:
+              name: Test << parameters.edgeVersion >>
+              no_output_timeout: '1m'
+              command: docker run cypress/test ./node_modules/.bin/cypress run --browser edge
+
   test-included-image:
     description: Testing Docker image with Cypress pre-installed
     parameters:

--- a/circle.yml
+++ b/circle.yml
@@ -92,26 +92,34 @@ commands:
         description: Cypress browser docker image to test
       chromeVersion:
         type: string
+        default: ''
         description: Chrome version to expect in the base image, starts with "Google Chrome XX"
       firefoxVersion:
         type: string
         default: ''
         description: Firefox version to expect in the base image, starts with "Mozilla Firefox XX"
+      edgeVersion:
+        type: string
+        default: ''
+        description: Edge version to expect in the base image, starts with "Microsoft Edge XX"
     steps:
-      - run:
-          name: confirm image has Chrome << parameters.chromeVersion >>
-          # do not run Docker in the interactive mode - adds control characters!
-          # and use Bash regex string comparison
-          command: |
-            version=$(docker run << parameters.imageName >> google-chrome --version)
-            if [[ "$version" =~ ^"<< parameters.chromeVersion >>" ]]; then
-              echo "Image has the expected version of Chrome << parameters.chromeVersion >>"
-              echo "found $version"
-            else
-              echo "Problem: image has unexpected Chrome version"
-              echo "Expected << parameters.chromeVersion >> and got $version"
-              exit 1
-            fi
+      - when:
+          condition: << parameters.chromeVersion >>
+          steps:
+          - run:
+              name: confirm image has Chrome << parameters.chromeVersion >>
+              # do not run Docker in the interactive mode - adds control characters!
+              # and use Bash regex string comparison
+              command: |
+                version=$(docker run << parameters.imageName >> google-chrome --version)
+                if [[ "$version" =~ ^"<< parameters.chromeVersion >>" ]]; then
+                  echo "Image has the expected version of Chrome << parameters.chromeVersion >>"
+                  echo "found $version"
+                else
+                  echo "Problem: image has unexpected Chrome version"
+                  echo "Expected << parameters.chromeVersion >> and got $version"
+                  exit 1
+                fi
 
       - when:
           condition: << parameters.firefoxVersion >>
@@ -126,6 +134,22 @@ commands:
                 else
                   echo "Problem: image has unexpected Firefox version"
                   echo "Expected << parameters.firefoxVersion >> and got $version"
+                  exit 1
+                fi
+
+      - when:
+          condition: << parameters.edgeVersion >>
+          steps:
+          - run:
+              name: confirm the image has Edge << parameters.edgeVersion >>
+              command: |
+                version=$(docker run << parameters.imageName >> edge --version)
+                if [[ "$version" =~ ^"<< parameters.edgeVersion >>" ]]; then
+                  echo "Image has the expected version of Edge << parameters.edgeVersion >>"
+                  echo "found $version"
+                else
+                  echo "Problem: image has unexpected Edge version"
+                  echo "Expected << parameters.edgeVersion >> and got $version"
                   exit 1
                 fi
 
@@ -265,11 +289,16 @@ jobs:
         description: Image tag to build like "node12.4.0-chrome76"
       chromeVersion:
         type: string
+        default: ''
         description: Chrome version to expect in the base image, starts with "Google Chrome XX"
       firefoxVersion:
         type: string
         default: ''
         description: Firefox version to expect in the base image, starts with "Mozilla Firefox XX"
+      edgeVersion:
+        type: string
+        default: ''
+        description: Edge version to expect in the base image, starts with "Microsoft Edge XX"
     steps:
       - checkout
       - halt-if-docker-image-exists:
@@ -283,6 +312,7 @@ jobs:
           imageName: << parameters.dockerName >>:<< parameters.dockerTag >>
           chromeVersion: << parameters.chromeVersion >>
           firefoxVersion: << parameters.firefoxVersion >>
+          edgeVersion: << parameters.edgeVersion >>
       - halt-on-branch
       - docker-push:
           imageName: << parameters.dockerName >>:<< parameters.dockerTag >>
@@ -362,6 +392,10 @@ workflows:
           dockerTag: "node13.8.0-chrome81-ff75"
           chromeVersion: "Google Chrome 81"
           firefoxVersion: "Mozilla Firefox 75"
+      - build-browser-image:
+          name: "browsers node14.10.1-edge88"
+          dockerTag: "node14.10.1-edge88"
+          edgeVersion: "Microsoft Edge 88"
       - build-browser-image:
           name: "browsers node14.7.0-chrome84"
           dockerTag: "node14.7.0-chrome84"

--- a/generate-config.js
+++ b/generate-config.js
@@ -198,6 +198,14 @@ commands:
               no_output_timeout: '1m'
               command: docker run cypress/test ./node_modules/.bin/cypress run --browser firefox
 
+      - when:
+          condition: << parameters.edgeVersion >>
+          steps:
+          - run:
+              name: Test << parameters.edgeVersion >>
+              no_output_timeout: '1m'
+              command: docker run cypress/test ./node_modules/.bin/cypress run --browser edge
+
   test-included-image:
     description: Testing Docker image with Cypress pre-installed
     parameters:


### PR DESCRIPTION
- closes #385 
- [x] build image with Microsoft Edge browser
- [x] detect Edge browser using `npx cypress info` command by adding a symbolic link `/usr/bin/edge`
- [x] run tests using Edge browser on CI