### PR TITLE
chore: bump the cypress version for image release and update browsers to latest

### DIFF
--- a/factory/.env
+++ b/factory/.env
@@ -8,25 +8,25 @@
 BASE_IMAGE='debian:bullseye-slim'
 
 # Node Versions: https://nodejs.org/en/download/releases/
-FACTORY_DEFAULT_NODE_VERSION='20.5.0'
+FACTORY_DEFAULT_NODE_VERSION='20.6.1'
 
 # Node Versions: https://nodejs.org/en/download/releases/
 NODE_VERSION="${FACTORY_DEFAULT_NODE_VERSION}"
 
 # Update this to deploy the docker factory if you make changes to factory.Dockerfile or install scripts
-FACTORY_VERSION='3.0.0'
+FACTORY_VERSION='3.1.0'
 
 # Chrome versions: https://www.ubuntuupdates.org/package/google_chrome/stable/main/base/google-chrome-stable
-CHROME_VERSION='114.0.5735.133-1'
+CHROME_VERSION='116.0.5845.187-1'
 
 # Cypress versions: https://www.npmjs.com/package/cypress
-CYPRESS_VERSION='13.1.0'
+CYPRESS_VERSION='13.2.0'
 
 # Edge versions: https://packages.microsoft.com/repos/edge/pool/main/m/microsoft-edge-stable/
-EDGE_VERSION='114.0.1823.51-1'
+EDGE_VERSION='116.0.1938.76-1'
 
 # Firefox versions: https://download-installer.cdn.mozilla.net/pub/firefox/releases/
-FIREFOX_VERSION='114.0.2'
+FIREFOX_VERSION='117.0'
 
 # Yarn versions: https://www.npmjs.com/package/yarn
 YARN_VERSION='1.22.19'

--- a/factory/CHANGELOG.md
+++ b/factory/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Change log
 
+## 3.1.0
+
+* Updated default node version from `20.5.0` to `20.6.1`. Addressed in [#936](https://github.com/cypress-io/cypress-docker-images/pull/936)
+
 ## 3.0.0
 
 * Updated default node version from `18.16.1` to `20.5.0`. Addressed in [#920](https://github.com/cypress-io/cypress-docker-images/pull/920)


### PR DESCRIPTION


Also bumps the factory version from `3.0.0` to `3.1.0` as have updated the default factory node version