### PR TITLE
chore: release 18.15.0 images needed for cypress monorepo (chrome/fir…

### DIFF
--- a/circle.yml
+++ b/circle.yml
@@ -32,14 +32,6 @@ commands:
                       if [ << parameters.target >> == browsers ]; then DOCKER_TAG=cypress/browsers:${BROWSERS_IMAGE_TAG}; fi
                       if [ << parameters.target >> == included ]; then DOCKER_TAG=cypress/included:${INCLUDED_IMAGE_TAG}; fi
 
-                      if npx docker-image-not-found --repo $DOCKER_TAG; then
-                        echo Docker hub says image $DOCKER_TAG does not exist
-                      else
-                        echo Docker hub has image $DOCKER_TAG or not responding
-                        echo We should stop in this case
-                        circleci-agent step halt
-                      fi
-
 jobs:
     check-factory-versions:
         machine:
@@ -329,7 +321,7 @@ workflows:
                 filters:
                     branches:
                         only:  # only branches matching the below regex filters will run
-                            - master
+                            - chore/node_18.15.0_images
                 requires:
                     - factory
                     - factory-arm
@@ -342,7 +334,7 @@ workflows:
                 filters:
                     branches:
                         only:  # only branches matching the below regex filters will run
-                            - master
+                            - chore/node_18.15.0_images
                 requires:
                     - "Push Factory Image"
                     - base
@@ -354,7 +346,7 @@ workflows:
                 filters:
                     branches:
                         only:  # only branches matching the below regex filters will run
-                            - master
+                            - chore/node_18.15.0_images
                 requires:
                     - "Push Factory Image"
                     - browsers
@@ -366,7 +358,7 @@ workflows:
                 filters:
                     branches:
                         only:  # only branches matching the below regex filters will run
-                            - master
+                            - chore/node_18.15.0_images
                 requires:
                     - "Push Factory Image"
                     - included

--- a/factory/.env
+++ b/factory/.env
@@ -11,13 +11,13 @@ BASE_IMAGE='debian:bullseye-slim'
 FACTORY_DEFAULT_NODE_VERSION='20.5.0'
 
 # Node Versions: https://nodejs.org/en/download/releases/
-NODE_VERSION="${FACTORY_DEFAULT_NODE_VERSION}"
+NODE_VERSION='18.15.0'
 
 # Update this to deploy the docker factory if you make changes to factory.Dockerfile or install scripts
 FACTORY_VERSION='3.0.0'
 
 # Chrome versions: https://www.ubuntuupdates.org/package/google_chrome/stable/main/base/google-chrome-stable
-CHROME_VERSION='114.0.5735.133-1'
+CHROME_VERSION='106.0.5249.61-1'
 
 # Cypress versions: https://www.npmjs.com/package/cypress
 CYPRESS_VERSION='13.0.0'
@@ -26,7 +26,7 @@ CYPRESS_VERSION='13.0.0'
 EDGE_VERSION='114.0.1823.51-1'
 
 # Firefox versions: https://download-installer.cdn.mozilla.net/pub/firefox/releases/
-FIREFOX_VERSION='114.0.2'
+FIREFOX_VERSION='99.0.1'
 
 # Yarn versions: https://www.npmjs.com/package/yarn
 YARN_VERSION='1.22.19'

--- a/factory/factory.Dockerfile
+++ b/factory/factory.Dockerfile
@@ -34,6 +34,7 @@ RUN ls -la /root \
   && apt-get install --no-install-recommends -y \
     # Always install: Needed to run Cypress
     xvfb \
+    xauth \
     libglib2.0-0 \
     libnss3 \
     libatk1.0-0 \


### PR DESCRIPTION
…efox updates to come later)

need to republish to include xauth to run xvfb correctly