### PR TITLE
docs: set package.json license to MIT

### DIFF
--- a/package.json
+++ b/package.json
@@ -26,7 +26,7 @@
   },
   "keywords": [],
   "author": "Cypress-io",
-  "license": "ISC",
+  "license": "MIT",
   "bugs": {
     "url": "https://github.com/cypress-io/cypress-docker-images/issues"
   },


### PR DESCRIPTION
This PR corrects the `license` field in [package.json](https://github.com/MikeMcC399/cypress-docker-images/blob/master/package.json) to read `MIT` (instead of `ISC`) to align with the [README > License](https://github.com/MikeMcC399/cypress-docker-images/blob/master/README.md#license) section reference to the MIT [LICENSE](https://github.com/MikeMcC399/cypress-docker-images/blob/master/LICENSE) file.
