### PR TITLE
chore: 12.16.0 release

### DIFF
--- a/factory/.env
+++ b/factory/.env
@@ -20,7 +20,7 @@ FACTORY_VERSION='2.3.0'
 CHROME_VERSION='114.0.5735.133-1'
 
 # Cypress versions: https://www.npmjs.com/package/cypress
-CYPRESS_VERSION='12.15.0'
+CYPRESS_VERSION='12.16.0'
 
 # Edge versions: https://packages.microsoft.com/repos/edge/pool/main/m/microsoft-edge-stable/
 EDGE_VERSION='114.0.1823.51-1'


### PR DESCRIPTION
Use Cypress 12.16.0 as default