### PR TITLE
Bump Node.js 18.14.1

### DIFF
--- a/factory/.env
+++ b/factory/.env
@@ -8,7 +8,7 @@
 BASE_IMAGE='debian:bullseye-slim'
 
 # Node Versions: https://nodejs.org/en/download/releases/
-NODE_VERSION='16.18.1'
+NODE_VERSION='18.14.1'
 
 # Update this to deploy the docker factory if you make changes to factory.Dockerfile or install scripts
 FACTORY_VERSION='1.0.4'

--- a/factory/.env
+++ b/factory/.env
@@ -11,7 +11,7 @@ BASE_IMAGE='debian:bullseye-slim'
 NODE_VERSION='18.14.1'
 
 # Update this to deploy the docker factory if you make changes to factory.Dockerfile or install scripts
-FACTORY_VERSION='1.0.4'
+FACTORY_VERSION='2.0.0'
 
 # Chrome versions: https://www.ubuntuupdates.org/package/google_chrome/stable/main/base/google-chrome-stable
 CHROME_VERSION='110.0.5481.96-1'


### PR DESCRIPTION
Security update Node.js 18
https://nodejs.org/en/blog/vulnerability/february-2023-security-releases/