### PR TITLE
fix: update circle.yml with proper dockerName and workingDirectory values. dry up getImageType calls.

### DIFF
--- a/circle.yml
+++ b/circle.yml
@@ -454,9 +454,9 @@ workflows:
                 firefoxVersion: "Mozilla Firefox 102"
             - push-images:
                 name: "push browser node16.14.2-slim-chrome103-ff102 images"
-                dockerName: 'cypress/browser'
+                dockerName: 'cypress/browsers'
                 dockerTag: 'node16.14.2-slim-chrome103-ff102'
-                workingDirectory: '~/project/browser/node16.14.2-slim-chrome103-ff102'
+                workingDirectory: '~/project/browsers/node16.14.2-slim-chrome103-ff102'
                 context: test-runner:docker-push
                 requires:
                     - "build+test browser node16.14.2-slim-chrome103-ff102 arm64"

--- a/scripts/__tests__/__snapshots__/generate-config-snapshots.test.js.snap
+++ b/scripts/__tests__/__snapshots__/generate-config-snapshots.test.js.snap
@@ -439,27 +439,31 @@ workflows:
         jobs:
             - lint-markdown
             - test
-    build-base-images:
+    build-browser-images:
         jobs:
-            - build-base-image:
-                name: \\"build+test base 16.14.2-slim arm64\\"
-                dockerTag: \\"16.14.2-slim\\"
+            - build-browser-image:
+                name: \\"build+test browser node16.14.2-slim-chrome103-ff102 arm64\\"
+                dockerTag: \\"node16.14.2-slim-chrome103-ff102\\"
                 resourceClass: arm.large
                 platformArg: linux/arm64
-            - build-base-image:
-                name: \\"build+test base 16.14.2-slim x64\\"
-                dockerTag: \\"16.14.2-slim\\"
+                chromeVersion: \\"Google Chrome 103\\"
+                firefoxVersion: \\"Mozilla Firefox 102\\"
+            - build-browser-image:
+                name: \\"build+test browser node16.14.2-slim-chrome103-ff102 x64\\"
+                dockerTag: \\"node16.14.2-slim-chrome103-ff102\\"
                 resourceClass: large
                 platformArg: linux/amd64
+                chromeVersion: \\"Google Chrome 103\\"
+                firefoxVersion: \\"Mozilla Firefox 102\\"
             - push-images:
-                name: \\"push base 16.14.2-slim images\\"
-                dockerName: 'cypress/base'
-                dockerTag: '16.14.2-slim'
-                workingDirectory: '~/project/base/16.14.2-slim'
+                name: \\"push browser node16.14.2-slim-chrome103-ff102 images\\"
+                dockerName: 'cypress/browsers'
+                dockerTag: 'node16.14.2-slim-chrome103-ff102'
+                workingDirectory: '~/project/browsers/node16.14.2-slim-chrome103-ff102'
                 context: test-runner:docker-push
                 requires:
-                    - \\"build+test base 16.14.2-slim arm64\\"
-                    - \\"build+test base 16.14.2-slim x64\\""
+                    - \\"build+test browser node16.14.2-slim-chrome103-ff102 arm64\\"
+                    - \\"build+test browser node16.14.2-slim-chrome103-ff102 x64\\""
 `;
 
 exports[`generate config snapshots generates config for browsers 1`] = `
@@ -904,28 +908,28 @@ workflows:
     build-browser-images:
         jobs:
             - build-browser-image:
-                name: \\"build+test browser node16.14.2-slim-chrome103-ff99 arm64\\"
-                dockerTag: \\"node16.14.2-slim-chrome103-ff99\\"
+                name: \\"build+test browser node16.14.2-slim-chrome103-ff102 arm64\\"
+                dockerTag: \\"node16.14.2-slim-chrome103-ff102\\"
                 resourceClass: arm.large
                 platformArg: linux/arm64
                 chromeVersion: \\"Google Chrome 103\\"
-                firefoxVersion: \\"Mozilla Firefox 99\\"
+                firefoxVersion: \\"Mozilla Firefox 102\\"
             - build-browser-image:
-                name: \\"build+test browser node16.14.2-slim-chrome103-ff99 x64\\"
-                dockerTag: \\"node16.14.2-slim-chrome103-ff99\\"
+                name: \\"build+test browser node16.14.2-slim-chrome103-ff102 x64\\"
+                dockerTag: \\"node16.14.2-slim-chrome103-ff102\\"
                 resourceClass: large
                 platformArg: linux/amd64
                 chromeVersion: \\"Google Chrome 103\\"
-                firefoxVersion: \\"Mozilla Firefox 99\\"
+                firefoxVersion: \\"Mozilla Firefox 102\\"
             - push-images:
-                name: \\"push browser node16.14.2-slim-chrome103-ff99 images\\"
+                name: \\"push browser node16.14.2-slim-chrome103-ff102 images\\"
                 dockerName: 'cypress/browsers'
-                dockerTag: 'node16.14.2-slim-chrome103-ff99'
-                workingDirectory: '~/project/browsers/node16.14.2-slim-chrome103-ff99'
+                dockerTag: 'node16.14.2-slim-chrome103-ff102'
+                workingDirectory: '~/project/browsers/node16.14.2-slim-chrome103-ff102'
                 context: test-runner:docker-push
                 requires:
-                    - \\"build+test browser node16.14.2-slim-chrome103-ff99 arm64\\"
-                    - \\"build+test browser node16.14.2-slim-chrome103-ff99 x64\\""
+                    - \\"build+test browser node16.14.2-slim-chrome103-ff102 arm64\\"
+                    - \\"build+test browser node16.14.2-slim-chrome103-ff102 x64\\""
 `;
 
 exports[`generate config snapshots generates config for included 1`] = `
@@ -1367,25 +1371,29 @@ workflows:
         jobs:
             - lint-markdown
             - test
-    build-included-images:
+    build-browser-images:
         jobs:
-            - build-included-image:
-                name: \\"build+test included 10.2.0 arm64\\"
-                dockerTag: \\"10.2.0\\"
+            - build-browser-image:
+                name: \\"build+test browser node16.14.2-slim-chrome103-ff102 arm64\\"
+                dockerTag: \\"node16.14.2-slim-chrome103-ff102\\"
                 resourceClass: arm.large
                 platformArg: linux/arm64
-            - build-included-image:
-                name: \\"build+test included 10.2.0 x64\\"
-                dockerTag: \\"10.2.0\\"
+                chromeVersion: \\"Google Chrome 103\\"
+                firefoxVersion: \\"Mozilla Firefox 102\\"
+            - build-browser-image:
+                name: \\"build+test browser node16.14.2-slim-chrome103-ff102 x64\\"
+                dockerTag: \\"node16.14.2-slim-chrome103-ff102\\"
                 resourceClass: large
                 platformArg: linux/amd64
+                chromeVersion: \\"Google Chrome 103\\"
+                firefoxVersion: \\"Mozilla Firefox 102\\"
             - push-images:
-                name: \\"push included 10.2.0 images\\"
-                dockerName: 'cypress/included'
-                dockerTag: '10.2.0'
-                workingDirectory: '~/project/included/10.2.0'
+                name: \\"push browser node16.14.2-slim-chrome103-ff102 images\\"
+                dockerName: 'cypress/browsers'
+                dockerTag: 'node16.14.2-slim-chrome103-ff102'
+                workingDirectory: '~/project/browsers/node16.14.2-slim-chrome103-ff102'
                 context: test-runner:docker-push
                 requires:
-                    - \\"build+test included 10.2.0 arm64\\"
-                    - \\"build+test included 10.2.0 x64\\""
+                    - \\"build+test browser node16.14.2-slim-chrome103-ff102 arm64\\"
+                    - \\"build+test browser node16.14.2-slim-chrome103-ff102 x64\\""
 `;


### PR DESCRIPTION
Fixes the build issue for the `node16.14.2-slim-chrome103-ff102` browser image.