### PR TITLE
chore: cypress v12.15.0 release updates

### DIFF
--- a/factory/.env
+++ b/factory/.env
@@ -17,16 +17,16 @@ NODE_VERSION="${FACTORY_DEFAULT_NODE_VERSION}"
 FACTORY_VERSION='2.3.0'
 
 # Chrome versions: https://www.ubuntuupdates.org/package/google_chrome/stable/main/base/google-chrome-stable
-CHROME_VERSION='113.0.5672.92-1'
+CHROME_VERSION='114.0.5735.133-1'
 
 # Cypress versions: https://www.npmjs.com/package/cypress
-CYPRESS_VERSION='12.14.0'
+CYPRESS_VERSION='12.15.0'
 
 # Edge versions: https://packages.microsoft.com/repos/edge/pool/main/m/microsoft-edge-stable/
-EDGE_VERSION='113.0.1774.35-1'
+EDGE_VERSION='114.0.1823.51-1'
 
 # Firefox versions: https://download-installer.cdn.mozilla.net/pub/firefox/releases/
-FIREFOX_VERSION='113.0'
+FIREFOX_VERSION='114.0.2'
 
 # Yarn versions: https://www.npmjs.com/package/yarn
 YARN_VERSION='1.22.19'


### PR DESCRIPTION
This PR updates the factory/.env file to use Cypress v12.15.0 and newest browser versions.