### PR TITLE
chore: bump cypress version to 12.8.1 and bump browsers to mirror latest

### DIFF
--- a/factory/.env
+++ b/factory/.env
@@ -14,16 +14,16 @@ NODE_VERSION='18.14.1'
 FACTORY_VERSION='2.0.0'
 
 # Chrome versions: https://www.ubuntuupdates.org/package/google_chrome/stable/main/base/google-chrome-stable
-CHROME_VERSION='110.0.5481.96-1'
+CHROME_VERSION='111.0.5563.64-1'
 
 # Cypress versions: https://www.npmjs.com/package/cypress
-CYPRESS_VERSION='12.8.0'
+CYPRESS_VERSION='12.8.1'
 
 # Edge versions: https://packages.microsoft.com/repos/edge/pool/main/m/microsoft-edge-stable/
-EDGE_VERSION='110.0.1587.41-1'
+EDGE_VERSION='111.0.1661.43-1'
 
 # Firefox versions: https://download-installer.cdn.mozilla.net/pub/firefox/releases/
-FIREFOX_VERSION='109.0'
+FIREFOX_VERSION='111.0'
 
 # Yarn versions: https://www.npmjs.com/package/yarn
 YARN_VERSION='1.22.19'


### PR DESCRIPTION
Bump the factory to Cypress `12.8.1` and update browsers to latest