### PR TITLE
chore: sync Node.js install script with upstream install

### DIFF
--- a/factory/installScripts/node/default.sh
+++ b/factory/installScripts/node/default.sh
@@ -3,7 +3,7 @@
 groupadd --gid 1000 node \
   && useradd --uid 1000 --gid node --shell /bin/bash --create-home node
 
-# The following is borrowed from https://github.com/nodejs/docker-node/blob/main/16/bullseye-slim/Dockerfile
+# The following is borrowed from https://github.com/nodejs/docker-node/blob/main/20/bookworm-slim/Dockerfile
 ARCH= && dpkgArch="$(dpkg --print-architecture)" \
     && case "${dpkgArch##*-}" in \
       amd64) ARCH='x64';; \
@@ -29,6 +29,7 @@ ARCH= && dpkgArch="$(dpkg --print-architecture)" \
       890C08DB8579162FEE0DF9DB8BEAB4DFCF555EF4 \
       C82FA3AE1CBEDC6BE46B9360C43CEC45C17AB93C \
       108F52B48DB57BB0CC439B2997B01419BD92F80A \
+      A363A499291CBBC940DD62E41F10027AF002F8B0 \
     ; do \
       gpg --batch --keyserver hkps://keys.openpgp.org --recv-keys "$key" || \
       gpg --batch --keyserver keyserver.ubuntu.com --recv-keys "$key" ; \
@@ -42,7 +43,7 @@ ARCH= && dpkgArch="$(dpkg --print-architecture)" \
     && apt-mark auto '.*' > /dev/null \
     && { [ -z "$savedAptMark" ] || apt-mark manual $savedAptMark > /dev/null; } \
     && find /usr/local -type f -executable -exec ldd '{}' ';' \
-      | awk '/=>/ { print $(NF-1) }' \
+      | awk '/=>/ { so = $(NF-1); if (index(so, "/usr/local/") == 1) { next }; gsub("^/(usr/)?", "", so); print so }' \
       | sort -u \
       | xargs -r dpkg-query --search \
       | cut -d: -f1 \


### PR DESCRIPTION
Fixes #939 by adding the new release key introduced in that release.

Also syncs the rest of the script with the [upstream Dockerfile from docker-node](https://github.com/nodejs/docker-node/blob/main/20/bookworm-slim/Dockerfile)