### PR TITLE
chore: fix cypress/included cross-build

### DIFF
--- a/circle.yml
+++ b/circle.yml
@@ -439,21 +439,21 @@ workflows:
     build-included-images:
         jobs:
             - build-included-image:
-                name: "build+test included 10.2.0 arm64"
-                dockerTag: "10.2.0"
+                name: "build+test included 10.3.1 arm64"
+                dockerTag: "10.3.1"
                 resourceClass: arm.large
                 platformArg: linux/arm64
             - build-included-image:
-                name: "build+test included 10.2.0 x64"
-                dockerTag: "10.2.0"
+                name: "build+test included 10.3.1 x64"
+                dockerTag: "10.3.1"
                 resourceClass: large
                 platformArg: linux/amd64
             - push-images:
-                name: "push included 10.2.0 images"
+                name: "push included 10.3.1 images"
                 dockerName: 'cypress/included'
-                dockerTag: '10.2.0'
-                workingDirectory: '~/project/included/10.2.0'
+                dockerTag: '10.3.1'
+                workingDirectory: '~/project/included/10.3.1'
                 context: test-runner:docker-push
                 requires:
-                    - "build+test included 10.2.0 arm64"
-                    - "build+test included 10.2.0 x64"
+                    - "build+test included 10.3.1 arm64"
+                    - "build+test included 10.3.1 x64"

--- a/circle.yml
+++ b/circle.yml
@@ -367,7 +367,7 @@ jobs:
             - run:
                   name: building Docker image cypress/included:<< parameters.dockerTag >>
                   command: |
-                      docker build -t cypress/included:<< parameters.dockerTag >> --platform << parameters.platformArg >> .
+                      docker build --build-arg CI_XBUILD=1 -t cypress/included:<< parameters.dockerTag >> --platform << parameters.platformArg >> .
                   working_directory: included/<< parameters.dockerTag >>
 
             - test-included-image-versions:
@@ -398,8 +398,7 @@ jobs:
                 imageName: << parameters.dockerName >>:<< parameters.dockerTag >>
             - halt-on-branch
             - run:
-                ## see https://docs.docker.com/desktop/multi-arch/
-                name: build + push multi-arch image to docker hub
+                name: build + push multi-arch image
                 working_directory: << parameters.workingDirectory >>
                 command: |
                     ## install QEMU, pulled from https://github.com/docker/setup-qemu-action/blob/4620c11b701e878e3f2b7aa142927d0646857fd9/src/main.ts
@@ -416,16 +415,13 @@ jobs:
                     docker buildx create --name builder --use
                     docker buildx inspect --bootstrap
                     DOCKER_TAG=<< parameters.dockerName >>:<< parameters.dockerTag >>
-                    docker buildx build --progress plain --platform linux/arm64,linux/amd64 -t $DOCKER_TAG --push .
-            - run:
-                name: build + push multi-arch image to amazon ecr
-                working_directory: << parameters.workingDirectory >>
-                command: |
+                    docker buildx build --build-arg CI_XBUILD=1 --progress plain --platform linux/arm64,linux/amd64 -t $DOCKER_TAG --push .
+
                     ## now, let's re-build those same images for Amazon ECR
                     ## see https://docs.aws.amazon.com/AmazonECR/latest/userguide/docker-push-ecr-image.html
                     aws ecr-public get-login-password --region $AWS_ECR_REGION | docker login --username AWS --password-stdin $AWS_ECR_PREFIX
                     ## it is inefficient to re-build here - look below for a TODO on how this could be made faster
-                    docker buildx build --progress plain --platform linux/arm64,linux/amd64 -t $AWS_ECR_PREFIX/$DOCKER_TAG --push .
+                    docker buildx build --build-arg CI_XBUILD=1 --progress plain --platform linux/arm64,linux/amd64 -t $AWS_ECR_PREFIX/$DOCKER_TAG --push .
 
                     ## TODO: figure out why we can't simply 're-tag' a manifest - the below code gives "authentication required" for some unknown reason
                     #apt-get install jq -y

--- a/circle.yml
+++ b/circle.yml
@@ -367,7 +367,7 @@ jobs:
             - run:
                   name: building Docker image cypress/included:<< parameters.dockerTag >>
                   command: |
-                      docker build --build-arg CI_XBUILD=1 -t cypress/included:<< parameters.dockerTag >> --platform << parameters.platformArg >> .
+                      docker build -t cypress/included:<< parameters.dockerTag >> --platform << parameters.platformArg >> .
                   working_directory: included/<< parameters.dockerTag >>
 
             - test-included-image-versions:
@@ -439,21 +439,21 @@ workflows:
     build-included-images:
         jobs:
             - build-included-image:
-                name: "build+test included 10.3.1 arm64"
-                dockerTag: "10.3.1"
+                name: "build+test included 10.2.0 arm64"
+                dockerTag: "10.2.0"
                 resourceClass: arm.large
                 platformArg: linux/arm64
             - build-included-image:
-                name: "build+test included 10.3.1 x64"
-                dockerTag: "10.3.1"
+                name: "build+test included 10.2.0 x64"
+                dockerTag: "10.2.0"
                 resourceClass: large
                 platformArg: linux/amd64
             - push-images:
-                name: "push included 10.3.1 images"
+                name: "push included 10.2.0 images"
                 dockerName: 'cypress/included'
-                dockerTag: '10.3.1'
-                workingDirectory: '~/project/included/10.3.1'
+                dockerTag: '10.2.0'
+                workingDirectory: '~/project/included/10.2.0'
                 context: test-runner:docker-push
                 requires:
-                    - "build+test included 10.3.1 arm64"
-                    - "build+test included 10.3.1 x64"
+                    - "build+test included 10.2.0 arm64"
+                    - "build+test included 10.2.0 x64"

--- a/included/10.3.1/Dockerfile
+++ b/included/10.3.1/Dockerfile
@@ -21,6 +21,10 @@ ENV CI=1 \
   # Allow projects to reference globally installed cypress
   NODE_PATH=/usr/local/lib/node_modules
 
+# CI_XBUILD is set when we are building a multi-arch build from x64 in CI.
+# This is necessary so that local `./build.sh` usage still verifies `cypress` on `arm64`.
+ARG CI_XBUILD
+
 # should be root user
 RUN echo "whoami: $(whoami)" \
   && npm config -g set user $(whoami) \
@@ -29,13 +33,14 @@ RUN echo "whoami: $(whoami)" \
   # which means the current user is root
   && id \
   && npm install -g "cypress@10.3.1" \
-  && cypress verify \
-  # Cypress cache and installed version
-  # should be in the root user's home folder
-  && cypress cache path \
-  && cypress cache list \
-  && cypress info \
-  && cypress version \
+  && (node -p "process.env.CI_XBUILD && process.arch === 'arm64' ? 'Skipping cypress verify on arm64 due to SIGSEGV.' : process.exit(1)" \
+    || (cypress verify \
+    # Cypress cache and installed version
+    # should be in the root user's home folder
+    && cypress cache path \
+    && cypress cache list \
+    && cypress info \
+    && cypress version)) \
   # give every user read access to the "/root" folder where the binary is cached
   # we really only need to worry about the top folder, fortunately
   && ls -la /root \

--- a/scripts/__tests__/__snapshots__/generate-config-snapshots.test.js.snap
+++ b/scripts/__tests__/__snapshots__/generate-config-snapshots.test.js.snap
@@ -370,7 +370,7 @@ jobs:
             - run:
                   name: building Docker image cypress/included:<< parameters.dockerTag >>
                   command: |
-                      docker build --build-arg CI_XBUILD=1 -t cypress/included:<< parameters.dockerTag >> --platform << parameters.platformArg >> .
+                      docker build -t cypress/included:<< parameters.dockerTag >> --platform << parameters.platformArg >> .
                   working_directory: included/<< parameters.dockerTag >>
 
             - test-included-image-versions:
@@ -832,7 +832,7 @@ jobs:
             - run:
                   name: building Docker image cypress/included:<< parameters.dockerTag >>
                   command: |
-                      docker build --build-arg CI_XBUILD=1 -t cypress/included:<< parameters.dockerTag >> --platform << parameters.platformArg >> .
+                      docker build -t cypress/included:<< parameters.dockerTag >> --platform << parameters.platformArg >> .
                   working_directory: included/<< parameters.dockerTag >>
 
             - test-included-image-versions:
@@ -1298,7 +1298,7 @@ jobs:
             - run:
                   name: building Docker image cypress/included:<< parameters.dockerTag >>
                   command: |
-                      docker build --build-arg CI_XBUILD=1 -t cypress/included:<< parameters.dockerTag >> --platform << parameters.platformArg >> .
+                      docker build -t cypress/included:<< parameters.dockerTag >> --platform << parameters.platformArg >> .
                   working_directory: included/<< parameters.dockerTag >>
 
             - test-included-image-versions:

--- a/scripts/__tests__/__snapshots__/generate-config-snapshots.test.js.snap
+++ b/scripts/__tests__/__snapshots__/generate-config-snapshots.test.js.snap
@@ -370,7 +370,7 @@ jobs:
             - run:
                   name: building Docker image cypress/included:<< parameters.dockerTag >>
                   command: |
-                      docker build -t cypress/included:<< parameters.dockerTag >> --platform << parameters.platformArg >> .
+                      docker build --build-arg CI_XBUILD=1 -t cypress/included:<< parameters.dockerTag >> --platform << parameters.platformArg >> .
                   working_directory: included/<< parameters.dockerTag >>
 
             - test-included-image-versions:
@@ -401,8 +401,7 @@ jobs:
                 imageName: << parameters.dockerName >>:<< parameters.dockerTag >>
             - halt-on-branch
             - run:
-                ## see https://docs.docker.com/desktop/multi-arch/
-                name: build + push multi-arch image to docker hub
+                name: build + push multi-arch image
                 working_directory: << parameters.workingDirectory >>
                 command: |
                     ## install QEMU, pulled from https://github.com/docker/setup-qemu-action/blob/4620c11b701e878e3f2b7aa142927d0646857fd9/src/main.ts
@@ -419,16 +418,13 @@ jobs:
                     docker buildx create --name builder --use
                     docker buildx inspect --bootstrap
                     DOCKER_TAG=<< parameters.dockerName >>:<< parameters.dockerTag >>
-                    docker buildx build --progress plain --platform linux/arm64,linux/amd64 -t $DOCKER_TAG --push .
-            - run:
-                name: build + push multi-arch image to amazon ecr
-                working_directory: << parameters.workingDirectory >>
-                command: |
+                    docker buildx build --build-arg CI_XBUILD=1 --progress plain --platform linux/arm64,linux/amd64 -t $DOCKER_TAG --push .
+
                     ## now, let's re-build those same images for Amazon ECR
                     ## see https://docs.aws.amazon.com/AmazonECR/latest/userguide/docker-push-ecr-image.html
                     aws ecr-public get-login-password --region $AWS_ECR_REGION | docker login --username AWS --password-stdin $AWS_ECR_PREFIX
                     ## it is inefficient to re-build here - look below for a TODO on how this could be made faster
-                    docker buildx build --progress plain --platform linux/arm64,linux/amd64 -t $AWS_ECR_PREFIX/$DOCKER_TAG --push .
+                    docker buildx build --build-arg CI_XBUILD=1 --progress plain --platform linux/arm64,linux/amd64 -t $AWS_ECR_PREFIX/$DOCKER_TAG --push .
 
                     ## TODO: figure out why we can't simply 're-tag' a manifest - the below code gives \\"authentication required\\" for some unknown reason
                     #apt-get install jq -y
@@ -836,7 +832,7 @@ jobs:
             - run:
                   name: building Docker image cypress/included:<< parameters.dockerTag >>
                   command: |
-                      docker build -t cypress/included:<< parameters.dockerTag >> --platform << parameters.platformArg >> .
+                      docker build --build-arg CI_XBUILD=1 -t cypress/included:<< parameters.dockerTag >> --platform << parameters.platformArg >> .
                   working_directory: included/<< parameters.dockerTag >>
 
             - test-included-image-versions:
@@ -867,8 +863,7 @@ jobs:
                 imageName: << parameters.dockerName >>:<< parameters.dockerTag >>
             - halt-on-branch
             - run:
-                ## see https://docs.docker.com/desktop/multi-arch/
-                name: build + push multi-arch image to docker hub
+                name: build + push multi-arch image
                 working_directory: << parameters.workingDirectory >>
                 command: |
                     ## install QEMU, pulled from https://github.com/docker/setup-qemu-action/blob/4620c11b701e878e3f2b7aa142927d0646857fd9/src/main.ts
@@ -885,16 +880,13 @@ jobs:
                     docker buildx create --name builder --use
                     docker buildx inspect --bootstrap
                     DOCKER_TAG=<< parameters.dockerName >>:<< parameters.dockerTag >>
-                    docker buildx build --progress plain --platform linux/arm64,linux/amd64 -t $DOCKER_TAG --push .
-            - run:
-                name: build + push multi-arch image to amazon ecr
-                working_directory: << parameters.workingDirectory >>
-                command: |
+                    docker buildx build --build-arg CI_XBUILD=1 --progress plain --platform linux/arm64,linux/amd64 -t $DOCKER_TAG --push .
+
                     ## now, let's re-build those same images for Amazon ECR
                     ## see https://docs.aws.amazon.com/AmazonECR/latest/userguide/docker-push-ecr-image.html
                     aws ecr-public get-login-password --region $AWS_ECR_REGION | docker login --username AWS --password-stdin $AWS_ECR_PREFIX
                     ## it is inefficient to re-build here - look below for a TODO on how this could be made faster
-                    docker buildx build --progress plain --platform linux/arm64,linux/amd64 -t $AWS_ECR_PREFIX/$DOCKER_TAG --push .
+                    docker buildx build --build-arg CI_XBUILD=1 --progress plain --platform linux/arm64,linux/amd64 -t $AWS_ECR_PREFIX/$DOCKER_TAG --push .
 
                     ## TODO: figure out why we can't simply 're-tag' a manifest - the below code gives \\"authentication required\\" for some unknown reason
                     #apt-get install jq -y
@@ -1306,7 +1298,7 @@ jobs:
             - run:
                   name: building Docker image cypress/included:<< parameters.dockerTag >>
                   command: |
-                      docker build -t cypress/included:<< parameters.dockerTag >> --platform << parameters.platformArg >> .
+                      docker build --build-arg CI_XBUILD=1 -t cypress/included:<< parameters.dockerTag >> --platform << parameters.platformArg >> .
                   working_directory: included/<< parameters.dockerTag >>
 
             - test-included-image-versions:
@@ -1337,8 +1329,7 @@ jobs:
                 imageName: << parameters.dockerName >>:<< parameters.dockerTag >>
             - halt-on-branch
             - run:
-                ## see https://docs.docker.com/desktop/multi-arch/
-                name: build + push multi-arch image to docker hub
+                name: build + push multi-arch image
                 working_directory: << parameters.workingDirectory >>
                 command: |
                     ## install QEMU, pulled from https://github.com/docker/setup-qemu-action/blob/4620c11b701e878e3f2b7aa142927d0646857fd9/src/main.ts
@@ -1355,16 +1346,13 @@ jobs:
                     docker buildx create --name builder --use
                     docker buildx inspect --bootstrap
                     DOCKER_TAG=<< parameters.dockerName >>:<< parameters.dockerTag >>
-                    docker buildx build --progress plain --platform linux/arm64,linux/amd64 -t $DOCKER_TAG --push .
-            - run:
-                name: build + push multi-arch image to amazon ecr
-                working_directory: << parameters.workingDirectory >>
-                command: |
+                    docker buildx build --build-arg CI_XBUILD=1 --progress plain --platform linux/arm64,linux/amd64 -t $DOCKER_TAG --push .
+
                     ## now, let's re-build those same images for Amazon ECR
                     ## see https://docs.aws.amazon.com/AmazonECR/latest/userguide/docker-push-ecr-image.html
                     aws ecr-public get-login-password --region $AWS_ECR_REGION | docker login --username AWS --password-stdin $AWS_ECR_PREFIX
                     ## it is inefficient to re-build here - look below for a TODO on how this could be made faster
-                    docker buildx build --progress plain --platform linux/arm64,linux/amd64 -t $AWS_ECR_PREFIX/$DOCKER_TAG --push .
+                    docker buildx build --build-arg CI_XBUILD=1 --progress plain --platform linux/arm64,linux/amd64 -t $AWS_ECR_PREFIX/$DOCKER_TAG --push .
 
                     ## TODO: figure out why we can't simply 're-tag' a manifest - the below code gives \\"authentication required\\" for some unknown reason
                     #apt-get install jq -y

--- a/scripts/includes/circle-header.yml
+++ b/scripts/includes/circle-header.yml
@@ -367,7 +367,7 @@ jobs:
             - run:
                   name: building Docker image cypress/included:<< parameters.dockerTag >>
                   command: |
-                      docker build -t cypress/included:<< parameters.dockerTag >> --platform << parameters.platformArg >> .
+                      docker build --build-arg CI_XBUILD=1 -t cypress/included:<< parameters.dockerTag >> --platform << parameters.platformArg >> .
                   working_directory: included/<< parameters.dockerTag >>
 
             - test-included-image-versions:
@@ -398,8 +398,7 @@ jobs:
                 imageName: << parameters.dockerName >>:<< parameters.dockerTag >>
             - halt-on-branch
             - run:
-                ## see https://docs.docker.com/desktop/multi-arch/
-                name: build + push multi-arch image to docker hub
+                name: build + push multi-arch image
                 working_directory: << parameters.workingDirectory >>
                 command: |
                     ## install QEMU, pulled from https://github.com/docker/setup-qemu-action/blob/4620c11b701e878e3f2b7aa142927d0646857fd9/src/main.ts
@@ -416,16 +415,13 @@ jobs:
                     docker buildx create --name builder --use
                     docker buildx inspect --bootstrap
                     DOCKER_TAG=<< parameters.dockerName >>:<< parameters.dockerTag >>
-                    docker buildx build --progress plain --platform linux/arm64,linux/amd64 -t $DOCKER_TAG --push .
-            - run:
-                name: build + push multi-arch image to amazon ecr
-                working_directory: << parameters.workingDirectory >>
-                command: |
+                    docker buildx build --build-arg CI_XBUILD=1 --progress plain --platform linux/arm64,linux/amd64 -t $DOCKER_TAG --push .
+
                     ## now, let's re-build those same images for Amazon ECR
                     ## see https://docs.aws.amazon.com/AmazonECR/latest/userguide/docker-push-ecr-image.html
                     aws ecr-public get-login-password --region $AWS_ECR_REGION | docker login --username AWS --password-stdin $AWS_ECR_PREFIX
                     ## it is inefficient to re-build here - look below for a TODO on how this could be made faster
-                    docker buildx build --progress plain --platform linux/arm64,linux/amd64 -t $AWS_ECR_PREFIX/$DOCKER_TAG --push .
+                    docker buildx build --build-arg CI_XBUILD=1 --progress plain --platform linux/arm64,linux/amd64 -t $AWS_ECR_PREFIX/$DOCKER_TAG --push .
 
                     ## TODO: figure out why we can't simply 're-tag' a manifest - the below code gives "authentication required" for some unknown reason
                     #apt-get install jq -y

--- a/scripts/includes/circle-header.yml
+++ b/scripts/includes/circle-header.yml
@@ -367,7 +367,7 @@ jobs:
             - run:
                   name: building Docker image cypress/included:<< parameters.dockerTag >>
                   command: |
-                      docker build --build-arg CI_XBUILD=1 -t cypress/included:<< parameters.dockerTag >> --platform << parameters.platformArg >> .
+                      docker build -t cypress/included:<< parameters.dockerTag >> --platform << parameters.platformArg >> .
                   working_directory: included/<< parameters.dockerTag >>
 
             - test-included-image-versions:


### PR DESCRIPTION
In CI, we cross-build `linux/arm64` from `linux/amd64` using QEMU. It seems like QEMU doesn't support Electron (I'm guessing for the same reasons QEMU doesn't support Chromium), since this error results from running `cypress verify` in QEMU:

```
Command was killed with SIGSEGV (Segmentation fault): /root/.cache/Cypress/10.3.1/Cypress/Cypress --no-sandbox --smoke-test --ping=342
```

This PR updates the cross-build to pass a new buildArg, `CI_XBUILD`, which lets the Dockerfile know it's being cross-built. This causes the `verify` step to be skipped in the cross-built `arm64` build process. This seems safe since we are also running a real `arm64` build as a pre-requisite to the build+push job. Dockerfile manually tested to work with cross-building in CI via SSH.

This will enable the 10.3.1 image to be released:

Closes #707 