### PR TITLE
feat: add ssh

### DIFF
--- a/circle.yml
+++ b/circle.yml
@@ -130,6 +130,12 @@ jobs:
                     fi
                     echo "Version ${ACTUAL_VERSION} confirmed"
                   working_directory: factory/test-project
+            - run:
+                  name: check ssh version # We don't really care what version ssh has as long as the command doesn't error
+                  command: |
+                    ACTUAL_VERSION=$(docker compose run test-factory-all-included ssh -V)
+                    echo "Version ${ACTUAL_VERSION} confirmed"
+                  working_directory: factory/test-project
     check-node-override-version:
         machine:
             image: ubuntu-2204:2022.10.2

--- a/factory/.env
+++ b/factory/.env
@@ -14,7 +14,7 @@ FACTORY_DEFAULT_NODE_VERSION='18.15.0'
 NODE_VERSION="${FACTORY_DEFAULT_NODE_VERSION}"
 
 # Update this to deploy the docker factory if you make changes to factory.Dockerfile or install scripts
-FACTORY_VERSION='2.1.0'
+FACTORY_VERSION='2.2.0'
 
 # Chrome versions: https://www.ubuntuupdates.org/package/google_chrome/stable/main/base/google-chrome-stable
 CHROME_VERSION='111.0.5563.146-1'

--- a/factory/CHANGELOG.md
+++ b/factory/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Change log
 
+## 2.2.0
+
+* Install ssh client to enable get cloning via ssh without falling back to CI's native get client. Addressed in [#880](https://github.com/cypress-io/cypress-docker-images/pull/880)
+
 ## 2.1.0
 
 * Updated default node version from `18.14.1` to `18.15.0`. Addressed in [#866](https://github.com/cypress-io/cypress-docker-images/pull/866)

--- a/factory/CHANGELOG.md
+++ b/factory/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## 2.2.0
 
-* Install ssh client to enable get cloning via ssh without falling back to CI's native get client. Addressed in [#880](https://github.com/cypress-io/cypress-docker-images/pull/880)
+* Install ssh client to enable git cloning via ssh without falling back to CI's native git client. Addressed in [#880](https://github.com/cypress-io/cypress-docker-images/pull/880)
 
 ## 2.1.0
 

--- a/factory/factory.Dockerfile
+++ b/factory/factory.Dockerfile
@@ -48,7 +48,7 @@ RUN ls -la /root \
     curl \
     # Always install: Needed for dashboard integration
     git \
-    # Install ssh for to enable get cloning via ssh without falling back to CI's native get client
+    # Install ssh client to enable git cloning via ssh without falling back to CI's native git client.
     openssh-client\
     # Chrome and Edge require wget even after installation. We could do more work to dynamically remove it, but I doubt it's worth it.
     wget \

--- a/factory/factory.Dockerfile
+++ b/factory/factory.Dockerfile
@@ -48,6 +48,8 @@ RUN ls -la /root \
     curl \
     # Always install: Needed for dashboard integration
     git \
+    # Install ssh for to enable get cloning via ssh without falling back to CI's native get client
+    openssh-client\
     # Chrome and Edge require wget even after installation. We could do more work to dynamically remove it, but I doubt it's worth it.
     wget \
     # build only dependancies: removed in onbuild step


### PR DESCRIPTION
Install ssh client to enable git cloning via ssh without falling back to CI's native git client

Fixes: #846