### PR TITLE
Fix env variables, error `unknown terminal "xterm npm_config_loglevel warn npm_config_unsafe_perm true"`

### DIFF
--- a/browsers/node14.17.6-chrome100-ff98/Dockerfile
+++ b/browsers/node14.17.6-chrome100-ff98/Dockerfile
@@ -69,8 +69,8 @@ RUN echo  " node version:    $(node -v) \n" \
 
 # a few environment variables to make NPM installs easier
 # good colors for most applications
-ENV TERM xterm \
+ENV TERM xterm
 # avoid million NPM install messages
-ENV npm_config_loglevel warn \
+ENV npm_config_loglevel warn
 # allow installing when the main user is root
 ENV npm_config_unsafe_perm true

--- a/browsers/node16.14.0-slim-chrome99-ff97/Dockerfile
+++ b/browsers/node16.14.0-slim-chrome99-ff97/Dockerfile
@@ -68,8 +68,8 @@ RUN echo  " node version:    $(node -v) \n" \
 
 # a few environment variables to make NPM installs easier
 # good colors for most applications
-ENV TERM xterm \
-  # avoid million NPM install messages
-  npm_config_loglevel warn \
-  # allow installing when the main user is root
-  npm_config_unsafe_perm true
+ENV TERM xterm
+# avoid million NPM install messages
+ENV npm_config_loglevel warn
+# allow installing when the main user is root
+ENV npm_config_unsafe_perm true


### PR DESCRIPTION
In couple of images, the env variables definition is wrong, as it's creating one ENV variable instead of 3

When running `printenv` in the container, it shows:

`TERM=xterm   npm_config_loglevel warn   npm_config_unsafe_perm true` in one line

So this causes error: `tput: unknown terminal "xterm   npm_config_loglevel warn   npm_config_unsafe_perm true"`