### PR TITLE
Add cypress/browsers:node14.17.0-chrome88-ff89

### DIFF
--- a/browsers/README.md
+++ b/browsers/README.md
@@ -28,6 +28,7 @@ Name + Tag | Base image | Chrome | Firefox | Edge
 [cypress/browsers:node12.14.1-chrome85-ff81](./node12.14.1-chrome85-ff81) | `cypress/base:12.14.1` | `85.0.4183.121` | `81.0`
 [cypress/browsers:node14.10.1-edge88](./node14.10.1-edge88) | `cypress/base:14.10.1` | 🚫 | 🚫 | `88.0.673.0 dev`
 [cypress/browsers:node14.15.0-chrome86-ff82](./node14.15.0-chrome86-ff82) | `cypress/base:14.15.0` | `86.0.4240.193` | `82.0.3`
+[cypress/browsers:node14.17.0-chrome88-ff89](./node14.17.0-chrome88-ff89) | `cypress/base:14.17.0` | `88.0.4324.0` | `89.0.2`
 [cypress/browsers:node14.16.0-chrome89-ff77](./node14.16.0-chrome89-ff77) | `cypress/base:14.16.0` | `89.0.4389.72` | `77.0`
 [cypress/browsers:node14.16.0-chrome89-ff86](./node14.16.0-chrome89-ff86) | `cypress/base:14.16.0` | `89.0.4389.72` | `86.0.1`
 [cypress/browsers:node14.17.0-chrome91-ff89](./node14.17.0-chrome91-ff89) | `cypress/base:14.17.0` | `91.0.4472.114` | `89.0.2`

--- a/browsers/README.md
+++ b/browsers/README.md
@@ -28,7 +28,7 @@ Name + Tag | Base image | Chrome | Firefox | Edge
 [cypress/browsers:node12.14.1-chrome85-ff81](./node12.14.1-chrome85-ff81) | `cypress/base:12.14.1` | `85.0.4183.121` | `81.0`
 [cypress/browsers:node14.10.1-edge88](./node14.10.1-edge88) | `cypress/base:14.10.1` | 🚫 | 🚫 | `88.0.673.0 dev`
 [cypress/browsers:node14.15.0-chrome86-ff82](./node14.15.0-chrome86-ff82) | `cypress/base:14.15.0` | `86.0.4240.193` | `82.0.3`
-[cypress/browsers:node14.17.0-chrome88-ff89](./node14.17.0-chrome88-ff89) | `cypress/base:14.17.0` | `88.0.4324.0` | `89.0.2`
+[cypress/browsers:node14.17.0-chrome88-ff89](./node14.17.0-chrome88-ff89) | `cypress/base:14.17.0` | `88.0.4324.96` | `89.0.2`
 [cypress/browsers:node14.16.0-chrome89-ff77](./node14.16.0-chrome89-ff77) | `cypress/base:14.16.0` | `89.0.4389.72` | `77.0`
 [cypress/browsers:node14.16.0-chrome89-ff86](./node14.16.0-chrome89-ff86) | `cypress/base:14.16.0` | `89.0.4389.72` | `86.0.1`
 [cypress/browsers:node14.17.0-chrome91-ff89](./node14.17.0-chrome91-ff89) | `cypress/base:14.17.0` | `91.0.4472.114` | `89.0.2`

--- a/browsers/node14.17.0-chrome88-ff89/Dockerfile
+++ b/browsers/node14.17.0-chrome88-ff89/Dockerfile
@@ -1,0 +1,53 @@
+FROM cypress/base:14.17.0
+
+USER root
+
+RUN node --version
+
+# Chrome dependencies
+RUN apt-get update
+RUN apt-get install -y fonts-liberation libappindicator3-1 xdg-utils
+
+# install Chrome browser
+ENV CHROME_VERSION 88.0.4324.0
+RUN wget -O /usr/src/google-chrome-stable_current_amd64.deb "http://dl.google.com/linux/chrome/deb/pool/main/g/google-chrome-stable/google-chrome-stable_${CHROME_VERSION}-1_amd64.deb" && \
+  dpkg -i /usr/src/google-chrome-stable_current_amd64.deb ; \
+  apt-get install -f -y && \
+  rm -f /usr/src/google-chrome-stable_current_amd64.deb
+RUN google-chrome --version
+
+# "fake" dbus address to prevent errors
+# https://github.com/SeleniumHQ/docker-selenium/issues/87
+ENV DBUS_SESSION_BUS_ADDRESS=/dev/null
+
+# Add zip utility - it comes in very handy
+RUN apt-get update && apt-get install -y zip
+
+# add codecs needed for video playback in firefox
+# https://github.com/cypress-io/cypress-docker-images/issues/150
+RUN apt-get install mplayer -y
+
+# install Firefox browser
+ARG FIREFOX_VERSION=89.0.2
+RUN wget --no-verbose -O /tmp/firefox.tar.bz2 https://download-installer.cdn.mozilla.net/pub/firefox/releases/$FIREFOX_VERSION/linux-x86_64/en-US/firefox-$FIREFOX_VERSION.tar.bz2 \
+  && tar -C /opt -xjf /tmp/firefox.tar.bz2 \
+  && rm /tmp/firefox.tar.bz2 \
+  && ln -fs /opt/firefox/firefox /usr/bin/firefox
+
+# versions of local tools
+RUN echo  " node version:    $(node -v) \n" \
+  "npm version:     $(npm -v) \n" \
+  "yarn version:    $(yarn -v) \n" \
+  "debian version:  $(cat /etc/debian_version) \n" \
+  "Chrome version:  $(google-chrome --version) \n" \
+  "Firefox version: $(firefox --version) \n" \
+  "git version:     $(git --version) \n" \
+  "whoami:          $(whoami) \n"
+
+# a few environment variables to make NPM installs easier
+# good colors for most applications
+ENV TERM xterm
+# avoid million NPM install messages
+ENV npm_config_loglevel warn
+# allow installing when the main user is root
+ENV npm_config_unsafe_perm true

--- a/browsers/node14.17.0-chrome88-ff89/Dockerfile
+++ b/browsers/node14.17.0-chrome88-ff89/Dockerfile
@@ -9,7 +9,7 @@ RUN apt-get update
 RUN apt-get install -y fonts-liberation libappindicator3-1 xdg-utils
 
 # install Chrome browser
-ENV CHROME_VERSION 88.0.4324.0
+ENV CHROME_VERSION 88.0.4324.96
 RUN wget -O /usr/src/google-chrome-stable_current_amd64.deb "http://dl.google.com/linux/chrome/deb/pool/main/g/google-chrome-stable/google-chrome-stable_${CHROME_VERSION}-1_amd64.deb" && \
   dpkg -i /usr/src/google-chrome-stable_current_amd64.deb ; \
   apt-get install -f -y && \

--- a/browsers/node14.17.0-chrome88-ff89/README.md
+++ b/browsers/node14.17.0-chrome88-ff89/README.md
@@ -1,4 +1,4 @@
-# cypress/browsers:node14.17.0-chrome91-ff89
+# cypress/browsers:node14.17.0-chrome88-ff89
 
 A complete image with all operating system dependencies for Cypress, Chrome
 88 and Firefox 89 browsers.
@@ -10,7 +10,7 @@ node version:    v14.17.0
 npm version:     6.14.13
 yarn version:    1.22.10
 debian version:  10.9
-Chrome version:  Google Chrome 88.0.4324.0  
+Chrome version:  Google Chrome 88.0.4324.96 
 Firefox version: Mozilla Firefox 89.0.2
 git version:     git version 2.20.1
 whoami:          root

--- a/browsers/node14.17.0-chrome88-ff89/README.md
+++ b/browsers/node14.17.0-chrome88-ff89/README.md
@@ -1,0 +1,20 @@
+# cypress/browsers:node14.17.0-chrome91-ff89
+
+A complete image with all operating system dependencies for Cypress, Chrome
+88 and Firefox 89 browsers.
+
+[Dockerfile](Dockerfile)
+
+```text
+node version:    v14.17.0
+npm version:     6.14.13
+yarn version:    1.22.10
+debian version:  10.9
+Chrome version:  Google Chrome 88.0.4324.0  
+Firefox version: Mozilla Firefox 89.0.2
+git version:     git version 2.20.1
+whoami:          root
+```
+
+**Note:** this image uses the `root` user. You might want to switch to non-root
+user like `node` when running this container for security.

--- a/browsers/node14.17.0-chrome88-ff89/build.sh
+++ b/browsers/node14.17.0-chrome88-ff89/build.sh
@@ -1,0 +1,6 @@
+set e+x
+
+LOCAL_NAME=cypress/browsers:node14.17.0-chrome88-ff89
+
+echo "Building $LOCAL_NAME"
+docker build --no-cache -t $LOCAL_NAME .

--- a/buildspec.yml
+++ b/buildspec.yml
@@ -267,6 +267,16 @@ batch:
           IMAGE_REPO_NAME: "cypress/browsers"
           IMAGE_DIR: "browsers"
           IMAGE_TAG: "node14.17.0-chrome91-ff89"
+    - identifier: browsersnode14170Chrome88Ff89
+      env:
+        image: aws/codebuild/standard:5.0
+        type: LINUX_CONTAINER
+        privileged-mode: true
+        compute-type: BUILD_GENERAL1_MEDIUM
+        variables:
+          IMAGE_REPO_NAME: "cypress/browsers"
+          IMAGE_DIR: "browsers"
+          IMAGE_TAG: "node14.17.0-chrome88-ff89"
     - identifier: browsersnode1470Chrome84
       env:
         image: aws/codebuild/standard:5.0

--- a/circle.yml
+++ b/circle.yml
@@ -602,6 +602,11 @@ workflows:
           chromeVersion: "Google Chrome 91"
           firefoxVersion: "Mozilla Firefox 89"
       - build-browser-image:
+          name: "browsers node14.17.0-chrome88-ff89"
+          dockerTag: "node14.17.0-chrome88-ff89"
+          chromeVersion: "Google Chrome 88"
+          firefoxVersion: "Mozilla Firefox 89"
+      - build-browser-image:
           name: "browsers node14.7.0-chrome84"
           dockerTag: "node14.7.0-chrome84"
           chromeVersion: "Google Chrome 84"


### PR DESCRIPTION
Need to publish  an image with  Chrome 88 to test performance before Chrome version 89.0.4330.0 which introduced video frame capture changes.

Need this for my video tests.