### PR TITLE
dep: don't remove curl

### DIFF
--- a/factory/.env
+++ b/factory/.env
@@ -11,7 +11,7 @@ BASE_IMAGE='debian:bullseye-slim'
 NODE_VERSION='16.18.1'
 
 # Update this to deploy the docker factory if you make changes to factory.Dockerfile or install scripts
-FACTORY_VERSION='1.0.2'
+FACTORY_VERSION='1.0.3'
 
 # Chrome versions: https://www.ubuntuupdates.org/package/google_chrome/stable/main/base/google-chrome-stable
 CHROME_VERSION='109.0.5414.74-1'

--- a/factory/factory.Dockerfile
+++ b/factory/factory.Dockerfile
@@ -44,13 +44,14 @@ RUN ls -la /root \
     libasound2 \
     # Needed to support the ps command, while not used by cypress directly it is used by some of our examples and the dependency is small (~1mb).
     procps \
+    # Needed to support curl, similar to ps, it's not directly used by cypress but leaving it in the container is practically free.
+    curl \
     # Always install: Needed for dashboard integration
     git \
     # Chrome and Edge require wget even after installation. We could do more work to dynamically remove it, but I doubt it's worth it.
     wget \
     # build only dependancies: removed in onbuild step
     bzip2 \
-    curl \
     gnupg \
     dirmngr
 
@@ -111,7 +112,6 @@ ONBUILD RUN node /opt/installScripts/cypress/install-cypress-version.js ${CYPRES
 # Global Cleanup
 ONBUILD RUN apt-get purge -y --auto-remove \
     bzip2 \
-    curl \
     gnupg \
     dirmngr\
   && rm -rf /usr/share/doc \


### PR DESCRIPTION
Users have requested use of the curl command. Typically we wouldn't add dependencies that aren't directly used by cypress, but upon investigation, not cleaning up the curl command adds less than a MB to the final package size.