### PR TITLE
fix: updates from manual `arm64` retagging

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -134,3 +134,60 @@ In CI, the images are built and tested in real `arm64` and `x64` architectures. 
 It would be nice to re-publish the Docker Hub images verbatim to ECR instead of building twice, but more work needs to be done in this area - see the `push-images` step in `circle.yml` for details.
 
 A current limitation is that no `arm64` images have browser binaries - see https://github.com/cypress-io/cypress-docker-images/issues/695 for details. [`global-profile.sh`](./scripts/for-images/global-profile.sh) is placed in `/etc/bash.bashrc`, so Arm Docker users will see a warning about this limitation.
+
+### Updating images to add `linux/arm64`
+
+Using the `docker` CLI, you can build the `linux/arm64` image of an image, glue the existing `linux/amd64` image to it to create a "manifest list", and then push that to update the current tag on the registry. The end result is that `amd64` users will see no change at all, while `arm64` users will now get the correct `arm64` image. 
+
+<details>
+<summary>Step-by-step instructions:</summary>
+
+These steps assume you have Docker Hub and ECR credentials.
+
+When following these steps, you may get into a state where you have cached copies of images causing wrong behavior. If this happens, delete the offending images, or `docker system prune -all` to be safe.
+
+1. Ensure that the entire `FROM` chain of this image has a `linux/arm64` version, and follow this guide for those `FROM` images if necessary. For example, generating an `arm64` `cypress/browsers:node1.2.3-chrome100` would require an `arm64` `cypress/base:1.2.3` image.
+2. Re-run the `yarn add:<type>:image` command to update the Dockerfile folder with any changes in the build scripts. The correct command is at the top of every `build.sh` file in a comment. Verify that this has replaced the existing image and not caused any unexpected changes, like generating in the wrong directory.
+3. `cd` into the Dockerfile folder.
+4. Build the image and tag it with `tmp`:
+    ```shell
+    docker build -t cypress/<image>:tmp --platform linux/arm64 .
+    ```
+5. Manually validate that the image works as expected and is really in `arm64`:
+    ```shell
+    docker run -it cypress/<image>:tmp node -p "process.arch" # expect arm64
+    ```
+6. Push the `tmp` tag, and record the digest string (`sha256:hexadecimal...`). This is your `arm64` digest string.
+    ```shell
+    docker push cypress/<image>:tmp
+    # example output:
+    # [...]
+    # tmp: digest: sha256:6c38510771b756153b6f4d54c3ef9185006c1659f725e79d4999cd6304720353 size: 3659
+    ```
+7. Find the current `amd64` digest string, either by using Docker Hub to browse tags, or `docker image inspect cypress/...`
+8. Create a combined manifest using the existing name:
+    ```shell
+    docker manifest create cypress/<image>:<tag> \
+      cypress/<image>:tmp@sha256:rest-of-arm64-digest \
+      cypress/<image>:<tag>@sha256:rest-of-amd64-digest
+
+    # example:
+    # docker manifest create cypress/included:10.3.0 \
+    #  cypress/included:tmp@sha256:6c38510771b756153b6f4d54c3ef9185006c1659f725e79d4999cd6304720353 \
+    #  cypress/included:10.3.0@sha256:942468cdb722c408607093f60eeb1b4ff098a384f9123bf2ded36f55d4c96352
+    ```
+9. Run `docker manifest push cypress/<image>:<tag>` to push the completed manifest to Docker Hub.
+10. Validate that the pushed image is correct.
+11. To publish to ECR, use `docker login` to switch accounts and follow the below, slightly modified, steps - you don't need to rebuild the `linux/arm64` version. ECR Digest strings may differ from the Hub Digest strings since they are built separately.
+    ```shell
+    docker login --username AWS --password $(aws ecr-public get-login-password --region us-east-1) public.ecr.aws/cypress-io
+    # tag+push the arm64 build to public.ecr.aws
+    docker tag cypress/$IMAGE_NAME:$TAG@sha256:$ARM64_DIGEST public.ecr.aws/cypress-io/cypress/$IMAGE_NAME:tmp
+    # create a local tag for the public.ecr.aws amd64 build
+    docker pull public.ecr.aws/cypress-io/cypress/$IMAGE_NAME:$TAG
+    # create an arm64+amd64 manifest + replace the old image with the manifest
+    docker manifest create public.ecr.aws/cypress-io/cypress/$IMAGE_NAME:$TAG public.ecr.aws/cypress-io/cypress/$IMAGE_NAME:$TAG public.ecr.aws/cypress-io/cypress/$IMAGE_NAME:tmp
+    docker manifest push public.ecr.aws/cypress-io/cypress/$IMAGE_NAME:$TAG
+    ```
+12. Delete the `tmp` tag.
+</details>

--- a/browsers/node16.14.2-slim-chrome100-ff99-edge/Dockerfile
+++ b/browsers/node16.14.2-slim-chrome100-ff99-edge/Dockerfile
@@ -12,6 +12,9 @@ USER root
 
 RUN node --version
 
+COPY ./global-profile.sh /tmp/global-profile.sh
+RUN cat /tmp/global-profile.sh >> /etc/bash.bashrc && rm /tmp/global-profile.sh
+
 # Install dependencies
 RUN apt-get update && \
   apt-get install -y \
@@ -42,35 +45,33 @@ RUN wget --no-verbose /usr/src/libappindicator3-1_0.4.92-7_amd64.deb "http://ftp
   rm -f /usr/src/libappindicator3-1_0.4.92-7_amd64.deb
 
 # install Chrome browser
-RUN wget --no-verbose -O /usr/src/google-chrome-stable_current_amd64.deb "http://dl.google.com/linux/chrome/deb/pool/main/g/google-chrome-stable/google-chrome-stable_100.0.4896.88-1_amd64.deb" && \
+RUN node -p "process.arch === 'arm64' ? 'Not downloading Chrome since we are on arm64: https://crbug.com/677140' : process.exit(1)" || \
+  (wget --no-verbose -O /usr/src/google-chrome-stable_current_amd64.deb "http://dl.google.com/linux/chrome/deb/pool/main/g/google-chrome-stable/google-chrome-stable_100.0.4896.88-1_amd64.deb" && \
   dpkg -i /usr/src/google-chrome-stable_current_amd64.deb ; \
   apt-get install -f -y && \
-  rm -f /usr/src/google-chrome-stable_current_amd64.deb
+  rm -f /usr/src/google-chrome-stable_current_amd64.deb)
 
 # "fake" dbus address to prevent errors
 # https://github.com/SeleniumHQ/docker-selenium/issues/87
 ENV DBUS_SESSION_BUS_ADDRESS=/dev/null
 
 # install Firefox browser
-RUN wget --no-verbose -O /tmp/firefox.tar.bz2 https://download-installer.cdn.mozilla.net/pub/firefox/releases/99.0.1/linux-x86_64/en-US/firefox-99.0.1.tar.bz2 && \
+RUN node -p "process.arch === 'arm64' ? 'Not downloading Firefox since we are on arm64: https://bugzilla.mozilla.org/show_bug.cgi?id=1678342' : process.exit(1)" || \
+  (wget --no-verbose -O /tmp/firefox.tar.bz2 https://download-installer.cdn.mozilla.net/pub/firefox/releases/99.0.1/linux-x86_64/en-US/firefox-99.0.1.tar.bz2 && \
   tar -C /opt -xjf /tmp/firefox.tar.bz2 && \
   rm /tmp/firefox.tar.bz2 && \
-  ln -fs /opt/firefox/firefox /usr/bin/firefox
+  ln -fs /opt/firefox/firefox /usr/bin/firefox)
 
-RUN echo "Downloading Latest Edge version..."
-
-## Setup Edge
-RUN curl https://packages.microsoft.com/keys/microsoft.asc | gpg --dearmor > microsoft.gpg
-RUN install -o root -g root -m 644 microsoft.gpg /etc/apt/trusted.gpg.d/
-RUN sh -c 'echo "deb [arch=amd64] https://packages.microsoft.com/repos/edge stable main" > /etc/apt/sources.list.d/microsoft-edge-dev.list'
-RUN rm microsoft.gpg
-
-## Install Edge
-RUN apt-get update
-RUN apt-get install -y microsoft-edge-dev
-
-# Add a link to the browser that allows Cypress to find it
-RUN ln -s /usr/bin/microsoft-edge /usr/bin/edge
+RUN node -p "process.arch === 'arm64' ? 'Not downloading Edge since we are on arm64: https://techcommunity.microsoft.com/t5/discussions/edge-for-linux-arm64/m-p/1532272' : process.exit(1)" || \
+  (curl https://packages.microsoft.com/keys/microsoft.asc | gpg --dearmor > microsoft.gpg \
+  install -o root -g root -m 644 microsoft.gpg /etc/apt/trusted.gpg.d/ && \
+  sh -c 'echo "deb [arch=amd64] https://packages.microsoft.com/repos/edge stable main" > /etc/apt/sources.list.d/microsoft-edge-dev.list' && \
+  rm microsoft.gpg && \
+  ## Install Edge
+  apt-get update && \
+  apt-get install -y microsoft-edge-dev && \
+  ## Add a link to the browser that allows Cypress to find it && \
+  ln -s /usr/bin/microsoft-edge /usr/bin/edge)
 
 # versions of local tools
 RUN echo  " node version:    $(node -v) \n" \

--- a/browsers/node16.14.2-slim-chrome100-ff99-edge/README.md
+++ b/browsers/node16.14.2-slim-chrome100-ff99-edge/README.md
@@ -11,3 +11,5 @@ A complete image with all operating system depedencies for Cypress, and Chrome 1
 [Dockerfile](Dockerfile)
 
 **Note:** this image uses the `root` user. You might want to switch to nonroot user like `node` when running this container for security
+
+**Note:** Currently, the linux/arm64 build of this image does not contain any browsers except Electron. See https://github.com/cypress-io/cypress-docker-images/issues/695 for more information.

--- a/browsers/node16.14.2-slim-chrome100-ff99-edge/global-profile.sh
+++ b/browsers/node16.14.2-slim-chrome100-ff99-edge/global-profile.sh
@@ -1,0 +1,11 @@
+if [[ "$(uname -a)" = *"arm"* || "$(uname -a)" = *"aarch64"* ]]; then
+    printf "\e[31m" # red
+    echo "Warning: You are using the beta Arm build of a cypress/browsers or cypress/included image."
+    echo
+    echo "On Arm, non-Electron browsers are not available, because browser vendors are not yet building for Linux arm64."
+    echo "You must use the built-in Electron browser (--browser electron) to run Cypress or find and install unofficial Arm binary builds."
+    echo
+    echo "More details and links to upstream issues for Chrome, Firefox, and Edge can be found at Cypress's issue tracker:"
+    echo "  https://github.com/cypress-io/cypress-docker-images/issues/695"
+    printf "\e[0m" # reset
+fi

--- a/included/10.3.0/README.md
+++ b/included/10.3.0/README.md
@@ -15,4 +15,6 @@ $ docker run -it -v $PWD:/e2e -w /e2e cypress/included:10.3.0
 # runs Cypress tests from the current folder
 ```
 
+**Note:** Currently, the linux/arm64 build of this image does not contain any browsers except Electron. See https://github.com/cypress-io/cypress-docker-images/issues/695 for more information.
+
 [blog post url]: https://www.cypress.io/blog/2019/05/02/run-cypress-with-a-single-docker-command/

--- a/scripts/generate-browser-image.js
+++ b/scripts/generate-browser-image.js
@@ -71,14 +71,14 @@ RUN node -p "process.arch === 'arm64' ? 'Not downloading Firefox since we are on
 
 const edgeDownload = `
 RUN node -p "process.arch === 'arm64' ? 'Not downloading Edge since we are on arm64: https://techcommunity.microsoft.com/t5/discussions/edge-for-linux-arm64/m-p/1532272' : process.exit(1)" || \\
-  (curl https://packages.microsoft.com/keys/microsoft.asc | gpg --dearmor > microsoft.gpg \
-  install -o root -g root -m 644 microsoft.gpg /etc/apt/trusted.gpg.d/ && \
-  sh -c 'echo "deb [arch=amd64] https://packages.microsoft.com/repos/edge stable main" > /etc/apt/sources.list.d/microsoft-edge-dev.list' && \
-  rm microsoft.gpg && \
+  (curl https://packages.microsoft.com/keys/microsoft.asc | gpg --dearmor > microsoft.gpg \\
+  install -o root -g root -m 644 microsoft.gpg /etc/apt/trusted.gpg.d/ && \\
+  sh -c 'echo "deb [arch=amd64] https://packages.microsoft.com/repos/edge stable main" > /etc/apt/sources.list.d/microsoft-edge-dev.list' && \\
+  rm microsoft.gpg && \\
   ## Install Edge
-  apt-get update && \
-  apt-get install -y microsoft-edge-dev && \
-  ## Add a link to the browser that allows Cypress to find it
+  apt-get update && \\
+  apt-get install -y microsoft-edge-dev && \\
+  ## Add a link to the browser that allows Cypress to find it && \\
   ln -s /usr/bin/microsoft-edge /usr/bin/edge)`
 
 const Dockerfile = `

--- a/scripts/generate-included-image.js
+++ b/scripts/generate-included-image.js
@@ -117,7 +117,6 @@ $ docker run -it -v $PWD:/e2e -w /e2e cypress/included:${folderName}
 # runs Cypress tests from the current folder
 \`\`\`
 
-
 **Note:** Currently, the linux/arm64 build of this image does not contain any browsers except Electron. See https://github.com/cypress-io/cypress-docker-images/issues/695 for more information.
 
 [blog post url]: https://www.cypress.io/blog/2019/05/02/run-cypress-with-a-single-docker-command/


### PR DESCRIPTION
Updates from the manual `arm64` retagging process: https://github.com/cypress-io/cypress-docker-images/issues/431#issuecomment-1184977847

Details:

* Documents the process to add `arm64` builds to existing `amd64` images on Hub/ECR, if we ever have to do it :see_no_evil: 
* Fixes a syntax error in the generated "browsers" Dockerfiles