### PR TITLE
Scaffold the kitchensink tests when testing browsers

### DIFF
--- a/browsers/README.md
+++ b/browsers/README.md
@@ -18,6 +18,7 @@ Name + Tag | Base image | Chrome | Firefox | Edge
 [cypress/browsers:node12.16.2-chrome81-ff75](./node12.16.2-chrome81-ff75) | `cypress/base:12.16.2` | `81.0.4044.113` | `75.0`
 [cypress/browsers:node12.18.0-chrome83-ff77](./node12.18.0-chrome83-ff77) | `cypress/base:12.18.0` | `83.0.4103.61` | `77.0`
 [cypress/browsers:node12.8.1-chrome80-ff72](./node12.8.1-chrome80-ff72) | `cypress/base:node12.8.1` | `80.0.3987.87` | `72.0.2`
+[cypress/browsers:node12.18.4-edge88](./node12.18.4-edge88) | `cypress/base:12.18.4` | 🚫 | 🚫 | `88.0.673.0 dev`
 [cypress/browsers:node13.6.0-chrome80-ff72](./node13.6.0-chrome80-ff72) | `cypress/base:13.6.0` | `80.0.3987.87` | `72.0.2`
 [cypress/browsers:node13.8.0-chrome81-ff75](./node13.8.0-chrome81-ff75) | `cypress/base:13.8.0` | `81.0.4044.113` | `75.0`
 [cypress/browsers:node14.7.0-chrome84](./node14.7.0-chrome84) | `cypress/base:14.7.0` | `84.0.4147.105` | 🚫

--- a/browsers/node12.18.4-edge88/Dockerfile
+++ b/browsers/node12.18.4-edge88/Dockerfile
@@ -1,0 +1,37 @@
+FROM cypress/base:12.18.4
+
+USER root
+
+RUN node --version
+RUN echo "force new Edge version here!"
+
+## Setup
+RUN curl https://packages.microsoft.com/keys/microsoft.asc | gpg --dearmor > microsoft.gpg
+RUN install -o root -g root -m 644 microsoft.gpg /etc/apt/trusted.gpg.d/
+RUN sh -c 'echo "deb [arch=amd64] https://packages.microsoft.com/repos/edge stable main" > /etc/apt/sources.list.d/microsoft-edge-dev.list'
+RUN rm microsoft.gpg
+## Install Edge
+RUN apt-get update
+RUN apt-get install -y microsoft-edge-dev
+# Add a link to the browser that allows Cypress to find it
+RUN ln -s /usr/bin/microsoft-edge /usr/bin/edge
+
+# Add zip utility - it comes in very handy
+RUN apt-get update && apt-get install -y zip
+
+# versions of local tools
+RUN echo  " node version:    $(node -v) \n" \
+  "npm version:     $(npm -v) \n" \
+  "yarn version:    $(yarn -v) \n" \
+  "Debian version:  $(cat /etc/debian_version) \n" \
+  "Edge version:    $(edge --version) \n" \
+  "git version:     $(git --version) \n" \
+  "whoami:          $(whoami) \n"
+
+# a few environment variables to make NPM installs easier
+# good colors for most applications
+ENV TERM xterm
+# avoid million NPM install messages
+ENV npm_config_loglevel warn
+# allow installing when the main user is root
+ENV npm_config_unsafe_perm true

--- a/browsers/node12.18.4-edge88/README.md
+++ b/browsers/node12.18.4-edge88/README.md
@@ -5,7 +5,7 @@ A complete image with all operating system dependencies for Cypress and [Microso
 [Dockerfile](Dockerfile)
 
 ```text
-node versions:   v12.18.4
+node version:    v12.18.4
 npm version:     6.14.8
 yarn version:    1.22.10
 Debian version:  10.5

--- a/browsers/node12.18.4-edge88/README.md
+++ b/browsers/node12.18.4-edge88/README.md
@@ -1,0 +1,18 @@
+# cypress/browsers:node12.18.4-edge88
+
+A complete image with all operating system dependencies for Cypress and [Microsoft Edge browser](https://www.microsoftedgeinsider.com/en-us/download/?platform=linux-deb).
+
+[Dockerfile](Dockerfile)
+
+```text
+node versions:   v12.18.4
+npm version:     6.14.8
+yarn version:    1.22.10
+Debian version:  10.5
+Edge version:    Microsoft Edge 88.0.673.0 dev
+git version:     git version 2.20.1
+whoami:          root
+```
+
+**Note:** this image uses the `root` user. You might want to switch to non-root
+user like `node` when running this container for security.

--- a/browsers/node12.18.4-edge88/build.sh
+++ b/browsers/node12.18.4-edge88/build.sh
@@ -1,0 +1,6 @@
+set e+x
+
+LOCAL_NAME=cypress/browsers:node12.18.4-edge88
+
+echo "Building $LOCAL_NAME"
+docker build -t $LOCAL_NAME .

--- a/circle.yml
+++ b/circle.yml
@@ -229,8 +229,6 @@ commands:
             RUN npm install --save-dev cypress
             RUN ./node_modules/.bin/cypress verify
             RUN echo '{}' > cypress.json
-
-            RUN ./node_modules/.bin/cypress run
             EOF
 
       - when:

--- a/circle.yml
+++ b/circle.yml
@@ -419,6 +419,10 @@ workflows:
           chromeVersion: "Google Chrome 83"
           firefoxVersion: "Mozilla Firefox 77"
       - build-browser-image:
+          name: "browsers node12.18.4-edge88"
+          dockerTag: "node12.18.4-edge88"
+          edgeVersion: "Microsoft Edge 88"
+      - build-browser-image:
           name: "browsers node13.8.0-chrome81-ff75"
           dockerTag: "node13.8.0-chrome81-ff75"
           chromeVersion: "Google Chrome 81"

--- a/circle.yml
+++ b/circle.yml
@@ -216,6 +216,47 @@ commands:
               no_output_timeout: '1m'
               command: docker run cypress/test ./node_modules/.bin/cypress run --browser edge
 
+      - run:
+          name: scaffold image << parameters.imageName >> using Kitchensink
+          no_output_timeout: '3m'
+          command: |
+            docker build -t cypress/test-kitchensink -\<<EOF
+            FROM << parameters.imageName >>
+            RUN echo "current user: $(whoami)"
+            ENV CI=1
+            ENV CYPRESS_INTERNAL_FORCE_SCAFFOLD=1
+            RUN npm init --yes
+            RUN npm install --save-dev cypress
+            RUN ./node_modules/.bin/cypress verify
+            RUN echo '{}' > cypress.json
+
+            RUN ./node_modules/.bin/cypress run
+            EOF
+
+      - when:
+          condition: << parameters.chromeVersion >>
+          steps:
+          - run:
+              name: Test << parameters.chromeVersion >>
+              no_output_timeout: '1m'
+              command: docker run cypress/test-kitchensink ./node_modules/.bin/cypress run --browser chrome
+
+      - when:
+          condition: << parameters.firefoxVersion >>
+          steps:
+          - run:
+              name: Test << parameters.firefoxVersion >>
+              no_output_timeout: '1m'
+              command: docker run cypress/test-kitchensink ./node_modules/.bin/cypress run --browser firefox
+
+      - when:
+          condition: << parameters.edgeVersion >>
+          steps:
+          - run:
+              name: Test << parameters.edgeVersion >>
+              no_output_timeout: '1m'
+              command: docker run cypress/test-kitchensink ./node_modules/.bin/cypress run --browser edge
+
   test-included-image:
     description: Testing Docker image with Cypress pre-installed
     parameters:

--- a/generate-config.js
+++ b/generate-config.js
@@ -226,6 +226,47 @@ commands:
               no_output_timeout: '1m'
               command: docker run cypress/test ./node_modules/.bin/cypress run --browser edge
 
+      - run:
+          name: scaffold image << parameters.imageName >> using Kitchensink
+          no_output_timeout: '3m'
+          command: |
+            docker build -t cypress/test-kitchensink -\\<<EOF
+            FROM << parameters.imageName >>
+            RUN echo "current user: $(whoami)"
+            ENV CI=1
+            ENV CYPRESS_INTERNAL_FORCE_SCAFFOLD=1
+            RUN npm init --yes
+            RUN npm install --save-dev cypress
+            RUN ./node_modules/.bin/cypress verify
+            RUN echo '{}' > cypress.json
+
+            RUN ./node_modules/.bin/cypress run
+            EOF
+
+      - when:
+          condition: << parameters.chromeVersion >>
+          steps:
+          - run:
+              name: Test << parameters.chromeVersion >>
+              no_output_timeout: '1m'
+              command: docker run cypress/test-kitchensink ./node_modules/.bin/cypress run --browser chrome
+
+      - when:
+          condition: << parameters.firefoxVersion >>
+          steps:
+          - run:
+              name: Test << parameters.firefoxVersion >>
+              no_output_timeout: '1m'
+              command: docker run cypress/test-kitchensink ./node_modules/.bin/cypress run --browser firefox
+
+      - when:
+          condition: << parameters.edgeVersion >>
+          steps:
+          - run:
+              name: Test << parameters.edgeVersion >>
+              no_output_timeout: '1m'
+              command: docker run cypress/test-kitchensink ./node_modules/.bin/cypress run --browser edge
+
   test-included-image:
     description: Testing Docker image with Cypress pre-installed
     parameters:

--- a/generate-config.js
+++ b/generate-config.js
@@ -239,8 +239,6 @@ commands:
             RUN npm install --save-dev cypress
             RUN ./node_modules/.bin/cypress verify
             RUN echo '{}' > cypress.json
-
-            RUN ./node_modules/.bin/cypress run
             EOF
 
       - when:


### PR DESCRIPTION
- [x] run full set of Kitchensink tests when testing a browser
- [x] add `cypress/browsers:node12.18.4-edge88` image
- [x] update the list of browser images

for #387 