### PR TITLE
chore: Bump for node 18.17.0 to support latest next.js 14 release

### DIFF
--- a/factory/.env
+++ b/factory/.env
@@ -17,7 +17,7 @@ NODE_VERSION="${FACTORY_DEFAULT_NODE_VERSION}"
 FACTORY_VERSION='3.2.0'
 
 # Chrome versions: https://www.ubuntuupdates.org/package/google_chrome/stable/main/base/google-chrome-stable
-CHROME_VERSION='118.0.5993.117-1'
+CHROME_VERSION='118.0.5993.88-1'
 
 # Cypress versions: https://www.npmjs.com/package/cypress
 CYPRESS_VERSION='13.4.0'

--- a/factory/.env
+++ b/factory/.env
@@ -8,7 +8,7 @@
 BASE_IMAGE='debian:bullseye-slim'
 
 # Node Versions: https://nodejs.org/en/download/releases/
-FACTORY_DEFAULT_NODE_VERSION='20.9.0'
+FACTORY_DEFAULT_NODE_VERSION='18.17.0'
 
 # Node Versions: https://nodejs.org/en/download/releases/
 NODE_VERSION="${FACTORY_DEFAULT_NODE_VERSION}"
@@ -17,7 +17,7 @@ NODE_VERSION="${FACTORY_DEFAULT_NODE_VERSION}"
 FACTORY_VERSION='3.2.0'
 
 # Chrome versions: https://www.ubuntuupdates.org/package/google_chrome/stable/main/base/google-chrome-stable
-CHROME_VERSION='118.0.5993.88-1'
+CHROME_VERSION='118.0.5993.117-1'
 
 # Cypress versions: https://www.npmjs.com/package/cypress
 CYPRESS_VERSION='13.4.0'


### PR DESCRIPTION
- Need to support node 18.17.0 for latest next.js version https://nextjs.org/blog/next-14#other-changes
- Just updated to the latest chrome version because it wasn't there either 
- Only saw the latest node version with browser chrome as `cypress/browsers:node18.12.0-chrome107` 
- Also it's cool if we go past 18.17.0 to 18.18.2 for hydrogen tag https://nodejs.org/en/download/releases
![Screenshot 2023-10-31 at 3 50 19 PM](https://github.com/cypress-io/cypress-docker-images/assets/5950956/36a0a510-d3c9-4b34-a4ae-13d2268789d7)