### PR TITLE
docs(factory): update docker-compose.yml configuration

### DIFF
--- a/factory/README.md
+++ b/factory/README.md
@@ -136,12 +136,12 @@ version: '3'
 
 services:
   test:
-    args:
-      CHROME_VERSION: '107.0.5304.121-1'
-      EDGE_VERSION: '100.0.1185.29-1'
-      FIREFOX_VERSION: '107.0'
     build:
       context: .
+      args:
+        CHROME_VERSION: '107.0.5304.121-1'
+        EDGE_VERSION: '100.0.1185.29-1'
+        FIREFOX_VERSION: '107.0'
     command: npm run test
 ```
 


### PR DESCRIPTION
## Issue
Running `docker compose up` using the configuration mentioned in the [`README.md`](https://github.com/cypress-io/cypress-docker-images/blob/master/factory/README.md#in-docker-composeyml) file, docker returns the following error:
```
services.test Additional property args is not allowed
```

Docker documentation refers that `args` are configuration options that are applied at build time.

## Changes
- Moved the `args` argument under the `build` attribute

## More information:
- https://docs.docker.com/compose/compose-file/compose-file-v3/#build