### PR TITLE
BREAKING CHANGE: factory to use nodejs v20

### DIFF
--- a/factory/.env
+++ b/factory/.env
@@ -8,13 +8,13 @@
 BASE_IMAGE='debian:bullseye-slim'
 
 # Node Versions: https://nodejs.org/en/download/releases/
-FACTORY_DEFAULT_NODE_VERSION='18.16.1'
+FACTORY_DEFAULT_NODE_VERSION='20.5.0'
 
 # Node Versions: https://nodejs.org/en/download/releases/
 NODE_VERSION="${FACTORY_DEFAULT_NODE_VERSION}"
 
 # Update this to deploy the docker factory if you make changes to factory.Dockerfile or install scripts
-FACTORY_VERSION='2.4.0'
+FACTORY_VERSION='3.0.0'
 
 # Chrome versions: https://www.ubuntuupdates.org/package/google_chrome/stable/main/base/google-chrome-stable
 CHROME_VERSION='114.0.5735.133-1'

--- a/factory/CHANGELOG.md
+++ b/factory/CHANGELOG.md
@@ -4,6 +4,8 @@
 
 * Updated default node version from `18.16.1` to `20.5.0`. Addressed in [#920](https://github.com/cypress-io/cypress-docker-images/pull/920)
 
+* Added `openssl` and `ca-certificates` to factory. Addressed in [#920](https://github.com/cypress-io/cypress-docker-images/pull/920)
+
 
 ## 2.4.0
 

--- a/factory/CHANGELOG.md
+++ b/factory/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Change log
 
+## 3.0.0
+
+* Updated default node version from `18.16.1` to `20.5.0`. Addressed in [#920](https://github.com/cypress-io/cypress-docker-images/pull/920)
+
+
 ## 2.4.0
 
 * Updated default node version from `18.16.0` to `18.16.1`. Addressed in [#906](https://github.com/cypress-io/cypress-docker-images/pull/906)

--- a/factory/factory.Dockerfile
+++ b/factory/factory.Dockerfile
@@ -52,6 +52,7 @@ RUN ls -la /root \
     openssh-client\
     # Chrome and Edge require wget even after installation. We could do more work to dynamically remove it, but I doubt it's worth it.
     wget \
+    # Needed to make https calls from the docker container
     openssl \
     ca-certificates \
     # build only dependancies: removed in onbuild step

--- a/factory/factory.Dockerfile
+++ b/factory/factory.Dockerfile
@@ -52,12 +52,12 @@ RUN ls -la /root \
     openssh-client\
     # Chrome and Edge require wget even after installation. We could do more work to dynamically remove it, but I doubt it's worth it.
     wget \
+    openssl \
+    ca-certificates \
     # build only dependancies: removed in onbuild step
     bzip2 \
     gnupg \
-    dirmngr \
-    openssl \
-    ca-certificates
+    dirmngr
 
 # Copy install scripts into container, these will be deleted in an onbuild step later.
 COPY ./installScripts /opt/installScripts

--- a/factory/factory.Dockerfile
+++ b/factory/factory.Dockerfile
@@ -55,7 +55,9 @@ RUN ls -la /root \
     # build only dependancies: removed in onbuild step
     bzip2 \
     gnupg \
-    dirmngr
+    dirmngr \
+    openssl \
+    ca-certificates
 
 # Copy install scripts into container, these will be deleted in an onbuild step later.
 COPY ./installScripts /opt/installScripts

--- a/factory/installScripts/edge/default.sh
+++ b/factory/installScripts/edge/default.sh
@@ -3,7 +3,6 @@
 # Microsoft offers a debian package, here we're adding the package list and then installing the specific version we want to install.
 apt-get update \
   && apt-get install --no-install-recommends -y \
-    ca-certificates \
   && curl https://packages.microsoft.com/keys/microsoft.asc | gpg --dearmor > microsoft.gpg \
   && install -o root -g root -m 644 microsoft.gpg /etc/apt/trusted.gpg.d \
   && sh -c 'echo "deb [arch=amd64] https://packages.microsoft.com/repos/edge stable main" > /etc/apt/sources.list.d/microsoft-edge-stable.list' \

--- a/factory/installScripts/edge/default.sh
+++ b/factory/installScripts/edge/default.sh
@@ -1,9 +1,7 @@
 #! /bin/bash
 
 # Microsoft offers a debian package, here we're adding the package list and then installing the specific version we want to install.
-apt-get update \
-  && apt-get install --no-install-recommends -y \
-  && curl https://packages.microsoft.com/keys/microsoft.asc | gpg --dearmor > microsoft.gpg \
+curl https://packages.microsoft.com/keys/microsoft.asc | gpg --dearmor > microsoft.gpg \
   && install -o root -g root -m 644 microsoft.gpg /etc/apt/trusted.gpg.d \
   && sh -c 'echo "deb [arch=amd64] https://packages.microsoft.com/repos/edge stable main" > /etc/apt/sources.list.d/microsoft-edge-stable.list' \
   && rm microsoft.gpg \

--- a/factory/installScripts/node/default.sh
+++ b/factory/installScripts/node/default.sh
@@ -16,7 +16,7 @@ ARCH= && dpkgArch="$(dpkg --print-architecture)" \
     esac \
     && set -ex \
     && savedAptMark="$(apt-mark showmanual)" \
-    && apt-get update && apt-get install -y ca-certificates curl wget gnupg dirmngr xz-utils libatomic1 --no-install-recommends \
+    && apt-get update && apt-get install -y curl wget gnupg dirmngr xz-utils libatomic1 --no-install-recommends \
     && rm -rf /var/lib/apt/lists/* \
     && for key in \
       4ED778F539E3634C779C87C6D7062848A1AB005C \


### PR DESCRIPTION
BREAKING CHANGE: the cypress docker factory by default will now use node version 20.5.0. For node 18, please use v2

Uses node `v20.5.0` by default which is the current node. factory `v2` will be used for 18 which is current LTS