### PR TITLE
fix: update dockerName and workingDirectory values to properly reflect browsers and not browser

### DIFF
--- a/.prettierrc
+++ b/.prettierrc
@@ -2,5 +2,6 @@
   "printWidth": 120,
   "semi": false,
   "trailingComma": "all",
-  "arrowParens": "always"
+  "arrowParens": "always",
+  "singleQuote": true
 }

--- a/scripts/__tests__/__snapshots__/generate-config-snapshots.test.js.snap
+++ b/scripts/__tests__/__snapshots__/generate-config-snapshots.test.js.snap
@@ -927,9 +927,9 @@ workflows:
                 firefoxVersion: \\"Mozilla Firefox 99\\"
             - push-images:
                 name: \\"push browser node16.14.2-slim-chrome103-ff99 images\\"
-                dockerName: 'cypress/browser'
+                dockerName: 'cypress/browsers'
                 dockerTag: 'node16.14.2-slim-chrome103-ff99'
-                workingDirectory: '~/project/browser/node16.14.2-slim-chrome103-ff99'
+                workingDirectory: '~/project/browsers/node16.14.2-slim-chrome103-ff99'
                 context: test-runner:docker-push
                 requires:
                     - \\"build+test browser node16.14.2-slim-chrome103-ff99 arm64\\"

--- a/scripts/generate-config.js
+++ b/scripts/generate-config.js
@@ -23,7 +23,7 @@ const splitImageFolderName = (folderName) => {
 }
 
 const getImageType = (image) => {
-  return image.name.includes('base') ? 'base' : image.name.includes('browser') ? 'browsers' : 'included'
+  return image.name.includes('base') ? 'base' : image.name.includes('browser') ? 'browser' : 'included'
 }
 
 const getDockerArchFromNodeArch = (nodeArch) => {
@@ -76,9 +76,11 @@ const formWorkflow = (image) => {
     os.EOL +
     `            - push-images:
                 name: "push ${getImageType(image)} ${image.tag} images"
-                dockerName: 'cypress/${getImageType(image)}'
+                dockerName: 'cypress/${getImageType(image) === 'browser' ? 'browsers' : getImageType(image)}'
                 dockerTag: '${image.tag}'
-                workingDirectory: '~/project/${getImageType(image)}/${image.tag}'
+                workingDirectory: '~/project/${getImageType(image) === 'browser' ? 'browsers' : getImageType(image)}/${
+      image.tag
+    }'
                 context: test-runner:docker-push
                 requires:`
 

--- a/scripts/generate-config.js
+++ b/scripts/generate-config.js
@@ -48,7 +48,7 @@ const formWorkflow = (image) => {
                 platformArg: ${getDockerArchFromNodeArch(arch)}`
 
     // add browser versions
-    if (getImageType(image) === 'browsers') {
+    if (getImageType(image) === 'browser') {
       if (image.tag.includes('-chrome')) {
         yml =
           yml +

--- a/scripts/generate-config.js
+++ b/scripts/generate-config.js
@@ -1,30 +1,29 @@
-const path = require("path")
-const fs = require("fs")
-const { camelCase } = require("lodash")
-const os = require("os")
+const path = require('path')
+const fs = require('fs')
+const os = require('os')
 
 const imageType = process.argv[2]
 const versionTag = process.argv[3]
 
 if (!imageType) {
-  console.error("expected an image type like included")
+  console.error('expected an image type like included')
   process.exit(1)
 }
 
 if (!versionTag) {
-  console.error("expected Cypress version argument like 3.8.3")
+  console.error('expected Cypress version argument like 3.8.3')
   process.exit(1)
 }
 
 const circleHeader = fs.readFileSync(path.join(__dirname, 'includes', 'circle-header.yml')).toString()
 
 const splitImageFolderName = (folderName) => {
-  const [name, tag] = folderName.split("/")
+  const [name, tag] = folderName.split('/')
   return { name, tag }
 }
 
 const getImageType = (image) => {
-  return image.name.includes("base") ? "base" : image.name.includes("browser") ? "browser" : "included"
+  return image.name.includes('base') ? 'base' : image.name.includes('browser') ? 'browser' : 'included'
 }
 
 const getDockerArchFromNodeArch = (nodeArch) => {
@@ -40,42 +39,46 @@ const formWorkflow = (image) => {
   const arches = ['arm64', 'x64']
 
   for (const arch of arches) {
-    yml += os.EOL + `            - build-${getImageType(image)}-image:
+    yml +=
+      os.EOL +
+      `            - build-${getImageType(image)}-image:
                 name: "build+test ${getImageType(image)} ${image.tag} ${arch}"
                 dockerTag: "${image.tag}"
                 resourceClass: ${arch === 'arm64' ? 'arm.large' : 'large'}
                 platformArg: ${getDockerArchFromNodeArch(arch)}`
 
     // add browser versions
-    if (getImageType(image) === "browser") {
-        if (image.tag.includes("-chrome")) {
+    if (getImageType(image) === 'browser') {
+      if (image.tag.includes('-chrome')) {
         yml =
-            yml +
-            `
+          yml +
+          `
                 chromeVersion: "Google Chrome ${image.tag.match(/-chrome\d*/)[0].substring(7)}"`
-        }
+      }
 
-        if (image.tag.includes("-ff")) {
+      if (image.tag.includes('-ff')) {
         yml =
-            yml +
-            `
+          yml +
+          `
                 firefoxVersion: "Mozilla Firefox ${image.tag.match(/-ff\d*/)[0].substring(3)}"`
-        }
+      }
 
-        if (image.tag.includes("-edge")) {
+      if (image.tag.includes('-edge')) {
         yml =
-            yml +
-            `
+          yml +
+          `
                 edgeVersion: "Microsoft Edge"`
-        }
+      }
     }
   }
 
-  yml += os.EOL + `            - push-images:
+  yml +=
+    os.EOL +
+    `            - push-images:
                 name: "push ${getImageType(image)} ${image.tag} images"
-                dockerName: 'cypress/${getImageType(image)}'
+                dockerName: 'cypress/browsers'
                 dockerTag: '${image.tag}'
-                workingDirectory: '~/project/${getImageType(image)}/${image.tag}'
+                workingDirectory: '~/project/browsers/${image.tag}'
                 context: test-runner:docker-push
                 requires:`
 
@@ -89,14 +92,14 @@ const formWorkflow = (image) => {
 const writeConfigFile = (image) => {
   const workflow = formWorkflow(image)
   const text = circleHeader.trim() + os.EOL + workflow
-  fs.writeFileSync("circle.yml", text, "utf8")
-  console.log("Generated circle.yml")
+  fs.writeFileSync('circle.yml', text, 'utf8')
+  console.log('Generated circle.yml')
 }
 
 const outputFolder = path.join(imageType, versionTag)
-console.log("** outputFolder : %s", outputFolder)
+console.log('** outputFolder : %s', outputFolder)
 
 const image = splitImageFolderName(outputFolder)
-console.log("** image : %s \n", image)
+console.log('** image : %s \n', image)
 
 writeConfigFile(image)

--- a/scripts/generate-config.js
+++ b/scripts/generate-config.js
@@ -23,7 +23,7 @@ const splitImageFolderName = (folderName) => {
 }
 
 const getImageType = (image) => {
-  return image.name.includes('base') ? 'base' : image.name.includes('browser') ? 'browser' : 'included'
+  return image.name.includes('base') ? 'base' : image.name.includes('browser') ? 'browsers' : 'included'
 }
 
 const getDockerArchFromNodeArch = (nodeArch) => {
@@ -48,7 +48,7 @@ const formWorkflow = (image) => {
                 platformArg: ${getDockerArchFromNodeArch(arch)}`
 
     // add browser versions
-    if (getImageType(image) === 'browser') {
+    if (getImageType(image) === 'browsers') {
       if (image.tag.includes('-chrome')) {
         yml =
           yml +
@@ -76,9 +76,9 @@ const formWorkflow = (image) => {
     os.EOL +
     `            - push-images:
                 name: "push ${getImageType(image)} ${image.tag} images"
-                dockerName: 'cypress/browsers'
+                dockerName: 'cypress/${getImageType(image)}'
                 dockerTag: '${image.tag}'
-                workingDirectory: '~/project/browsers/${image.tag}'
+                workingDirectory: '~/project/${getImageType(image)}/${image.tag}'
                 context: test-runner:docker-push
                 requires:`
 


### PR DESCRIPTION
I think this is causing CircleCI to fail [here](https://app.circleci.com/pipelines/github/cypress-io/cypress-docker-images/992/workflows/ef8ab5cc-1600-4814-8988-f28bbca84edc/jobs/37713) because it's not in an existing working directory. Also, the `dockerName` does not exist as is. It should be [cypress/browsers](https://hub.docker.com/r/cypress/browsers/).

The other changes are stylistic. The const return value change is [here](https://github.com/cypress-io/cypress-docker-images/pull/713/files#diff-4572eb49b4d6810989d89c931ba501b12276c24a8e4c5d5c0ab577611e42d3abR26).