### PR TITLE
Add Browsers node12.19.0 chrome86 ff82

### DIFF
--- a/browsers/README.md
+++ b/browsers/README.md
@@ -17,6 +17,7 @@ Name + Tag | Base image | Chrome | Firefox | Edge
 [cypress/browsers:node12.16.1-chrome80-ff73](./node12.16.1-chrome80-ff73) | `cypress/base:12.16.1` | `80.0.3987.122` | `73.0.1`
 [cypress/browsers:node12.16.2-chrome81-ff75](./node12.16.2-chrome81-ff75) | `cypress/base:12.16.2` | `81.0.4044.113` | `75.0`
 [cypress/browsers:node12.18.0-chrome83-ff77](./node12.18.0-chrome83-ff77) | `cypress/base:12.18.0` | `83.0.4103.61` | `77.0`
+[cypress/browsers:node12.19.0-chrome86-ff82](./node12.19.0-chrome86-ff82) | `cypress/base:12.19.0` | `86.0.4240.111` | `82.0`
 [cypress/browsers:node12.8.1-chrome80-ff72](./node12.8.1-chrome80-ff72) | `cypress/base:node12.8.1` | `80.0.3987.87` | `72.0.2`
 [cypress/browsers:node12.18.4-edge88](./node12.18.4-edge88) | `cypress/base:12.18.4` | 🚫 | 🚫 | `88.0.673.0 dev`
 [cypress/browsers:node13.6.0-chrome80-ff72](./node13.6.0-chrome80-ff72) | `cypress/base:13.6.0` | `80.0.3987.87` | `72.0.2`

--- a/browsers/README.md
+++ b/browsers/README.md
@@ -17,7 +17,7 @@ Name + Tag | Base image | Chrome | Firefox | Edge
 [cypress/browsers:node12.16.1-chrome80-ff73](./node12.16.1-chrome80-ff73) | `cypress/base:12.16.1` | `80.0.3987.122` | `73.0.1`
 [cypress/browsers:node12.16.2-chrome81-ff75](./node12.16.2-chrome81-ff75) | `cypress/base:12.16.2` | `81.0.4044.113` | `75.0`
 [cypress/browsers:node12.18.0-chrome83-ff77](./node12.18.0-chrome83-ff77) | `cypress/base:12.18.0` | `83.0.4103.61` | `77.0`
-[cypress/browsers:node12.19.0-chrome86-ff82](./node12.19.0-chrome86-ff82) | `cypress/base:12.19.0` | `86.0.4240.111` | `82.0`
+[cypress/browsers:node12.19.0-chrome86-ff82](./node12.19.0-chrome86-ff82) | `cypress/base:12.19.0` | `86.0.4240.193` | `82.0.3`
 [cypress/browsers:node12.8.1-chrome80-ff72](./node12.8.1-chrome80-ff72) | `cypress/base:node12.8.1` | `80.0.3987.87` | `72.0.2`
 [cypress/browsers:node12.18.4-edge88](./node12.18.4-edge88) | `cypress/base:12.18.4` | 🚫 | 🚫 | `88.0.673.0 dev`
 [cypress/browsers:node13.6.0-chrome80-ff72](./node13.6.0-chrome80-ff72) | `cypress/base:13.6.0` | `80.0.3987.87` | `72.0.2`

--- a/browsers/node12.19.0-chrome86-ff82/Dockerfile
+++ b/browsers/node12.19.0-chrome86-ff82/Dockerfile
@@ -10,7 +10,7 @@ RUN apt-get update
 RUN apt-get install -y fonts-liberation libappindicator3-1 xdg-utils
 
 # install Chrome browser
-ENV CHROME_VERSION 86.0.4240.111
+ENV CHROME_VERSION 86.0.4240.193
 RUN wget -O /usr/src/google-chrome-stable_current_amd64.deb "http://dl.google.com/linux/chrome/deb/pool/main/g/google-chrome-stable/google-chrome-stable_${CHROME_VERSION}-1_amd64.deb" && \
   dpkg -i /usr/src/google-chrome-stable_current_amd64.deb ; \
   apt-get install -f -y && \
@@ -29,7 +29,7 @@ RUN apt-get update && apt-get install -y zip
 RUN apt-get install mplayer -y
 
 # install Firefox browser
-ARG FIREFOX_VERSION=82.0
+ARG FIREFOX_VERSION=82.0.3
 RUN wget --no-verbose -O /tmp/firefox.tar.bz2 https://download-installer.cdn.mozilla.net/pub/firefox/releases/$FIREFOX_VERSION/linux-x86_64/en-US/firefox-$FIREFOX_VERSION.tar.bz2 \
   && tar -C /opt -xjf /tmp/firefox.tar.bz2 \
   && rm /tmp/firefox.tar.bz2 \

--- a/browsers/node12.19.0-chrome86-ff82/Dockerfile
+++ b/browsers/node12.19.0-chrome86-ff82/Dockerfile
@@ -1,0 +1,54 @@
+FROM cypress/base:12.19.0
+
+USER root
+
+RUN node --version
+RUN echo "force new chrome here!"
+
+# Chrome dependencies
+RUN apt-get update
+RUN apt-get install -y fonts-liberation libappindicator3-1 xdg-utils
+
+# install Chrome browser
+ENV CHROME_VERSION 86.0.4240.111
+RUN wget -O /usr/src/google-chrome-stable_current_amd64.deb "http://dl.google.com/linux/chrome/deb/pool/main/g/google-chrome-stable/google-chrome-stable_${CHROME_VERSION}-1_amd64.deb" && \
+  dpkg -i /usr/src/google-chrome-stable_current_amd64.deb ; \
+  apt-get install -f -y && \
+  rm -f /usr/src/google-chrome-stable_current_amd64.deb
+RUN google-chrome --version
+
+# "fake" dbus address to prevent errors
+# https://github.com/SeleniumHQ/docker-selenium/issues/87
+ENV DBUS_SESSION_BUS_ADDRESS=/dev/null
+
+# Add zip utility - it comes in very handy
+RUN apt-get update && apt-get install -y zip
+
+# add codecs needed for video playback in firefox
+# https://github.com/cypress-io/cypress-docker-images/issues/150
+RUN apt-get install mplayer -y
+
+# install Firefox browser
+ARG FIREFOX_VERSION=82.0
+RUN wget --no-verbose -O /tmp/firefox.tar.bz2 https://download-installer.cdn.mozilla.net/pub/firefox/releases/$FIREFOX_VERSION/linux-x86_64/en-US/firefox-$FIREFOX_VERSION.tar.bz2 \
+  && tar -C /opt -xjf /tmp/firefox.tar.bz2 \
+  && rm /tmp/firefox.tar.bz2 \
+  && ln -fs /opt/firefox/firefox /usr/bin/firefox
+
+# versions of local tools
+RUN echo  " node version:    $(node -v) \n" \
+  "npm version:     $(npm -v) \n" \
+  "yarn version:    $(yarn -v) \n" \
+  "debian version:  $(cat /etc/debian_version) \n" \
+  "Chrome version:  $(google-chrome --version) \n" \
+  "Firefox version: $(firefox --version) \n" \
+  "git version:     $(git --version) \n" \
+  "whoami:          $(whoami) \n"
+
+# a few environment variables to make NPM installs easier
+# good colors for most applications
+ENV TERM xterm
+# avoid million NPM install messages
+ENV npm_config_loglevel warn
+# allow installing when the main user is root
+ENV npm_config_unsafe_perm true

--- a/browsers/node12.19.0-chrome86-ff82/README.md
+++ b/browsers/node12.19.0-chrome86-ff82/README.md
@@ -10,8 +10,8 @@ node version:    v12.19.0
 npm version:     6.14.8
 yarn version:    1.22.10
 debian version:  10.6
-Chrome version:  Google Chrome 86.0.4240.111
-Firefox version: Mozilla Firefox 82.0
+Chrome version:  Google Chrome 86.0.4240.193
+Firefox version: Mozilla Firefox 82.0.3
 git version:     git version 2.20.1
 ```
 

--- a/browsers/node12.19.0-chrome86-ff82/README.md
+++ b/browsers/node12.19.0-chrome86-ff82/README.md
@@ -1,0 +1,19 @@
+# cypress/browsers:node12.18.3-chrome83-ff77
+
+A complete image with all operating system dependencies for Cypress, Chrome
+86 and Firefox 82 browsers.
+
+[Dockerfile](Dockerfile)
+
+```text
+node version:    v12.19.0
+npm version:     6.14.8
+yarn version:    1.22.10
+debian version:  10.6
+Chrome version:  Google Chrome 86.0.4240.111
+Firefox version: Mozilla Firefox 82.0
+git version:     git version 2.20.1
+```
+
+**Note:** this image uses the `root` user. You might want to switch to non-root
+user like `node` when running this container for security.

--- a/browsers/node12.19.0-chrome86-ff82/build.sh
+++ b/browsers/node12.19.0-chrome86-ff82/build.sh
@@ -1,0 +1,6 @@
+set e+x
+
+LOCAL_NAME=cypress/browsers:node12.19.0-chrome86-ff82
+
+echo "Building $LOCAL_NAME"
+docker build -t $LOCAL_NAME .

--- a/circle.yml
+++ b/circle.yml
@@ -468,6 +468,11 @@ workflows:
           dockerTag: "node12.18.4-edge88"
           edgeVersion: "Microsoft Edge 88"
       - build-browser-image:
+          name: "browsers node12.19.0-chrome86-ff82"
+          dockerTag: "node12.19.0-chrome86-ff82"
+          chromeVersion: "Google Chrome 86"
+          firefoxVersion: "Mozilla Firefox 82"
+      - build-browser-image:
           name: "browsers node13.8.0-chrome81-ff75"
           dockerTag: "node13.8.0-chrome81-ff75"
           chromeVersion: "Google Chrome 81"


### PR DESCRIPTION
This PR adds a browser image to support the current node LTS version 12.19.0 (released 06-Oct-2020) and the latest versions of Chrome (86.0.4240.111) and Firefox (82.0).

This PR is based on #389.