### PR TITLE
chore: bump Cypress version to 13.3.1

### DIFF
--- a/factory/.env
+++ b/factory/.env
@@ -20,7 +20,7 @@ FACTORY_VERSION='3.1.0'
 CHROME_VERSION='116.0.5845.187-1'
 
 # Cypress versions: https://www.npmjs.com/package/cypress
-CYPRESS_VERSION='13.3.0'
+CYPRESS_VERSION='13.3.1'
 
 # Edge versions: https://packages.microsoft.com/repos/edge/pool/main/m/microsoft-edge-stable/
 EDGE_VERSION='116.0.1938.76-1'


### PR DESCRIPTION
Releasing 13.3.1