### PR TITLE
chore: update cypress version to 12.4.0 in factory/.env

### DIFF
--- a/factory/.env
+++ b/factory/.env
@@ -17,7 +17,7 @@ FACTORY_VERSION='1.0.2'
 CHROME_VERSION='109.0.5414.74-1'
 
 # Cypress versions: https://www.npmjs.com/package/cypress
-CYPRESS_VERSION='12.3.0'
+CYPRESS_VERSION='12.4.0'
 
 # Edge versions: https://packages.microsoft.com/repos/edge/pool/main/m/microsoft-edge-stable/
 EDGE_VERSION='109.0.1518.52-1'


### PR DESCRIPTION
Bumps cypress to `12.4.0` for `12.4.0` release