### PR TITLE
chore: cypress 13.3.3 release updates

### DIFF
--- a/factory/.env
+++ b/factory/.env
@@ -8,7 +8,7 @@
 BASE_IMAGE='debian:bullseye-slim'
 
 # Node Versions: https://nodejs.org/en/download/releases/
-FACTORY_DEFAULT_NODE_VERSION='20.8.1'
+FACTORY_DEFAULT_NODE_VERSION='20.9.0'
 
 # Node Versions: https://nodejs.org/en/download/releases/
 NODE_VERSION="${FACTORY_DEFAULT_NODE_VERSION}"
@@ -20,7 +20,7 @@ FACTORY_VERSION='3.2.0'
 CHROME_VERSION='118.0.5993.88-1'
 
 # Cypress versions: https://www.npmjs.com/package/cypress
-CYPRESS_VERSION='13.3.2'
+CYPRESS_VERSION='13.3.3'
 
 # Edge versions: https://packages.microsoft.com/repos/edge/pool/main/m/microsoft-edge-stable/
 EDGE_VERSION='118.0.2088.46-1'

--- a/factory/CHANGELOG.md
+++ b/factory/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## 3.2.0
 
-* Updated default node version from `20.8.1` to `20.9.0`. Addressed in [#952](https://github.com/cypress-io/cypress-docker-images/pull/952)
+* Updated default node version from `20.8.1` to `20.9.0`. Addressed in [#987](https://github.com/cypress-io/cypress-docker-images/pull/987)
 * Updated default node version from `20.6.1` to `20.8.1`. Addressed in [#951](https://github.com/cypress-io/cypress-docker-images/pull/951)
 
 ## 3.1.0

--- a/factory/CHANGELOG.md
+++ b/factory/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## 3.2.0
 
+* Updated default node version from `20.8.1` to `20.9.0`. Addressed in [#952](https://github.com/cypress-io/cypress-docker-images/pull/952)
 * Updated default node version from `20.6.1` to `20.8.1`. Addressed in [#951](https://github.com/cypress-io/cypress-docker-images/pull/951)
 
 ## 3.1.0


### PR DESCRIPTION
* Updated `CYPRESS_VERSION` to `13.3.3`
* Updated `FACTORY_DEFAULT_NODE_VERSION` to `20.9.0`

Note: `FACTORY_VERSION` `3.2.0` hasn't released yet, so there is no need to update the version for this change.