### PR TITLE
Scaffold kitchensink when testing included

### DIFF
--- a/circle.yml
+++ b/circle.yml
@@ -266,11 +266,18 @@ commands:
         description: Cypress included docker image to test
     steps:
       - run:
+          name: Install node@v12
+          command: |
+            ./load-nvm.sh
+            nvm install v12
+
+      - run:
           name: Scaffold test project and testing
           no_output_timeout: '3m'
           env:
             CYPRESS_INTERNAL_FORCE_SCAFFOLD: 1
           command: |
+            ./load-nvm.sh
             node --version
             mkdir test
             cd test

--- a/circle.yml
+++ b/circle.yml
@@ -313,7 +313,7 @@ jobs:
   lint-markdown:
     executor:
       name: node/default
-      tag: '12'
+      tag: '12.18.4'
     steps:
       - checkout
       - node/install-packages

--- a/circle.yml
+++ b/circle.yml
@@ -4,7 +4,7 @@
 version: 2.1
 
 orbs:
-  node: circleci/node@1.1
+  node: circleci/node@4.1.0
 
 commands:
   halt-on-branch:
@@ -265,11 +265,8 @@ commands:
         type: string
         description: Cypress included docker image to test
     steps:
-      - run:
-          name: Install node@v12
-          command: |
-            ./load-nvm.sh
-            nvm install v12
+      - node/install:
+          lts: true
 
       - run:
           name: Scaffold test project and testing
@@ -277,7 +274,6 @@ commands:
           env:
             CYPRESS_INTERNAL_FORCE_SCAFFOLD: 1
           command: |
-            ./load-nvm.sh
             node --version
             mkdir test
             cd test
@@ -320,9 +316,7 @@ jobs:
       tag: '12'
     steps:
       - checkout
-      - node/with-cache:
-          steps:
-            - run: npm ci
+      - node/install-packages
       - run: npm run check:markdown
 
   build-base-image:

--- a/circle.yml
+++ b/circle.yml
@@ -266,14 +266,20 @@ commands:
         description: Cypress included docker image to test
     steps:
       - run:
-          name: New test project and testing
+          name: Scaffold test project and testing
           no_output_timeout: '3m'
+          env:
+            CYPRESS_INTERNAL_FORCE_SCAFFOLD: 1
           command: |
             node --version
             mkdir test
             cd test
-            echo "Initializing test project"
-            npx @bahmutov/cly init --cypress-version << parameters.cypressVersion >>
+            echo "*** Initializing the test project **"
+            npm init --yes
+            npm install --save-dev cypress
+            npx cypress verify
+            echo "*** scaffold and run all tests ***"
+            echo '{}' > cypress.json
 
             echo "Testing Electron browser"
             docker run -it -v $PWD:/e2e -w /e2e cypress/included:<< parameters.cypressVersion >>

--- a/circle.yml
+++ b/circle.yml
@@ -402,8 +402,9 @@ jobs:
         description: Image tag to build, should match Cypress version, like "3.8.1"
     steps:
       - checkout
-      - halt-if-docker-image-exists:
-          imageName: << parameters.dockerName >>:<< parameters.dockerTag >>
+      # temporary to test the included image
+      # - halt-if-docker-image-exists:
+      #    imageName: << parameters.dockerName >>:<< parameters.dockerTag >>
       - run:
           name: building Docker image << parameters.dockerName >>:<< parameters.dockerTag >>
           command: |
@@ -483,21 +484,6 @@ workflows:
 
   build-included-images:
     jobs:
-      - build-included-image:
-          name: "included 4.12.1"
-          dockerTag: "4.12.1"
-      - build-included-image:
-          name: "included 5.0.0"
-          dockerTag: "5.0.0"
-      - build-included-image:
-          name: "included 5.1.0"
-          dockerTag: "5.1.0"
-      - build-included-image:
-          name: "included 5.2.0"
-          dockerTag: "5.2.0"
-      - build-included-image:
-          name: "included 5.3.0"
-          dockerTag: "5.3.0"
       - build-included-image:
           name: "included 5.4.0"
           dockerTag: "5.4.0"

--- a/generate-config.js
+++ b/generate-config.js
@@ -276,11 +276,18 @@ commands:
         description: Cypress included docker image to test
     steps:
       - run:
+          name: Install node@v12
+          command: |
+            ./load-nvm.sh
+            nvm install v12
+
+      - run:
           name: Scaffold test project and testing
           no_output_timeout: '3m'
           env:
             CYPRESS_INTERNAL_FORCE_SCAFFOLD: 1
           command: |
+            ./load-nvm.sh
             node --version
             mkdir test
             cd test

--- a/generate-config.js
+++ b/generate-config.js
@@ -276,14 +276,20 @@ commands:
         description: Cypress included docker image to test
     steps:
       - run:
-          name: New test project and testing
+          name: Scaffold test project and testing
           no_output_timeout: '3m'
+          env:
+            CYPRESS_INTERNAL_FORCE_SCAFFOLD: 1
           command: |
             node --version
             mkdir test
             cd test
-            echo "Initializing test project"
-            npx @bahmutov/cly init --cypress-version << parameters.cypressVersion >>
+            echo "*** Initializing the test project **"
+            npm init --yes
+            npm install --save-dev cypress
+            npx cypress verify
+            echo "*** scaffold and run all tests ***"
+            echo '{}' > cypress.json
 
             echo "Testing Electron browser"
             docker run -it -v $PWD:/e2e -w /e2e cypress/included:<< parameters.cypressVersion >>

--- a/generate-config.js
+++ b/generate-config.js
@@ -412,8 +412,9 @@ jobs:
         description: Image tag to build, should match Cypress version, like "3.8.1"
     steps:
       - checkout
-      - halt-if-docker-image-exists:
-          imageName: << parameters.dockerName >>:<< parameters.dockerTag >>
+      # temporary to test the included image
+      # - halt-if-docker-image-exists:
+      #    imageName: << parameters.dockerName >>:<< parameters.dockerTag >>
       - run:
           name: building Docker image << parameters.dockerName >>:<< parameters.dockerTag >>
           command: |
@@ -636,7 +637,7 @@ const formBrowserWorkflow = (browserImages) => {
 const formIncludedWorkflow = (images) => {
   // skip images that have been built already
   const isSkipped = (tag) => {
-    return semver.lte(tag, '4.12.0')
+    return semver.lte(tag, '5.3.0')
   }
   const isIncluded = (imageAndTag) => !isSkipped(imageAndTag.tag)
 

--- a/generate-config.js
+++ b/generate-config.js
@@ -323,7 +323,7 @@ jobs:
   lint-markdown:
     executor:
       name: node/default
-      tag: '12'
+      tag: '12.18.4'
     steps:
       - checkout
       - node/install-packages

--- a/generate-config.js
+++ b/generate-config.js
@@ -14,7 +14,7 @@ const preamble = `
 version: 2.1
 
 orbs:
-  node: circleci/node@1.1
+  node: circleci/node@4.1.0
 
 commands:
   halt-on-branch:
@@ -275,11 +275,8 @@ commands:
         type: string
         description: Cypress included docker image to test
     steps:
-      - run:
-          name: Install node@v12
-          command: |
-            ./load-nvm.sh
-            nvm install v12
+      - node/install:
+          lts: true
 
       - run:
           name: Scaffold test project and testing
@@ -287,7 +284,6 @@ commands:
           env:
             CYPRESS_INTERNAL_FORCE_SCAFFOLD: 1
           command: |
-            ./load-nvm.sh
             node --version
             mkdir test
             cd test
@@ -330,9 +326,7 @@ jobs:
       tag: '12'
     steps:
       - checkout
-      - node/with-cache:
-          steps:
-            - run: npm ci
+      - node/install-packages
       - run: npm run check:markdown
 
   build-base-image:

--- a/load-nvm.sh
+++ b/load-nvm.sh
@@ -1,0 +1,6 @@
+# to test cypress/included images on CircleCI machines
+# we need a newer Node version (by default it is Node v6!)
+# this example taken from
+# https://discuss.circleci.com/t/switch-nodejs-version-on-machine-executor-solved/26675/2
+export NVM_DIR="/opt/circleci/.nvm"
+[ -s "$NVM_DIR/nvm.sh" ] && \. "$NVM_DIR/nvm.sh"

--- a/load-nvm.sh
+++ b/load-nvm.sh
@@ -1,6 +1,0 @@
-# to test cypress/included images on CircleCI machines
-# we need a newer Node version (by default it is Node v6!)
-# this example taken from
-# https://discuss.circleci.com/t/switch-nodejs-version-on-machine-executor-solved/26675/2
-export NVM_DIR="/opt/circleci/.nvm"
-[ -s "$NVM_DIR/nvm.sh" ] && \. "$NVM_DIR/nvm.sh"


### PR DESCRIPTION
- closes #387
- [x] tests the Docker image `cypress/included` using Kitchensink project
- [ ] restore the check against present image in `circle.yml`