### PR TITLE
chore: update image for release 12.11.0

### DIFF
--- a/factory/.env
+++ b/factory/.env
@@ -20,7 +20,7 @@ FACTORY_VERSION='2.3.0'
 CHROME_VERSION='112.0.5615.121-1'
 
 # Cypress versions: https://www.npmjs.com/package/cypress
-CYPRESS_VERSION='12.10.0'
+CYPRESS_VERSION='12.11.0'
 
 # Edge versions: https://packages.microsoft.com/repos/edge/pool/main/m/microsoft-edge-stable/
 EDGE_VERSION='112.0.1722.48-1'


### PR DESCRIPTION
This PR updates the `factory/.env` file to use `12.11.0`