### PR TITLE
Update README.md to talk about non-root user for firefox per #938 in the github-action repo

### DIFF
--- a/README.md
+++ b/README.md
@@ -77,6 +77,44 @@ export _MITSHM=0
 
 See [issue #270](https://github.com/cypress-io/cypress-docker-images/issues/270)
 
+## Firefox doesn't work with root user
+
+By default, the containers run with the root user. However, Firefox by design cannot run with root user, leading to failures such as the cypress application claiming firefox is not installed when it is. 
+
+To resolve this, the container needs to run with user id `1001`. 
+
+One example using the [cypress-io/github-action](https://github.com/cypress-io/github-action)
+
+```yml
+name: E2E in custom container
+on: push
+jobs:
+  cypress-run:
+    runs-on: ubuntu-22.04
+    container: 
+     image: cypress/browsers:node18.12.0-chrome106-ff106
+     options: --user 1001  
+    steps:
+      - uses: actions/checkout@v3
+      - uses: cypress-io/github-action@v5
+        with:
+          browser: firefox
+```
+
+Or within a Dockerfile
+
+```Dockerfile
+# Use Cypress base image
+FROM cypress/browsers:node18.12.0-chrome106-ff106
+
+# Change to a non-root user
+USER 1001
+
+#rest of your dockerfile here
+```
+
+See [issue #871](https://github.com/cypress-io/cypress-docker-images/issues/871) for more details.
+
 ## Contributing
 
 See [CONTRIBUTING.md](CONTRIBUTING.md)

--- a/README.md
+++ b/README.md
@@ -79,7 +79,12 @@ See [issue #270](https://github.com/cypress-io/cypress-docker-images/issues/270)
 
 ## Firefox doesn't work with root user
 
-By default, the containers run with the root user. However, Firefox by design cannot run with root user, leading to failures such as the cypress application claiming firefox is not installed when it is. 
+By default, the containers run with the root user. However, Firefox by design cannot run with root user, leading to failures such as:
+
+```
+Browser: firefox was not found on your system or is not supported by Cypress.
+Can't run because you've entered an invalid browser name.
+```
 
 To resolve this, the container needs to run with user id `1001`. 
 

--- a/README.md
+++ b/README.md
@@ -77,7 +77,7 @@ export _MITSHM=0
 
 See [issue #270](https://github.com/cypress-io/cypress-docker-images/issues/270)
 
-## Firefox doesn't work with root user
+## Firefox not found
 
 By default, the containers run with the root user. However, Firefox by design cannot run with root user, leading to failures such as:
 

--- a/README.md
+++ b/README.md
@@ -134,7 +134,7 @@ USER 1001
 #rest of your dockerfile here
 ```
 
-See [issue #871](https://github.com/cypress-io/cypress-docker-images/issues/871) for more details.
+The [GitHub Actions Runner](https://github.com/actions/runner) creates the `/github/home` (`$HOME`) directory with non-root ownership `1001` (`runner`). Specifying this same user allows Cypress to detect and run Firefox.
 
 ## Contributing
 


### PR DESCRIPTION
Per the discussion [here](https://github.com/cypress-io/github-action/pull/938)

And [here](https://github.com/cypress-io/cypress-docker-images/issues/871)

I have been asked to move my changes from the first link into this PR here to help others troubleshoot potential issues when using firefox in these images.