### PR TITLE
chore: update CYPRESS_VERSION in factory to 13.6.3

### DIFF
--- a/factory/.env
+++ b/factory/.env
@@ -20,7 +20,7 @@ FACTORY_VERSION='3.4.0'
 CHROME_VERSION='118.0.5993.88-1'
 
 # Cypress versions: https://www.npmjs.com/package/cypress
-CYPRESS_VERSION='13.6.2'
+CYPRESS_VERSION='13.6.3'
 
 # Edge versions: https://packages.microsoft.com/repos/edge/pool/main/m/microsoft-edge-stable/
 EDGE_VERSION='118.0.2088.46-1'


### PR DESCRIPTION
updates the docker factory cypress version to 13.6.3