### PR TITLE
Fix not able to open binary_state.json when running as node user

### DIFF
--- a/circle.yml
+++ b/circle.yml
@@ -289,7 +289,8 @@ workflows:
                             test-included-electron,
                             test-included-chrome,
                             test-included-firefox,
-                            test-included-edge
+                            test-included-edge,
+                            test-included-non-root-user,
                         ]
                         resourceClass: [medium]
                         target: [included]

--- a/factory/installScripts/cypress/default.sh
+++ b/factory/installScripts/cypress/default.sh
@@ -3,3 +3,8 @@
 # TODO: should typescript be versioned? Should it have it's own ARG for the factory?
 # Typescript is installed to allow testing of .ts spec files.
 npm install -g "cypress@${1}" typescript
+
+# Run cypress verify to create the binary_state.json file. The node user
+# has access to read /root/.cache/Cypress/<version>/binary_state.json but
+# not to write it
+cypress verify

--- a/factory/test-project/docker-compose.yml
+++ b/factory/test-project/docker-compose.yml
@@ -187,3 +187,12 @@ services:
       args:
         BASE_TEST_IMAGE: cypress/included:${INCLUDED_IMAGE_TAG}
     command: cypress run -b edge
+
+  test-included-non-root-user:
+    build:
+      dockerfile: included.nonroot.Dockerfile
+      context: .
+      args:
+        BASE_TEST_IMAGE: cypress/included:${INCLUDED_IMAGE_TAG}
+    user: node
+    command: cypress run

--- a/factory/test-project/included.nonroot.Dockerfile
+++ b/factory/test-project/included.nonroot.Dockerfile
@@ -1,0 +1,8 @@
+ARG BASE_TEST_IMAGE
+
+FROM ${BASE_TEST_IMAGE}
+RUN echo "current user: $(whoami)"
+ENV CI=1
+COPY . /opt/app
+WORKDIR /opt/app
+RUN chown -R node:node /opt/app


### PR DESCRIPTION
The first commit adds a test which reproduces the issue described in https://github.com/cypress-io/cypress-docker-images/issues/832#issuecomment-1424761568 specifically for the `node` user. The second commit adds `cypress verify` to the install so that the `binary_state.json` file exists and can be read by non-root users, since they cannot create the file if it does not exist.
