### PR TITLE
Update factory install scripts to check for supported arch

### DIFF
--- a/factory/.env
+++ b/factory/.env
@@ -11,7 +11,7 @@ BASE_IMAGE='debian:bullseye-slim'
 NODE_VERSION='18.14.1'
 
 # Update this to deploy the docker factory if you make changes to factory.Dockerfile or install scripts
-FACTORY_VERSION='2.0.2'
+FACTORY_VERSION='2.0.3'
 
 # Chrome versions: https://www.ubuntuupdates.org/package/google_chrome/stable/main/base/google-chrome-stable
 CHROME_VERSION='111.0.5563.146-1'

--- a/factory/CHANGELOG.md
+++ b/factory/CHANGELOG.md
@@ -1,8 +1,12 @@
 # Change log
 
+## 2.0.3
+
+* Updated browser install scripts to explicitly check for supported platforms instead of subset of unsupported platforms. Addressed in [#875](https://github.com/cypress-io/cypress-docker-images/pull/875)
+
 ## 2.0.2
 
-* Git was accidentally removed. Addressed in [#855](https://github.com/cypress-io/cypress-docker-images/pull/874)
+* Git was accidentally removed. Addressed in [#874](https://github.com/cypress-io/cypress-docker-images/pull/874)
 
 ## 2.0.1
 

--- a/factory/installScripts/chrome/install-chrome-version.js
+++ b/factory/installScripts/chrome/install-chrome-version.js
@@ -8,8 +8,8 @@ if (!chromeVersion) {
   return
 }
 
-if (process.arch === 'arm64') {
-  console.log('Not downloading Chrome since we are on arm64: https://crbug.com/677140')
+if (process.arch !== 'x64') {
+  console.log('Not downloading Chrome since we are not on x64. For arm64 status see https://crbug.com/677140')
   return;
 }
 

--- a/factory/installScripts/edge/install-edge-version.js
+++ b/factory/installScripts/edge/install-edge-version.js
@@ -8,8 +8,8 @@ if (!edgeVersion) {
   return
 }
 
-if (process.arch === 'arm64') {
-  console.log('Not downloading Edge since we are on arm64: https://techcommunity.microsoft.com/t5/discussions/edge-for-linux-arm64/m-p/1532272')
+if (process.arch !== 'x64') {
+  console.log('Not downloading Edge since we are not on x64. For arm64 status see https://techcommunity.microsoft.com/t5/discussions/edge-for-linux-arm64/m-p/1532272')
   return;
 }
 

--- a/factory/installScripts/firefox/install-firefox-version.js
+++ b/factory/installScripts/firefox/install-firefox-version.js
@@ -8,8 +8,8 @@ if (!firefoxVersion) {
   return
 }
 
-if (process.arch === 'arm64') {
-  console.log('Not downloading Firefox since we are on arm64: https://bugzilla.mozilla.org/show_bug.cgi?id=1678342')
+if (process.arch !== 'x64') {
+  console.log('Not downloading Firefox since we are not on x64. For arm64 status see https://bugzilla.mozilla.org/show_bug.cgi?id=1678342')
   return
 }
 

--- a/factory/installScripts/webkit/install-webkit-version.js
+++ b/factory/installScripts/webkit/install-webkit-version.js
@@ -8,9 +8,8 @@ if (!webkitVersion) {
   return
 }
 
-// TODO: Verify that we don't have an arm64 version of webkit
-if (process.arch === 'arm64') {
-  console.log('Not downloading Webkit since we are on arm64')
+if (!['arm64', 'x64'].includes(process.arch)) {
+  console.log(`Not downloading Webkit since we are on ${process.arch}`)
   return;
 }
 


### PR DESCRIPTION
https://github.com/cypress-io/cypress-docker-images/issues/867

Prior to this change the install scripts explicitly check for arm64 arch and short-circuit on the browser install scripts since there are no linux/arm64 binaries available. However, this assumes that the only other target arch is x64, preventing the image from being successfully build on other platforms. For example, the node install script supports a variety of architectures, including ppc64le, s390x, etc.

Update the install scripts to check for supported platforms instead, this is mostly x64, with the exception being webkit which is available on both x64 and arm64. For all other values, short-circuit as before.

This means that the factory image can now be built for additional platforms using docker buildx for example without running into errors due to missing browser binaries.