### PR TITLE
fix: Update generated ENV to account for syntax change

### DIFF
--- a/scripts/generate-base-image.js
+++ b/scripts/generate-base-image.js
@@ -75,9 +75,9 @@ RUN apt-get update && \\
 
 # a few environment variables to make NPM installs easier
 # good colors for most applications
-ENV TERM=xterm \\
+ENV TERM=xterm
 # avoid million NPM install messages
-ENV npm_config_loglevel=warn \\
+ENV npm_config_loglevel=warn
 # allow installing when the main user is root
 ENV npm_config_unsafe_perm=true
 

--- a/scripts/generate-browser-image.js
+++ b/scripts/generate-browser-image.js
@@ -116,11 +116,11 @@ RUN echo  " node version:    $(node -v) \\n" \\
 
 # a few environment variables to make NPM installs easier
 # good colors for most applications
-ENV TERM xterm \\
+ENV TERM=xterm
 # avoid million NPM install messages
-ENV npm_config_loglevel warn \\
+ENV npm_config_loglevel=warn
 # allow installing when the main user is root
-ENV npm_config_unsafe_perm true
+ENV npm_config_unsafe_perm=true
 `
 
 const dockerFilename = path.join(outputFolder, "Dockerfile")


### PR DESCRIPTION
With the changes made in #619, the trailing backslashes are not necessary for our ENV declarations.

See recent failure [here](https://app.circleci.com/pipelines/github/cypress-io/cypress-docker-images/817/workflows/06095d6b-47da-4139-ad07-12e6d7f013d7/jobs/37096).

> Error response from daemon: failed to parse Dockerfile: Syntax error - can't find = in "ENV". Must be of the form: name=value

I generated new base/browser packages and built the images locally to ensure they built correctly with these PR changes. The browsers script actually worked okay, but I updated to be consistent with the other.