### PR TITLE
fix: add ps command

### DIFF
--- a/factory/.env
+++ b/factory/.env
@@ -11,7 +11,7 @@ BASE_IMAGE='debian:bullseye-slim'
 NODE_VERSION='16.18.1'
 
 # Update this to deploy the docker factory if you make changes to factory.Dockerfile or install scripts
-FACTORY_VERSION='1.0.1'
+FACTORY_VERSION='1.0.2'
 
 # Chrome versions: https://www.ubuntuupdates.org/package/google_chrome/stable/main/base/google-chrome-stable
 CHROME_VERSION='109.0.5414.74-1'

--- a/factory/CHANGELOG.md
+++ b/factory/CHANGELOG.md
@@ -1,0 +1,13 @@
+# Change log
+
+## 1.0.2
+
+* Fixed issue where the `ps` command was not included in the image. Fixed in [#819](https://github.com/cypress-io/cypress-docker-images/pull/819)
+
+## 1.0.1
+
+* Fixed issue where setting the `NODE_VERSION` arg value in the dockerfile would not override the default node version. Fixed in [#818](https://github.com/cypress-io/cypress-docker-images/pull/818)
+
+## 1.0.0
+
+* Initial Release of [cypress/factory](https://hub.docker.com/repository/docker/cypress/factory/general#)

--- a/factory/factory.Dockerfile
+++ b/factory/factory.Dockerfile
@@ -42,7 +42,7 @@ RUN ls -la /root \
     libgtk-3-0 \
     libgbm1 \
     libasound2 \
-    # Needed for ps support
+    # Needed to support the ps command, while not used by cypress directly it is used by some of our examples and the dependency is small (~1mb).
     procps \
     # Always install: Needed for dashboard integration
     git \

--- a/factory/factory.Dockerfile
+++ b/factory/factory.Dockerfile
@@ -42,6 +42,8 @@ RUN ls -la /root \
     libgtk-3-0 \
     libgbm1 \
     libasound2 \
+    # Needed for ps support
+    procps \
     # Always install: Needed for dashboard integration
     git \
     # Chrome and Edge require wget even after installation. We could do more work to dynamically remove it, but I doubt it's worth it.


### PR DESCRIPTION
The user in this PR https://github.com/cypress-io/cypress-docker-images/pull/809#issuecomment-1398748399 is requesting that we include the procps dependency to install the ps command. The `ps` command doesn't appear to be used by cypress directly for linux (it is used by in darwin), however we do use `ps` in the [start-server-and-test](https://github.com/bahmutov/start-server-and-test) example repo linked from our [docs](https://docs.cypress.io/guides/continuous-integration/introduction#Boot-your-server). [Previously](https://github.com/cypress-io/cypress-docker-images/pull/645) we added the `procps` dep to the base docker image.

When building out the cypress/factory docker container I specifically tried to only include dependencies used directly by cypress to minimize image size. In this case though I think we can offer an exception to that general rule. Installing the `procps` dep only increases the size of the cypress/factory image by 1 MB, which in comparison to our other dependencies (chrome/cypress) is minuscule. 