### PR TITLE
docs: remove outdated base/README latest tag reference

### DIFF
--- a/base/README.md
+++ b/base/README.md
@@ -6,8 +6,6 @@
 
 Each tag is in a sub folder, named after Node version or OS it is built on.
 
-Image `cypress/base:12` is tagged [`latest`](https://hub.docker.com/r/cypress/base/tags/)
-
 > **Note** All Base Images install the latest versions of NPM & Yarn.
 
 | Name + Tag                        | Node    | Operating System | Link                                         | NPM version | Yarn version | Notes       |
@@ -79,7 +77,7 @@ Image `cypress/base:12` is tagged [`latest`](https://hub.docker.com/r/cypress/ba
 | cypress/base:ubuntu16-12.13.1     | 12.13.1 | Ubuntu           | [/ubuntu16-12.13.1](ubuntu16-12.13.1)        | 6.12.1      | 🚫           |
 | cypress/base:ubuntu18-node12.14.1 | 12.14.1 | Ubuntu 18.04.3   | [ubuntu18-node12.14.1](ubuntu18-node12.14.1) | 6.13.6      | 1.21.1       |
 | cypress/base:ubuntu19-node12.14.1 | 12.14.1 | Ubuntu 19.0.4    | [ubuntu19-node12.14.1](ubuntu19-node12.14.1) | 6.13.6      | 1.21.1       |
-| cypress/base:manjaro-node14.12.0  | 14.12.0 | Manjaro          | [manjaro-14.12.0](manjaro-14.12.0)           | 6.14.8      | 1.22.10      | 
+| cypress/base:manjaro-node14.12.0  | 14.12.0 | Manjaro          | [manjaro-14.12.0](manjaro-14.12.0)           | 6.14.8      | 1.22.10      |
 | cypress/base:14.19.0              | 14.19.0 | Debian           | [/14.19.0](14.19.0)                          | 6.14.16     | 1.22.17      |
 | cypress/base:16.14.0-slim | 16.14.0 | Debian | [/16.14.0](16.14.0) | `🚫` | `🚫` | `🚫` |
 | cypress/base:17.8.0 | 17.8.0 | Debian | [/17.8.0](17.8.0) | `🚫` | `🚫` | `🚫` |


### PR DESCRIPTION
This PR removes an outdated statement in [base/README.md](https://github.com/cypress-io/cypress-docker-images/blob/master/base/README.md)

- Image `cypress/base:12` is tagged [`latest`](https://hub.docker.com/r/cypress/base/tags/)

which is no longer true. The tag `latest` is used for the literal latest version. For example at the time of writing:

- [cypress/base:18.16.0](https://hub.docker.com/layers/cypress/base/18.16.0/images/sha256-d00c441748e2f1b79d4002bddafe6628f9f9f5458a8a3c66697e622600dc5ad5) is tagged [cypress/base:latest](https://hub.docker.com/layers/cypress/base/latest/images/sha256-d00c441748e2f1b79d4002bddafe6628f9f9f5458a8a3c66697e622600dc5ad5).