### PR TITLE
chore: image for node 20.10.0

### DIFF
--- a/factory/.env
+++ b/factory/.env
@@ -8,7 +8,7 @@
 BASE_IMAGE='debian:bullseye-slim'
 
 # Node Versions: https://nodejs.org/en/download/releases/
-FACTORY_DEFAULT_NODE_VERSION='20.9.0'
+FACTORY_DEFAULT_NODE_VERSION='20.10.0'
 
 # Node Versions: https://nodejs.org/en/download/releases/
 NODE_VERSION="${FACTORY_DEFAULT_NODE_VERSION}"

--- a/factory/.env
+++ b/factory/.env
@@ -14,7 +14,7 @@ FACTORY_DEFAULT_NODE_VERSION='20.10.0'
 NODE_VERSION="${FACTORY_DEFAULT_NODE_VERSION}"
 
 # Update this to deploy the docker factory if you make changes to factory.Dockerfile or install scripts
-FACTORY_VERSION='3.3.0'
+FACTORY_VERSION='3.4.0'
 
 # Chrome versions: https://www.ubuntuupdates.org/package/google_chrome/stable/main/base/google-chrome-stable
 CHROME_VERSION='118.0.5993.88-1'

--- a/factory/CHANGELOG.md
+++ b/factory/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Change log
 
+## 3.4.0
+
+* Updated default node version from `20.9.0` to `20.10.0`. Addressed in [#999](https://github.com/cypress-io/cypress-docker-images/pull/999)
+
 ## 3.3.0
 * **Fixed:** Issue with temporary file cleanup due to extra character in temp Debian package file path. Addressed in [#998](https://github.com/cypress-io/cypress-docker-images/pull/998)
  


### PR DESCRIPTION
This PR updates:

- Node to `20.10.0` ([current LTS](https://nodejs.org/en))
