### PR TITLE
Increase default shm_size

### DIFF
--- a/scripts/generate-browser-image.js
+++ b/scripts/generate-browser-image.js
@@ -199,7 +199,7 @@ set e+x
 
 LOCAL_NAME=cypress/browsers:${folderName}
 echo "Building $LOCAL_NAME"
-docker build -t $LOCAL_NAME .
+docker build --shm-size 512M -t $LOCAL_NAME .
 `
 
 const buildFilename = path.join(outputFolder, "build.sh")


### PR DESCRIPTION
Fixes #308  

The default shared memory size for docker is 64M, this increases it to 512M.

# What is a good default size?

In a few places it appears to be 2GB that is the recommendation for browser testing

* https://lightrun.com/answers/cypress-io-cypress-cypress-hangs-during-execution-of-test-suite
* https://datawookie.dev/blog/2021/11/shared-memory-docker/


It appears that many cypress users have benefited from 512M https://github.com/cypress-io/cypress/issues/350#issuecomment-353572782 so I went with a smaller value. 