### PR TITLE
chore: bump node version to 20.8.1

### DIFF
--- a/factory/.env
+++ b/factory/.env
@@ -8,7 +8,7 @@
 BASE_IMAGE='debian:bullseye-slim'
 
 # Node Versions: https://nodejs.org/en/download/releases/
-FACTORY_DEFAULT_NODE_VERSION='20.6.1'
+FACTORY_DEFAULT_NODE_VERSION='20.8.1'
 
 # Node Versions: https://nodejs.org/en/download/releases/
 NODE_VERSION="${FACTORY_DEFAULT_NODE_VERSION}"

--- a/factory/.env
+++ b/factory/.env
@@ -14,7 +14,7 @@ FACTORY_DEFAULT_NODE_VERSION='20.8.1'
 NODE_VERSION="${FACTORY_DEFAULT_NODE_VERSION}"
 
 # Update this to deploy the docker factory if you make changes to factory.Dockerfile or install scripts
-FACTORY_VERSION='3.1.0'
+FACTORY_VERSION='3.2.0'
 
 # Chrome versions: https://www.ubuntuupdates.org/package/google_chrome/stable/main/base/google-chrome-stable
 CHROME_VERSION='118.0.5993.88-1'

--- a/factory/CHANGELOG.md
+++ b/factory/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Change log
 
+## 3.2.0
+
+* Updated default node version from `20.6.1` to `20.8.1`. Addressed in [#951](https://github.com/cypress-io/cypress-docker-images/pull/951)
+
 ## 3.1.0
 
 * Updated default node version from `20.5.0` to `20.6.1`. Addressed in [#936](https://github.com/cypress-io/cypress-docker-images/pull/936)


### PR DESCRIPTION
Bump default node version from v20.6.1 to v20.8.1 as it is a security release (and the new LTS since October 24):

- https://nodejs.org/en/blog/release/v20.8.1