### PR TITLE
add cypress/browsers:node14.16.0-chrome89-ff78

### DIFF
--- a/browsers/node14.16.0-chrome89-ff78/Dockerfile
+++ b/browsers/node14.16.0-chrome89-ff78/Dockerfile
@@ -1,0 +1,53 @@
+FROM cypress/base:14.16.0
+
+USER root
+
+RUN node --version
+
+# Chrome dependencies
+RUN apt-get update
+RUN apt-get install -y fonts-liberation libappindicator3-1 xdg-utils
+
+# install Chrome browser
+ENV CHROME_VERSION 89.0.4389.82
+RUN wget -O /usr/src/google-chrome-stable_current_amd64.deb "http://dl.google.com/linux/chrome/deb/pool/main/g/google-chrome-stable/google-chrome-stable_${CHROME_VERSION}-1_amd64.deb" && \
+  dpkg -i /usr/src/google-chrome-stable_current_amd64.deb ; \
+  apt-get install -f -y && \
+  rm -f /usr/src/google-chrome-stable_current_amd64.deb
+RUN google-chrome --version
+
+# "fake" dbus address to prevent errors
+# https://github.com/SeleniumHQ/docker-selenium/issues/87
+ENV DBUS_SESSION_BUS_ADDRESS=/dev/null
+
+# Add zip utility - it comes in very handy
+RUN apt-get update && apt-get install -y zip
+
+# add codecs needed for video playback in firefox
+# https://github.com/cypress-io/cypress-docker-images/issues/150
+RUN apt-get install mplayer -y
+
+# install Firefox browser
+ARG FIREFOX_VERSION=78.8.0esr
+RUN wget --no-verbose -O /tmp/firefox.tar.bz2 https://download-installer.cdn.mozilla.net/pub/firefox/releases/$FIREFOX_VERSION/linux-x86_64/en-US/firefox-$FIREFOX_VERSION.tar.bz2 \
+  && tar -C /opt -xjf /tmp/firefox.tar.bz2 \
+  && rm /tmp/firefox.tar.bz2 \
+  && ln -fs /opt/firefox/firefox /usr/bin/firefox
+
+# versions of local tools
+RUN echo  " node version:    $(node -v) \n" \
+  "npm version:     $(npm -v) \n" \
+  "yarn version:    $(yarn -v) \n" \
+  "debian version:  $(cat /etc/debian_version) \n" \
+  "Chrome version:  $(google-chrome --version) \n" \
+  "Firefox version: $(firefox --version) \n" \
+  "git version:     $(git --version) \n" \
+  "whoami:          $(whoami) \n"
+
+# a few environment variables to make NPM installs easier
+# good colors for most applications
+ENV TERM xterm
+# avoid million NPM install messages
+ENV npm_config_loglevel warn
+# allow installing when the main user is root
+ENV npm_config_unsafe_perm true

--- a/browsers/node14.16.0-chrome89-ff78/README.md
+++ b/browsers/node14.16.0-chrome89-ff78/README.md
@@ -1,0 +1,20 @@
+# cypress/browsers:node14.16.0-chrome89-ff78
+
+A complete image with all operating system dependencies for Cypress, Chrome
+89 and Firefox 78 browsers.
+
+[Dockerfile](Dockerfile)
+
+```text
+node version:    v14.16.0
+npm version:     6.14.11
+yarn version:    1.22.10
+debian version:  10.8
+Chrome version:  Google Chrome 89.0.4389.82
+Firefox version: Mozilla Firefox 78.8.0esr
+git version:     git version 2.20.1
+whoami:          root
+```
+
+**Note:** this image uses the `root` user. You might want to switch to non-root
+user like `node` when running this container for security.

--- a/browsers/node14.16.0-chrome89-ff78/build.sh
+++ b/browsers/node14.16.0-chrome89-ff78/build.sh
@@ -1,0 +1,6 @@
+set e+x
+
+LOCAL_NAME=cypress/browsers:node14.16.0-chrome89-ff78
+
+echo "Building $LOCAL_NAME"
+docker build -t $LOCAL_NAME .


### PR DESCRIPTION
Chrome 89 is now in the stable channel, and FireFox 78 is the current
extended support release.

Signed-off-by: Kent R. Spillner <kspillner@acm.org>