### PR TITLE
Add apt upgrade to generated cypress/included-image (#446)

### DIFF
--- a/generate-included-image.js
+++ b/generate-included-image.js
@@ -39,6 +39,9 @@ const Dockerfile = `
 #
 FROM ${baseImageTag}
 
+# Update the dependencies to get the latest and greatest (and safest!) packages. 
+RUN apt update && apt upgrade -y
+
 # avoid too many progress messages
 # https://github.com/cypress-io/cypress/issues/1243
 ENV CI=1


### PR DESCRIPTION
Updates the packages in the newly generated `cypress/included` images during build to avoid security vulnerabilities. 

Fixes https://github.com/cypress-io/cypress-docker-images/issues/446