### PR TITLE
feat: bump cypress version in docker factory

### DIFF
--- a/factory/.env
+++ b/factory/.env
@@ -20,7 +20,7 @@ FACTORY_VERSION='3.0.0'
 CHROME_VERSION='114.0.5735.133-1'
 
 # Cypress versions: https://www.npmjs.com/package/cypress
-CYPRESS_VERSION='13.0.0'
+CYPRESS_VERSION='13.1.0'
 
 # Edge versions: https://packages.microsoft.com/repos/edge/pool/main/m/microsoft-edge-stable/
 EDGE_VERSION='114.0.1823.51-1'


### PR DESCRIPTION
Bumps the Cypress version to `13.1.0`