### PR TITLE
fix: Missing git binary

### DIFF
--- a/circle.yml
+++ b/circle.yml
@@ -124,7 +124,7 @@ jobs:
             - run:
                   name: check git version
                   command: |
-                    ACTUAL_VERSION=$(docker compose run test-factory-all-included git -v)
+                    ACTUAL_VERSION=$(docker compose run test-factory-all-included git --version)
                     TRIMMED_ACTUAL_VERSION=$(echo ${ACTUAL_VERSION} | sed -e 's/ Cypress binary version:.*$//g')
                     if [  "git version 2.30.2" != "${ACTUAL_VERSION}" ]; then
                       echo "Version mismatch, git package version: git version 2.30.2 != ${TRIMMED_ACTUAL_VERSION}"

--- a/circle.yml
+++ b/circle.yml
@@ -116,7 +116,18 @@ jobs:
                     ACTUAL_VERSION=$(docker compose run test-factory-all-included cypress -v)
                     TRIMMED_ACTUAL_VERSION=$(echo ${ACTUAL_VERSION} | sed -e 's/ Cypress binary version:.*$//g')
                     if [  "Cypress package version: ${CYPRESS_VERSION}" != "${TRIMMED_ACTUAL_VERSION}" ]; then
-                      echo "NodeVersion mismatch, Cypress package version: ${CYPRESS_VERSION} != ${TRIMMED_ACTUAL_VERSION}"
+                      echo "Version mismatch, Cypress package version: ${CYPRESS_VERSION} != ${TRIMMED_ACTUAL_VERSION}"
+                      exit 1;
+                    fi
+                    echo "Version ${ACTUAL_VERSION} confirmed"
+                  working_directory: factory/test-project
+            - run:
+                  name: check git version
+                  command: |
+                    ACTUAL_VERSION=$(docker compose run test-factory-all-included git -v)
+                    TRIMMED_ACTUAL_VERSION=$(echo ${ACTUAL_VERSION} | sed -e 's/ Cypress binary version:.*$//g')
+                    if [  "git version 2.30.2" != "${ACTUAL_VERSION}" ]; then
+                      echo "Version mismatch, git package version: git version 2.30.2 != ${TRIMMED_ACTUAL_VERSION}"
                       exit 1;
                     fi
                     echo "Version ${ACTUAL_VERSION} confirmed"

--- a/circle.yml
+++ b/circle.yml
@@ -125,7 +125,6 @@ jobs:
                   name: check git version
                   command: |
                     ACTUAL_VERSION=$(docker compose run test-factory-all-included git --version)
-                    TRIMMED_ACTUAL_VERSION=$(echo ${ACTUAL_VERSION} | sed -e 's/ Cypress binary version:.*$//g')
                     if [  "git version 2.30.2" != "${ACTUAL_VERSION}" ]; then
                       echo "Version mismatch, git package version: git version 2.30.2 != ${TRIMMED_ACTUAL_VERSION}"
                       exit 1;

--- a/circle.yml
+++ b/circle.yml
@@ -126,7 +126,7 @@ jobs:
                   command: |
                     ACTUAL_VERSION=$(docker compose run test-factory-all-included git --version)
                     if [  "git version 2.30.2" != "${ACTUAL_VERSION}" ]; then
-                      echo "Version mismatch, git package version: git version 2.30.2 != ${TRIMMED_ACTUAL_VERSION}"
+                      echo "Version mismatch, git package version: git version 2.30.2 != ${ACTUAL_VERSION}"
                       exit 1;
                     fi
                     echo "Version ${ACTUAL_VERSION} confirmed"

--- a/factory/.env
+++ b/factory/.env
@@ -11,7 +11,7 @@ BASE_IMAGE='debian:bullseye-slim'
 NODE_VERSION='18.14.1'
 
 # Update this to deploy the docker factory if you make changes to factory.Dockerfile or install scripts
-FACTORY_VERSION='2.0.1'
+FACTORY_VERSION='2.0.2'
 
 # Chrome versions: https://www.ubuntuupdates.org/package/google_chrome/stable/main/base/google-chrome-stable
 CHROME_VERSION='111.0.5563.146-1'

--- a/factory/.env
+++ b/factory/.env
@@ -20,7 +20,7 @@ CHROME_VERSION='111.0.5563.146-1'
 CYPRESS_VERSION='12.9.0'
 
 # Edge versions: https://packages.microsoft.com/repos/edge/pool/main/m/microsoft-edge-stable/
-EDGE_VERSION='111.0.1661.54-1'
+EDGE_VERSION='111.0.1661.62-1'
 
 # Firefox versions: https://download-installer.cdn.mozilla.net/pub/firefox/releases/
 FIREFOX_VERSION='111.0.1'

--- a/factory/CHANGELOG.md
+++ b/factory/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Change log
 
+## 2.0.2
+
+* Git was accidentally removed. Addressed in [#855](https://github.com/cypress-io/cypress-docker-images/pull/874)
+
 ## 2.0.1
 
 * Removed the curl dependency to remove critical vulnerability. Addressed in [#855](https://github.com/cypress-io/cypress-docker-images/pull/855)

--- a/factory/factory.Dockerfile
+++ b/factory/factory.Dockerfile
@@ -112,8 +112,6 @@ ONBUILD RUN node /opt/installScripts/cypress/install-cypress-version.js ${CYPRES
 # Global Cleanup
 ONBUILD RUN apt-get purge -y --auto-remove \
     curl \
-    libcurl4 \
-    libcurl3-gnutls \
     bzip2 \
     gnupg \
     dirmngr\


### PR DESCRIPTION
We accidentally removed the git binary from the images. This restores the binary and adds a test to make sure we don't lose it again.

affected packages will be re-released

* cypress/browsers:node-18.14.1-chrome-111.0.5563.110-1-ff-111.0-edge-111.0.1661.51-1
* cypress/browsers:node-18.14.1-chrome-111.0.5563.146-1-ff-111.0.1-edge-111.0.1661.54-1
* cypress/included:cypress-12.8.1-node-18.14.1-chrome-111.0.5563.110-1-ff-111.0-edge-111.0.1661.51-1
* cypress/included:cypress-12.9.0-node-18.14.1-chrome-111.0.5563.146-1-ff-111.0.1-edge-111.0.1661.54-1
* cypress/included:12.9.0