### PR TITLE
Update example `included-as-non-root-mapped` (fixes #287)

### DIFF
--- a/examples/included-as-non-root-mapped/Dockerfile
+++ b/examples/included-as-non-root-mapped/Dockerfile
@@ -1,4 +1,4 @@
-FROM cypress/included:3.8.0
+FROM cypress/included:5.6.0
 
 # "root"
 RUN whoami

--- a/examples/included-as-non-root-mapped/Dockerfile
+++ b/examples/included-as-non-root-mapped/Dockerfile
@@ -22,6 +22,8 @@ RUN install -d -m 0755 -o appuser -g appuser /home/appuser
 
 # move test runner binary folder to the non-root's user home directory
 RUN mv /root/.cache /home/appuser/.cache
+# make sure cypress looks in the right place
+ENV CYPRESS_CACHE_FOLDER=/home/appuser/.cache/Cypress
 
 USER appuser
 # show user effective id and group - it should be non-zero


### PR DESCRIPTION
This implements the fix proposed by @danieleades here: https://github.com/cypress-io/cypress-docker-images/issues/287#issuecomment-717158878