### PR TITLE
Add missing line continuation to base Dockerfile generator

### DIFF
--- a/generate-base-image.js
+++ b/generate-base-image.js
@@ -59,7 +59,7 @@ RUN apt-get update && \\
   ttf-wqy-microhei \\
   xfonts-wqy \\
   # clean up
-  && rm -rf /var/lib/apt/lists/*
+  && rm -rf /var/lib/apt/lists/* \\
   && apt-get clean
 
 RUN npm --version


### PR DESCRIPTION
#456 added the call to apt clean, but unfortunately missed a line continuation. This leads to invalid syntax in the generated Dockerfile.
No base image Dockerfile has been added to the repository since that change, so no changes to existing Dockerfiles are necessary.