### PR TITLE
fix: pr checks for base image

### DIFF
--- a/circle.yml
+++ b/circle.yml
@@ -61,14 +61,6 @@ commands:
                       echo "Testing using Electron browser"
                       docker run -it -v $PWD:/e2e -w /e2e << parameters.imageName >> sh -c "./node_modules/.bin/cypress install && ./node_modules/.bin/cypress run"
 
-                      if [[ "$(node -p process.arch)" == 'arm64' ]]; then
-                        echo "Chrome does not support arm64 yet, skipping"
-                        exit 0
-                      fi
-
-                      echo "Testing using Chrome browser"
-                      docker run -it -v $PWD:/e2e -w /e2e << parameters.imageName >> sh -c "./node_modules/.bin/cypress install && ./node_modules/.bin/cypress run --browser chrome"
-
     test-browser-image:
         description: Build a test image from browser image and test it
         parameters:


### PR DESCRIPTION
Fixes [#727](https://github.com/artem-pereverzev/cypress-docker-images/issues/727)

We should remove testing with chrome from checks for base image build PR