### PR TITLE
Fix temp deb file name

### DIFF
--- a/factory/.env
+++ b/factory/.env
@@ -14,7 +14,7 @@ FACTORY_DEFAULT_NODE_VERSION='20.9.0'
 NODE_VERSION="${FACTORY_DEFAULT_NODE_VERSION}"
 
 # Update this to deploy the docker factory if you make changes to factory.Dockerfile or install scripts
-FACTORY_VERSION='3.2.0'
+FACTORY_VERSION='3.3.0'
 
 # Chrome versions: https://www.ubuntuupdates.org/package/google_chrome/stable/main/base/google-chrome-stable
 CHROME_VERSION='118.0.5993.88-1'

--- a/factory/CHANGELOG.md
+++ b/factory/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Change log
 
+## 3.3.0
+* **Fixed:** Issue with temporary file cleanup due to extra character in temp Debian package file path. Addressed in [#998](https://github.com/cypress-io/cypress-docker-images/pull/998)
+ 
+
 ## 3.2.0
 
 * Updated default node version from `20.8.1` to `20.9.0`. Addressed in [#987](https://github.com/cypress-io/cypress-docker-images/pull/987)

--- a/factory/installScripts/chrome/default.sh
+++ b/factory/installScripts/chrome/default.sh
@@ -12,4 +12,4 @@ apt-get update
 apt-get install -f -y /usr/src/google-chrome-stable_current_amd64.deb
 
 # remove temp download
-rm -f /usr/src/google-chrome-stable_current_amd64.debd
+rm -f /usr/src/google-chrome-stable_current_amd64.deb


### PR DESCRIPTION
Removing the extra `d` from the end of temp file name