### PR TITLE
docs: rework README references to tags and version

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,7 +29,9 @@ Some examples with specific tags including an explanation of the tag meanings ar
 - [cypress/included:12.17.1](https://hub.docker.com/layers/cypress/included/12.17.1/images/sha256-5d541ff206ed28631e720f8fe98dcadf5c62f8e194c028715fb748e564c8c0cc)
     Cypress `12.17.1`
 
-Once an image has been published to [Cypress on Docker Hub](https://hub.docker.com/u/cypress) it is frozen. We will never overwrite the existing Docker images to prevent accidental changes.
+Once an image with a specific version tag (except `latest`) has been published to [Cypress on Docker Hub](https://hub.docker.com/u/cypress) it is frozen. This prevents accidental changes.
+
+When a new version is published, an image copy with the `latest` tag is also published. This means that the Docker image selected using the `latest` tag (or selected by default if no tag is specified) will also change over time. Specify an explicit version, for example [cypress/base:18.16.0](https://hub.docker.com/layers/cypress/base/18.16.0/images/sha256-d00c441748e2f1b79d4002bddafe6628f9f9f5458a8a3c66697e622600dc5ad5), to access instead a frozen version.
 
 >📍Cypress Docker images are offered as a convenience measure. The goal is to offer Node.js, Browser and Cypress versions to streamline running tests in CI or other non-public, sandboxed environments.
 >

--- a/README.md
+++ b/README.md
@@ -1,31 +1,45 @@
 # Cypress Docker Images [![CircleCI](https://circleci.com/gh/cypress-io/cypress-docker-images/tree/master.svg?style=svg)](https://circleci.com/gh/cypress-io/cypress-docker-images/tree/master)
 
+Cypress Docker images are published to [Cypress on Docker Hub](https://hub.docker.com/u/cypress).
+
 These images provide all of the required dependencies for running Cypress in Docker.
 
-We build four images, click on the image name to see the available tags and versions.
+We build four images: click on the image name to see the available tags and versions. We provide multiple tags for various operating systems and specific browser versions. These allow you to target specific combinations you need.
 
-| Image                                                          | Default                     | Description                                                                        | Monthly pulls                                                                                                                         |
-| -------------------------------------------------------------- | --------------------------- | ---------------------------------------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------- |
-| [cypress/factory](https://hub.docker.com/r/cypress/factory/)   | `cypress/factory:1.0.0`    | A base image template which can be used with ARGs to create a custom docker image. | [![Docker Pulls](https://img.shields.io/docker/pulls/cypress/factory.svg?maxAge=604800)](https://hub.docker.com/r/cypress/factory/)   |
-| [cypress/base](https://hub.docker.com/r/cypress/base/)         | `cypress/base:16.13.0`      | All operating system dependencies, no Cypress, and no browsers.                    | [![Docker Pulls](https://img.shields.io/docker/pulls/cypress/base.svg?maxAge=604800)](https://hub.docker.com/r/cypress/base/)         |
-| [cypress/browsers](https://hub.docker.com/r/cypress/browsers/) | `cypress/browsers:chrome69` | All operating system dependencies, no Cypress, and some browsers.                               | [![Docker Pulls](https://img.shields.io/docker/pulls/cypress/browsers.svg?maxAge=604800)](https://hub.docker.com/r/cypress/browsers/) |
-| [cypress/included](https://hub.docker.com/r/cypress/included/) | `cypress/included:9.4.1`    | All operating system dependencies, Cypress, and some browsers installed globally.  | [![Docker Pulls](https://img.shields.io/docker/pulls/cypress/included.svg?maxAge=604800)](https://hub.docker.com/r/cypress/included/) |
+| Image Name                                                     | Description                                                                        | Monthly pulls                                                                                                                         |
+| -------------------------------------------------------------- | ---------------------------------------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------- |
+| [cypress/factory](https://hub.docker.com/r/cypress/factory/)   | A base image template which can be used with ARGs to create a custom docker image. | [![Docker Pulls](https://img.shields.io/docker/pulls/cypress/factory.svg?maxAge=604800)](https://hub.docker.com/r/cypress/factory/)   |
+| [cypress/base](https://hub.docker.com/r/cypress/base/)         | All operating system dependencies, no Cypress, and no browsers.                    | [![Docker Pulls](https://img.shields.io/docker/pulls/cypress/base.svg?maxAge=604800)](https://hub.docker.com/r/cypress/base/)         |
+| [cypress/browsers](https://hub.docker.com/r/cypress/browsers/) | All operating system dependencies, no Cypress, and some browsers.                  | [![Docker Pulls](https://img.shields.io/docker/pulls/cypress/browsers.svg?maxAge=604800)](https://hub.docker.com/r/cypress/browsers/) |
+| [cypress/included](https://hub.docker.com/r/cypress/included/) | All operating system dependencies, Cypress, and some browsers installed globally.  | [![Docker Pulls](https://img.shields.io/docker/pulls/cypress/included.svg?maxAge=604800)](https://hub.docker.com/r/cypress/included/) |
 
-Of these images, we provide multiple tags for various operating systems and specific browser versions. These allow you to target specific combinations you need.
+## Tag Selection
 
-## Best practice
+If no tag is specified, for example `cypress/included`, then the tag `latest` is used by default: `cypress/included:latest`. It is however recommended to use a specific image tag to avoid breaking changes when new images are released, especially when they include new major versions of Node.js or Cypress.
 
-It is recommended to use a specific image tag, and not rely on the `default` tag. For example, it is better to use `cypress/base:12` than `cypress/base`. Even better it is to use full version of the image, like `cypress/base:12.18.0` - we will never overwrite the existing Docker images to prevent accidental changes.
+Some examples with specific tags including an explanation of the tag meanings are:
 
->📍Cypress Docker images are offered as a convenience measure. The goal is to offer Node, Browser and Cypress versions to streamline running tests in CI or other non-public, sandboxed environments.
+- [cypress/base:18.16.0](https://hub.docker.com/layers/cypress/base/18.16.0/images/sha256-d00c441748e2f1b79d4002bddafe6628f9f9f5458a8a3c66697e622600dc5ad5)
+    Node.js `18.16.0`
+- [cypress/browsers:node-18.16.0-chrome-114.0.5735.133-1-ff-114.0.2-edge-114.0.1823.51-1](https://hub.docker.com/layers/cypress/browsers/node-18.16.0-chrome-114.0.5735.133-1-ff-114.0.2-edge-114.0.1823.51-1/images/sha256-e4c1a47c8107c37ca47398d8936743965d871c7285f58b852d5cb2658c400922)
+    Node.js `18.16.0`
+    Chrome `114.0.5735.133-1`
+    Firefox `114.0.2`
+    Edge `114.0.1823.51-1`
+- [cypress/included:12.17.1](https://hub.docker.com/layers/cypress/included/12.17.1/images/sha256-5d541ff206ed28631e720f8fe98dcadf5c62f8e194c028715fb748e564c8c0cc)
+    Cypress `12.17.1`
+
+Once an image has been published to [Cypress on Docker Hub](https://hub.docker.com/u/cypress) it is frozen. We will never overwrite the existing Docker images to prevent accidental changes.
+
+>📍Cypress Docker images are offered as a convenience measure. The goal is to offer Node.js, Browser and Cypress versions to streamline running tests in CI or other non-public, sandboxed environments.
 >
 > Some preparations and optimizations are not included. For example, given the near infinite permutations, images are not monitored for security vulnerabilities. Additionally, once images are published they are considered immutable and cannot be patched. That means (hypothetically) older images could become more vulnerable over time.
 >
 > This means they should **not** be used for production deployment and security scans should be performed as-needed by users of these images.
 
-## DockerHub
+## Docker Hub
 
-All of the images and tags are published to DockerHub under
+All of the images and tags are published to [Cypress on Docker Hub](https://hub.docker.com/u/cypress) under:
 
 - [https://hub.docker.com/r/cypress/factory](https://hub.docker.com/r/cypress/factory)
 - [https://hub.docker.com/r/cypress/base](https://hub.docker.com/r/cypress/base)
@@ -34,11 +48,11 @@ All of the images and tags are published to DockerHub under
 
 ## Cypress/Factory
 
-Don't see the exact combination of cypress, node and browser versions you need for your test environment? Checkout our [cypress/factory](factory). You can use it to generate a custom image to fit your needs.
+Don't see the exact combination of Cypress, Node.js and browser versions you need for your test environment? Checkout our [cypress/factory](factory). You can use it to generate a custom image to fit your needs.
 
 ## Examples
 
-These images have all dependencies necessary to install and run Cypress. Just install your NPM dependencies (including Cypress) and run the tests. We utilize many of these docker images in our own projects, with different CI providers.
+These images have all dependencies necessary to install and run Cypress. Just install your npm dependencies (including Cypress) and run the tests. We utilize many of these docker images in our own projects, with different CI providers.
 
 [Check out our docs for examples.](https://on.cypress.io/docker)
 
@@ -53,7 +67,7 @@ If you want to use the `cypress/included` image, read [Run Cypress with a single
 
 ### Cannot run post-install hook
 
-Some versions of Node restrict running the `postinstall` hook with the following error message:
+Some versions of Node.js restrict running the `postinstall` hook with the following error message:
 
 ```text
 lifecycle realworld@1.0.0~postinstall: cannot run in wd realworld@1.0.0


### PR DESCRIPTION
closes #913

This PR updates the main [README](https://github.com/cypress-io/cypress-docker-images/blob/master/README.md) file which previously listed outdated versions as being default. It reworks these sections and provides some other corrections and improvements.

The outdated "Default" column has been removed. Instead a separate example list is provided which does not need to be updated on every release. It serves as a relatively recent list of example tagged images and explains the meanings of the tags.

It also aligns some naming according to website reference documentation conventions:

- NPM => npm (see https://docs.npmjs.com/)
- Dockerhub => Docker Hub (see https://docs.docker.com/docker-hub/)
- Node => Node.js (see https://nodejs.org/en/docs)

cc: @mjhenkes 