### PR TITLE
bump node version due to node update

### DIFF
--- a/factory/.env
+++ b/factory/.env
@@ -8,7 +8,7 @@
 BASE_IMAGE='debian:bullseye-slim'
 
 # Node Versions: https://nodejs.org/en/download/releases/
-FACTORY_DEFAULT_NODE_VERSION='18.16.0'
+FACTORY_DEFAULT_NODE_VERSION='20.3.1'
 
 # Node Versions: https://nodejs.org/en/download/releases/
 NODE_VERSION="${FACTORY_DEFAULT_NODE_VERSION}"

--- a/factory/.env
+++ b/factory/.env
@@ -14,7 +14,7 @@ FACTORY_DEFAULT_NODE_VERSION='20.3.1'
 NODE_VERSION="${FACTORY_DEFAULT_NODE_VERSION}"
 
 # Update this to deploy the docker factory if you make changes to factory.Dockerfile or install scripts
-FACTORY_VERSION='2.3.0'
+FACTORY_VERSION='2.4.0'
 
 # Chrome versions: https://www.ubuntuupdates.org/package/google_chrome/stable/main/base/google-chrome-stable
 CHROME_VERSION='114.0.5735.133-1'

--- a/factory/CHANGELOG.md
+++ b/factory/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Change log
 
+## 2.4.0
+
+* Updated default node version from `18.16.0` to `20.3.1`. Addressed in [#905](https://github.com/cypress-io/cypress-docker-images/pull/905)
+
 ## 2.3.0
 
 * Updated default node version from `18.15.0` to `18.16.0`. Addressed in [#881](https://github.com/cypress-io/cypress-docker-images/pull/881)


### PR DESCRIPTION
Security update Node.js 20
https://nodejs.org/en/blog/vulnerability/june-2023-security-releases