### PR TITLE
Remove npm@latest install in generate-base-image script

### DIFF
--- a/generate-base-image.js
+++ b/generate-base-image.js
@@ -58,7 +58,6 @@ RUN apt-get update && \\
   # clean up
   && rm -rf /var/lib/apt/lists/*
 
-RUN npm install -g npm@latest
 RUN npm --version
 
 RUN npm install -g yarn@latest --force

--- a/generate-included-image.js
+++ b/generate-included-image.js
@@ -76,9 +76,10 @@ RUN cypress version
 RUN ls -la /root
 RUN chmod 755 /root
 
-# always grab the latest NPM and Yarn
+# always grab the latest Yarn
 # otherwise the base image might have old versions
-RUN npm i -g yarn@latest npm@latest
+# NPM does not need to be installed as it is already included with Node.
+RUN npm i -g yarn@latest
 
 # should print Cypress version
 # plus Electron and bundled Node versions


### PR DESCRIPTION
As experienced in #436, Node and NPM versions can be out of sync and it may seem odd, while there is already a version of NPM coming with Node, to force a version of Node while upgrading to a newer version of NPM.

This PR therefore removes the `RUN install npm@latest` script from `generate-base-image.js`