### PR TITLE
chore: bump cypress to 12.9.0 and update browsers

### DIFF
--- a/factory/.env
+++ b/factory/.env
@@ -14,16 +14,16 @@ NODE_VERSION='18.14.1'
 FACTORY_VERSION='2.0.1'
 
 # Chrome versions: https://www.ubuntuupdates.org/package/google_chrome/stable/main/base/google-chrome-stable
-CHROME_VERSION='111.0.5563.110-1'
+CHROME_VERSION='111.0.5563.146-1'
 
 # Cypress versions: https://www.npmjs.com/package/cypress
-CYPRESS_VERSION='12.8.1'
+CYPRESS_VERSION='12.9.0'
 
 # Edge versions: https://packages.microsoft.com/repos/edge/pool/main/m/microsoft-edge-stable/
-EDGE_VERSION='111.0.1661.51-1'
+EDGE_VERSION='111.0.1661.54-1'
 
 # Firefox versions: https://download-installer.cdn.mozilla.net/pub/firefox/releases/
-FIREFOX_VERSION='111.0'
+FIREFOX_VERSION='111.0.1'
 
 # Yarn versions: https://www.npmjs.com/package/yarn
 YARN_VERSION='1.22.19'


### PR DESCRIPTION
updates the docker factory (currently failing since version does not exist)