### PR TITLE
Test full Kitchensink project using cypress/included image

### DIFF
--- a/circle.yml
+++ b/circle.yml
@@ -255,8 +255,8 @@ commands:
               no_output_timeout: '1m'
               command: docker run cypress/test-kitchensink ./node_modules/.bin/cypress run --browser edge
 
-  test-included-image:
-    description: Testing Docker image with Cypress pre-installed
+  test-included-image-versions:
+    description: Testing pre-installed versions
     parameters:
       cypressVersion:
         type: string
@@ -265,6 +265,14 @@ commands:
         type: string
         description: Cypress included docker image to test
     steps:
+      - run:
+          name: 'Print versions'
+          command: docker run -it --entrypoint cypress cypress/included:<< parameters.cypressVersion >> version
+
+      - run:
+          name: 'Print info'
+          command: docker run -it --entrypoint cypress cypress/included:<< parameters.cypressVersion >> info
+
       - run:
           name: 'Check Node version'
           command: |
@@ -280,9 +288,17 @@ commands:
               # https://github.com/cypress-io/cypress-docker-images/issues/411
               # exit 1
             fi
-      - run:
-          name: 'Print info'
-          command: docker run -it --entrypoint cypress cypress/included:<< parameters.cypressVersion >> info
+
+  test-included-image:
+    description: Testing Docker image with Cypress pre-installed
+    parameters:
+      cypressVersion:
+        type: string
+        description: Cypress version to test, like "4.0.0"
+      imageName:
+        type: string
+        description: Cypress included docker image to test
+    steps:
       - run:
           name: New test project and testing
           no_output_timeout: '3m'
@@ -414,17 +430,23 @@ jobs:
         description: Image tag to build, should match Cypress version, like "3.8.1"
     steps:
       - checkout
-      - halt-if-docker-image-exists:
-          imageName: << parameters.dockerName >>:<< parameters.dockerTag >>
+      # temporarily in this PR
+      # - halt-if-docker-image-exists:
+      #    imageName: << parameters.dockerName >>:<< parameters.dockerTag >>
       - run:
           name: building Docker image << parameters.dockerName >>:<< parameters.dockerTag >>
           command: |
             docker build -t << parameters.dockerName >>:<< parameters.dockerTag >> .
           working_directory: included/<< parameters.dockerTag >>
 
+      - test-included-image-versions:
+          cypressVersion: << parameters.dockerTag >>
+          imageName: << parameters.dockerName >>:<< parameters.dockerTag >>
+
       - test-included-image:
           cypressVersion: << parameters.dockerTag >>
           imageName: << parameters.dockerName >>:<< parameters.dockerTag >>
+
       - halt-on-branch
       - docker-push:
           imageName: << parameters.dockerName >>:<< parameters.dockerTag >>

--- a/circle.yml
+++ b/circle.yml
@@ -311,10 +311,10 @@ commands:
             echo "Initializing test project"
             npx @bahmutov/cly init --cypress-version << parameters.cypressVersion >>
 
-            echo "Testing Electron browser"
+            echo "Testing using Electron browser"
             docker run -it -v $PWD:/e2e -w /e2e cypress/included:<< parameters.cypressVersion >>
 
-            echo "Testing Chrome browser"
+            echo "Testing using Chrome browser"
             docker run -it -v $PWD:/e2e -w /e2e cypress/included:<< parameters.cypressVersion >> --browser chrome
           working_directory: /tmp
 
@@ -329,7 +329,7 @@ commands:
         description: Cypress included docker image to test
     steps:
       - run:
-          name: New test project and testing
+          name: Testing Kitchensink
           no_output_timeout: '3m'
           command: |
             node --version
@@ -339,10 +339,10 @@ commands:
             npm init -y
             echo '{}' > cypress.json
 
-            echo "Testing Electron browser"
+            echo "Testing using Electron browser"
             docker run -it -v $PWD:/e2e -w /e2e -e CYPRESS_INTERNAL_FORCE_SCAFFOLD=1 cypress/included:<< parameters.cypressVersion >>
 
-            echo "Testing Chrome browser"
+            echo "Testing using Chrome browser"
             docker run -it -v $PWD:/e2e -w /e2e -e CYPRESS_INTERNAL_FORCE_SCAFFOLD=1 cypress/included:<< parameters.cypressVersion >> --browser chrome
 
           working_directory: /tmp

--- a/circle.yml
+++ b/circle.yml
@@ -276,8 +276,8 @@ commands:
       - run:
           name: 'Check Node version'
           command: |
-            export NODE_VERSION=$(docker run -it --entrypoint node cypress/included:<< parameters.cypressVersion >> --version)
-            export CYPRESS_NODE_VERSION=$(docker run -it --entrypoint cypress cypress/included:<< parameters.cypressVersion >> version --component node)
+            export NODE_VERSION=$(docker run --entrypoint node cypress/included:<< parameters.cypressVersion >> --version)
+            export CYPRESS_NODE_VERSION=$(docker run --entrypoint cypress cypress/included:<< parameters.cypressVersion >> version --component node)
             echo "Included Node $NODE_VERSION"
             echo "Cypress includes Node $CYPRESS_NODE_VERSION"
             if [ "$NODE_VERSION" = "$CYPRESS_NODE_VERSION" ]; then

--- a/circle.yml
+++ b/circle.yml
@@ -316,6 +316,35 @@ commands:
             docker run -it -v $PWD:/e2e -w /e2e cypress/included:<< parameters.cypressVersion >> --browser chrome
           working_directory: /tmp
 
+  test-included-image-using-kitchensink:
+    description: Testing Cypress pre-installed using Kitchensink
+    parameters:
+      cypressVersion:
+        type: string
+        description: Cypress version to test, like "4.0.0"
+      imageName:
+        type: string
+        description: Cypress included docker image to test
+    steps:
+      - run:
+          name: New test project and testing
+          no_output_timeout: '3m'
+          command: |
+            node --version
+            mkdir test
+            cd test
+
+            npm init -y
+            echo '{}' > cypress.json
+
+            echo "Testing Electron browser"
+            docker run -it -v $PWD:/e2e -w /e2e -e CYPRESS_INTERNAL_FORCE_SCAFFOLD=1 cypress/included:<< parameters.cypressVersion >>
+
+            echo "Testing Chrome browser"
+            docker run -it -v $PWD:/e2e -w /e2e -e CYPRESS_INTERNAL_FORCE_SCAFFOLD=1 cypress/included:<< parameters.cypressVersion >> --browser chrome
+
+          working_directory: /tmp-kitchensink
+
   docker-push:
     description: Log in and push a given image to Docker hub
     parameters:
@@ -444,6 +473,10 @@ jobs:
           imageName: << parameters.dockerName >>:<< parameters.dockerTag >>
 
       - test-included-image:
+          cypressVersion: << parameters.dockerTag >>
+          imageName: << parameters.dockerName >>:<< parameters.dockerTag >>
+
+      - test-included-image-using-kitchensink:
           cypressVersion: << parameters.dockerTag >>
           imageName: << parameters.dockerName >>:<< parameters.dockerTag >>
 

--- a/circle.yml
+++ b/circle.yml
@@ -331,8 +331,8 @@ commands:
           no_output_timeout: '3m'
           command: |
             node --version
-            mkdir test
-            cd test
+            mkdir test-kitchensink
+            cd test-kitchensink
 
             npm init -y
             echo '{}' > cypress.json
@@ -343,7 +343,7 @@ commands:
             echo "Testing Chrome browser"
             docker run -it -v $PWD:/e2e -w /e2e -e CYPRESS_INTERNAL_FORCE_SCAFFOLD=1 cypress/included:<< parameters.cypressVersion >> --browser chrome
 
-          working_directory: /tmp-kitchensink
+          working_directory: /tmp
 
   docker-push:
     description: Log in and push a given image to Docker hub

--- a/circle.yml
+++ b/circle.yml
@@ -280,7 +280,9 @@ commands:
             export CYPRESS_NODE_VERSION=$(docker run --entrypoint cypress cypress/included:<< parameters.cypressVersion >> version --component node)
             echo "Included Node $NODE_VERSION"
             echo "Cypress includes Node $CYPRESS_NODE_VERSION"
-            if [ "$NODE_VERSION" = "$CYPRESS_NODE_VERSION" ]; then
+            # "node --version" returns something like "v12.1.2"
+            # and "cypres version ..." returns just "12.1.2"
+            if [ "$NODE_VERSION" = "v$CYPRESS_NODE_VERSION" ]; then
               echo "Node versions match"
             else
               echo "Node version mismatch 🔥"

--- a/circle.yml
+++ b/circle.yml
@@ -461,9 +461,8 @@ jobs:
         description: Image tag to build, should match Cypress version, like "3.8.1"
     steps:
       - checkout
-      # temporarily in this PR
-      # - halt-if-docker-image-exists:
-      #    imageName: << parameters.dockerName >>:<< parameters.dockerTag >>
+      - halt-if-docker-image-exists:
+          imageName: << parameters.dockerName >>:<< parameters.dockerTag >>
       - run:
           name: building Docker image << parameters.dockerName >>:<< parameters.dockerTag >>
           command: |

--- a/generate-config.js
+++ b/generate-config.js
@@ -341,8 +341,8 @@ commands:
           no_output_timeout: '3m'
           command: |
             node --version
-            mkdir test
-            cd test
+            mkdir test-kitchensink
+            cd test-kitchensink
 
             npm init -y
             echo '{}' > cypress.json
@@ -353,7 +353,7 @@ commands:
             echo "Testing Chrome browser"
             docker run -it -v $PWD:/e2e -w /e2e -e CYPRESS_INTERNAL_FORCE_SCAFFOLD=1 cypress/included:<< parameters.cypressVersion >> --browser chrome
 
-          working_directory: /tmp-kitchensink
+          working_directory: /tmp
 
   docker-push:
     description: Log in and push a given image to Docker hub

--- a/generate-config.js
+++ b/generate-config.js
@@ -321,10 +321,10 @@ commands:
             echo "Initializing test project"
             npx @bahmutov/cly init --cypress-version << parameters.cypressVersion >>
 
-            echo "Testing Electron browser"
+            echo "Testing using Electron browser"
             docker run -it -v $PWD:/e2e -w /e2e cypress/included:<< parameters.cypressVersion >>
 
-            echo "Testing Chrome browser"
+            echo "Testing using Chrome browser"
             docker run -it -v $PWD:/e2e -w /e2e cypress/included:<< parameters.cypressVersion >> --browser chrome
           working_directory: /tmp
 
@@ -339,7 +339,7 @@ commands:
         description: Cypress included docker image to test
     steps:
       - run:
-          name: New test project and testing
+          name: Testing Kitchensink
           no_output_timeout: '3m'
           command: |
             node --version
@@ -349,10 +349,10 @@ commands:
             npm init -y
             echo '{}' > cypress.json
 
-            echo "Testing Electron browser"
+            echo "Testing using Electron browser"
             docker run -it -v $PWD:/e2e -w /e2e -e CYPRESS_INTERNAL_FORCE_SCAFFOLD=1 cypress/included:<< parameters.cypressVersion >>
 
-            echo "Testing Chrome browser"
+            echo "Testing using Chrome browser"
             docker run -it -v $PWD:/e2e -w /e2e -e CYPRESS_INTERNAL_FORCE_SCAFFOLD=1 cypress/included:<< parameters.cypressVersion >> --browser chrome
 
           working_directory: /tmp

--- a/generate-config.js
+++ b/generate-config.js
@@ -290,7 +290,9 @@ commands:
             export CYPRESS_NODE_VERSION=$(docker run --entrypoint cypress cypress/included:<< parameters.cypressVersion >> version --component node)
             echo "Included Node $NODE_VERSION"
             echo "Cypress includes Node $CYPRESS_NODE_VERSION"
-            if [ "$NODE_VERSION" = "$CYPRESS_NODE_VERSION" ]; then
+            # "node --version" returns something like "v12.1.2"
+            # and "cypres version ..." returns just "12.1.2"
+            if [ "$NODE_VERSION" = "v$CYPRESS_NODE_VERSION" ]; then
               echo "Node versions match"
             else
               echo "Node version mismatch 🔥"

--- a/generate-config.js
+++ b/generate-config.js
@@ -471,9 +471,8 @@ jobs:
         description: Image tag to build, should match Cypress version, like "3.8.1"
     steps:
       - checkout
-      # temporarily in this PR
-      # - halt-if-docker-image-exists:
-      #    imageName: << parameters.dockerName >>:<< parameters.dockerTag >>
+      - halt-if-docker-image-exists:
+          imageName: << parameters.dockerName >>:<< parameters.dockerTag >>
       - run:
           name: building Docker image << parameters.dockerName >>:<< parameters.dockerTag >>
           command: |

--- a/generate-config.js
+++ b/generate-config.js
@@ -326,6 +326,35 @@ commands:
             docker run -it -v $PWD:/e2e -w /e2e cypress/included:<< parameters.cypressVersion >> --browser chrome
           working_directory: /tmp
 
+  test-included-image-using-kitchensink:
+    description: Testing Cypress pre-installed using Kitchensink
+    parameters:
+      cypressVersion:
+        type: string
+        description: Cypress version to test, like "4.0.0"
+      imageName:
+        type: string
+        description: Cypress included docker image to test
+    steps:
+      - run:
+          name: New test project and testing
+          no_output_timeout: '3m'
+          command: |
+            node --version
+            mkdir test
+            cd test
+
+            npm init -y
+            echo '{}' > cypress.json
+
+            echo "Testing Electron browser"
+            docker run -it -v $PWD:/e2e -w /e2e -e CYPRESS_INTERNAL_FORCE_SCAFFOLD=1 cypress/included:<< parameters.cypressVersion >>
+
+            echo "Testing Chrome browser"
+            docker run -it -v $PWD:/e2e -w /e2e -e CYPRESS_INTERNAL_FORCE_SCAFFOLD=1 cypress/included:<< parameters.cypressVersion >> --browser chrome
+
+          working_directory: /tmp-kitchensink
+
   docker-push:
     description: Log in and push a given image to Docker hub
     parameters:
@@ -454,6 +483,10 @@ jobs:
           imageName: << parameters.dockerName >>:<< parameters.dockerTag >>
 
       - test-included-image:
+          cypressVersion: << parameters.dockerTag >>
+          imageName: << parameters.dockerName >>:<< parameters.dockerTag >>
+
+      - test-included-image-using-kitchensink:
           cypressVersion: << parameters.dockerTag >>
           imageName: << parameters.dockerName >>:<< parameters.dockerTag >>
 

--- a/generate-config.js
+++ b/generate-config.js
@@ -265,8 +265,8 @@ commands:
               no_output_timeout: '1m'
               command: docker run cypress/test-kitchensink ./node_modules/.bin/cypress run --browser edge
 
-  test-included-image:
-    description: Testing Docker image with Cypress pre-installed
+  test-included-image-versions:
+    description: Testing pre-installed versions
     parameters:
       cypressVersion:
         type: string
@@ -275,6 +275,14 @@ commands:
         type: string
         description: Cypress included docker image to test
     steps:
+      - run:
+          name: 'Print versions'
+          command: docker run -it --entrypoint cypress cypress/included:<< parameters.cypressVersion >> version
+
+      - run:
+          name: 'Print info'
+          command: docker run -it --entrypoint cypress cypress/included:<< parameters.cypressVersion >> info
+
       - run:
           name: 'Check Node version'
           command: |
@@ -290,9 +298,17 @@ commands:
               # https://github.com/cypress-io/cypress-docker-images/issues/411
               # exit 1
             fi
-      - run:
-          name: 'Print info'
-          command: docker run -it --entrypoint cypress cypress/included:<< parameters.cypressVersion >> info
+
+  test-included-image:
+    description: Testing Docker image with Cypress pre-installed
+    parameters:
+      cypressVersion:
+        type: string
+        description: Cypress version to test, like "4.0.0"
+      imageName:
+        type: string
+        description: Cypress included docker image to test
+    steps:
       - run:
           name: New test project and testing
           no_output_timeout: '3m'
@@ -424,17 +440,23 @@ jobs:
         description: Image tag to build, should match Cypress version, like "3.8.1"
     steps:
       - checkout
-      - halt-if-docker-image-exists:
-          imageName: << parameters.dockerName >>:<< parameters.dockerTag >>
+      # temporarily in this PR
+      # - halt-if-docker-image-exists:
+      #    imageName: << parameters.dockerName >>:<< parameters.dockerTag >>
       - run:
           name: building Docker image << parameters.dockerName >>:<< parameters.dockerTag >>
           command: |
             docker build -t << parameters.dockerName >>:<< parameters.dockerTag >> .
           working_directory: included/<< parameters.dockerTag >>
 
+      - test-included-image-versions:
+          cypressVersion: << parameters.dockerTag >>
+          imageName: << parameters.dockerName >>:<< parameters.dockerTag >>
+
       - test-included-image:
           cypressVersion: << parameters.dockerTag >>
           imageName: << parameters.dockerName >>:<< parameters.dockerTag >>
+
       - halt-on-branch
       - docker-push:
           imageName: << parameters.dockerName >>:<< parameters.dockerTag >>

--- a/generate-config.js
+++ b/generate-config.js
@@ -286,8 +286,8 @@ commands:
       - run:
           name: 'Check Node version'
           command: |
-            export NODE_VERSION=$(docker run -it --entrypoint node cypress/included:<< parameters.cypressVersion >> --version)
-            export CYPRESS_NODE_VERSION=$(docker run -it --entrypoint cypress cypress/included:<< parameters.cypressVersion >> version --component node)
+            export NODE_VERSION=$(docker run --entrypoint node cypress/included:<< parameters.cypressVersion >> --version)
+            export CYPRESS_NODE_VERSION=$(docker run --entrypoint cypress cypress/included:<< parameters.cypressVersion >> version --component node)
             echo "Included Node $NODE_VERSION"
             echo "Cypress includes Node $CYPRESS_NODE_VERSION"
             if [ "$NODE_VERSION" = "$CYPRESS_NODE_VERSION" ]; then


### PR DESCRIPTION
- closes https://github.com/cypress-io/cypress-docker-images/issues/387
- closes #411 
- separate node version check command
