### PR TITLE
Chore: Node 18.17.1, Chrome 118 internal images

### DIFF
--- a/base-internal/18.16.0/Dockerfile
+++ b/base-internal/18.16.0/Dockerfile
@@ -1,5 +1,5 @@
 # build it with command
-#   docker build -t cypress/base-internal:18.15.0 .
+#   docker build -t cypress/base-internal:18.16.0 --platform linux/amd64 .
 #
 FROM node:18.16.0-bullseye-slim
 

--- a/base-internal/18.16.0/Dockerfile
+++ b/base-internal/18.16.0/Dockerfile
@@ -1,0 +1,58 @@
+# build it with command
+#   docker build -t cypress/base-internal:18.15.0 .
+#
+FROM node:18.16.0-bullseye-slim
+
+RUN apt-get update && \
+  apt-get install --no-install-recommends -y \
+  libgtk2.0-0 \
+  libgtk-3-0 \
+  libnotify-dev \
+  libgconf-2-4 \
+  libgbm-dev \
+  libnss3 \
+  libxss1 \
+  libasound2 \
+  libxtst6 \
+  procps \
+  xauth \
+  xvfb \
+  build-essential \
+  # install text editors
+  vim-tiny \
+  nano \
+  # install emoji font
+  fonts-noto-color-emoji \
+  # install Chinese fonts
+  # this list was copied from https://github.com/jim3ma/docker-leanote
+  fonts-arphic-bkai00mp \
+  fonts-arphic-bsmi00lp \
+  fonts-arphic-gbsn00lp \
+  fonts-arphic-gkai00mp \
+  fonts-arphic-ukai \
+  fonts-arphic-uming \
+  ttf-wqy-zenhei \
+  ttf-wqy-microhei \
+  xfonts-wqy \
+  # clean up
+  && rm -rf /var/lib/apt/lists/* \
+  && apt-get clean
+
+# a few environment variables to make NPM installs easier
+# good colors for most applications
+ENV TERM=xterm
+# avoid million NPM install messages
+ENV npm_config_loglevel=warn
+# allow installing when the main user is root
+ENV npm_config_unsafe_perm=true
+
+RUN npm --version \
+  && npm install -g yarn@latest --force \
+  && yarn --version \
+  && node -p process.versions \
+  && node -p 'module.paths' \
+  && echo  " node version:    $(node -v) \n" \
+    "npm version:     $(npm -v) \n" \
+    "yarn version:    $(yarn -v) \n" \
+    "debian version:  $(cat /etc/debian_version) \n" \
+    "user:            $(whoami) \n"

--- a/base-internal/18.16.0/README.md
+++ b/base-internal/18.16.0/README.md
@@ -1,0 +1,23 @@
+# cypress/base-internal:18.16.0
+
+A Docker image with all dependencies pre-installed.
+
+NOTE: This image is intended for internal use with https://github.com/cypress-io/cypress. It contains a few differences from the factory, such as:
+
+#### Dependency Additions
+* xauth (to run xvfb inside system-tests)
+* build-essential to install `make` and other linux build packages
+
+#### Env variables
+* Does not contain the `CACHE_FOLDER` and `FACTORY_DEFAULT_NODE_VERSION` env variables to keep unit tests non environment specific
+
+## Example
+
+Sample Dockerfile
+
+```
+FROM cypress/base-internal:18.16.0
+RUN npm install --save-dev cypress
+RUN $(npm bin)/cypress verify
+RUN $(npm bin)/cypress run
+```

--- a/base-internal/18.16.0/build.sh
+++ b/base-internal/18.16.0/build.sh
@@ -1,0 +1,7 @@
+set e+x
+
+# build image with Cypress dependencies
+LOCAL_NAME=cypress/base-internal:18.16.0
+
+echo "Building $LOCAL_NAME"
+docker build -t $LOCAL_NAME .

--- a/base-internal/18.17.0/Dockerfile
+++ b/base-internal/18.17.0/Dockerfile
@@ -1,0 +1,58 @@
+# build it with command
+#   docker build -t cypress/base-internal:18.17.0 --platform linux/amd64 .
+#
+FROM node:18.17.0-bullseye-slim
+
+RUN apt-get update && \
+  apt-get install --no-install-recommends -y \
+  libgtk2.0-0 \
+  libgtk-3-0 \
+  libnotify-dev \
+  libgconf-2-4 \
+  libgbm-dev \
+  libnss3 \
+  libxss1 \
+  libasound2 \
+  libxtst6 \
+  procps \
+  xauth \
+  xvfb \
+  build-essential \
+  # install text editors
+  vim-tiny \
+  nano \
+  # install emoji font
+  fonts-noto-color-emoji \
+  # install Chinese fonts
+  # this list was copied from https://github.com/jim3ma/docker-leanote
+  fonts-arphic-bkai00mp \
+  fonts-arphic-bsmi00lp \
+  fonts-arphic-gbsn00lp \
+  fonts-arphic-gkai00mp \
+  fonts-arphic-ukai \
+  fonts-arphic-uming \
+  ttf-wqy-zenhei \
+  ttf-wqy-microhei \
+  xfonts-wqy \
+  # clean up
+  && rm -rf /var/lib/apt/lists/* \
+  && apt-get clean
+
+# a few environment variables to make NPM installs easier
+# good colors for most applications
+ENV TERM=xterm
+# avoid million NPM install messages
+ENV npm_config_loglevel=warn
+# allow installing when the main user is root
+ENV npm_config_unsafe_perm=true
+
+RUN npm --version \
+  && npm install -g yarn@latest --force \
+  && yarn --version \
+  && node -p process.versions \
+  && node -p 'module.paths' \
+  && echo  " node version:    $(node -v) \n" \
+    "npm version:     $(npm -v) \n" \
+    "yarn version:    $(yarn -v) \n" \
+    "debian version:  $(cat /etc/debian_version) \n" \
+    "user:            $(whoami) \n"

--- a/base-internal/18.17.0/README.md
+++ b/base-internal/18.17.0/README.md
@@ -16,7 +16,7 @@ NOTE: This image is intended for internal use with https://github.com/cypress-io
 Sample Dockerfile
 
 ```
-FROM cypress/base-internal:18.16.0
+FROM cypress/base-internal:18.17.0
 RUN npm install --save-dev cypress
 RUN $(npm bin)/cypress verify
 RUN $(npm bin)/cypress run

--- a/base-internal/18.17.0/README.md
+++ b/base-internal/18.17.0/README.md
@@ -1,0 +1,23 @@
+# cypress/base-internal:18.17.0
+
+A Docker image with all dependencies pre-installed.
+
+NOTE: This image is intended for internal use with https://github.com/cypress-io/cypress. It contains a few differences from the factory, such as:
+
+#### Dependency Additions
+* xauth (to run xvfb inside system-tests)
+* build-essential to install `make` and other linux build packages
+
+#### Env variables
+* Does not contain the `CACHE_FOLDER` and `FACTORY_DEFAULT_NODE_VERSION` env variables to keep unit tests non environment specific
+
+## Example
+
+Sample Dockerfile
+
+```
+FROM cypress/base-internal:18.16.0
+RUN npm install --save-dev cypress
+RUN $(npm bin)/cypress verify
+RUN $(npm bin)/cypress run
+```

--- a/base-internal/18.17.0/build.sh
+++ b/base-internal/18.17.0/build.sh
@@ -1,0 +1,7 @@
+set e+x
+
+# build image with Cypress dependencies
+LOCAL_NAME=cypress/base-internal:18.17.0
+
+echo "Building $LOCAL_NAME"
+docker build -t $LOCAL_NAME .

--- a/base-internal/18.17.1/Dockerfile
+++ b/base-internal/18.17.1/Dockerfile
@@ -1,0 +1,58 @@
+# build it with command
+#   docker build -t cypress/base-internal:18.17.1 --platform linux/amd64 .
+#
+FROM node:18.17.1-bullseye-slim
+
+RUN apt-get update && \
+  apt-get install --no-install-recommends -y \
+  libgtk2.0-0 \
+  libgtk-3-0 \
+  libnotify-dev \
+  libgconf-2-4 \
+  libgbm-dev \
+  libnss3 \
+  libxss1 \
+  libasound2 \
+  libxtst6 \
+  procps \
+  xauth \
+  xvfb \
+  build-essential \
+  # install text editors
+  vim-tiny \
+  nano \
+  # install emoji font
+  fonts-noto-color-emoji \
+  # install Chinese fonts
+  # this list was copied from https://github.com/jim3ma/docker-leanote
+  fonts-arphic-bkai00mp \
+  fonts-arphic-bsmi00lp \
+  fonts-arphic-gbsn00lp \
+  fonts-arphic-gkai00mp \
+  fonts-arphic-ukai \
+  fonts-arphic-uming \
+  ttf-wqy-zenhei \
+  ttf-wqy-microhei \
+  xfonts-wqy \
+  # clean up
+  && rm -rf /var/lib/apt/lists/* \
+  && apt-get clean
+
+# a few environment variables to make NPM installs easier
+# good colors for most applications
+ENV TERM=xterm
+# avoid million NPM install messages
+ENV npm_config_loglevel=warn
+# allow installing when the main user is root
+ENV npm_config_unsafe_perm=true
+
+RUN npm --version \
+  && npm install -g yarn@latest --force \
+  && yarn --version \
+  && node -p process.versions \
+  && node -p 'module.paths' \
+  && echo  " node version:    $(node -v) \n" \
+    "npm version:     $(npm -v) \n" \
+    "yarn version:    $(yarn -v) \n" \
+    "debian version:  $(cat /etc/debian_version) \n" \
+    "user:            $(whoami) \n"

--- a/base-internal/18.17.1/README.md
+++ b/base-internal/18.17.1/README.md
@@ -1,0 +1,23 @@
+# cypress/base-internal:18.17.1
+
+A Docker image with all dependencies pre-installed.
+
+NOTE: This image is intended for internal use with https://github.com/cypress-io/cypress. It contains a few differences from the factory, such as:
+
+#### Dependency Additions
+* xauth (to run xvfb inside system-tests)
+* build-essential to install `make` and other linux build packages
+
+#### Env variables
+* Does not contain the `CACHE_FOLDER` and `FACTORY_DEFAULT_NODE_VERSION` env variables to keep unit tests non environment specific
+
+## Example
+
+Sample Dockerfile
+
+```
+FROM cypress/base-internal:18.16.0
+RUN npm install --save-dev cypress
+RUN $(npm bin)/cypress verify
+RUN $(npm bin)/cypress run
+```

--- a/base-internal/18.17.1/README.md
+++ b/base-internal/18.17.1/README.md
@@ -16,7 +16,7 @@ NOTE: This image is intended for internal use with https://github.com/cypress-io
 Sample Dockerfile
 
 ```
-FROM cypress/base-internal:18.16.0
+FROM cypress/base-internal:18.17.1
 RUN npm install --save-dev cypress
 RUN $(npm bin)/cypress verify
 RUN $(npm bin)/cypress run

--- a/base-internal/18.17.1/build.sh
+++ b/base-internal/18.17.1/build.sh
@@ -1,0 +1,7 @@
+set e+x
+
+# build image with Cypress dependencies
+LOCAL_NAME=cypress/base-internal:18.17.1
+
+echo "Building $LOCAL_NAME"
+docker build -t $LOCAL_NAME .

--- a/browsers-internal/node18.16.0-chrome116-ff115-edge/Dockerfile
+++ b/browsers-internal/node18.16.0-chrome116-ff115-edge/Dockerfile
@@ -1,0 +1,77 @@
+# build this image with command
+#   docker build -t cypress/browsers-internal:node18.15.0-chrome1114-ff115 .
+#
+FROM cypress/base-internal:18.16.0
+
+USER root
+
+RUN node --version
+
+COPY ./global-profile.sh /tmp/global-profile.sh
+RUN cat /tmp/global-profile.sh >> /etc/bash.bashrc && rm /tmp/global-profile.sh
+
+# Install dependencies
+RUN apt-get update && \
+  apt-get install -y \
+  fonts-liberation \
+  git \
+  libcurl4 \
+  libcurl3-gnutls \
+  libcurl3-nss \
+  xdg-utils \
+  wget \
+  curl \
+  # chrome dependencies
+  libu2f-udev \
+  # firefox dependencies
+  bzip2 \
+  # add codecs needed for video playback in firefox
+  # https://github.com/cypress-io/cypress-docker-images/issues/150
+  mplayer \
+  \
+  # clean up
+  && rm -rf /var/lib/apt/lists/* \
+  && apt-get clean
+
+# install libappindicator3-1 - not included with Debian 11
+RUN wget --no-verbose /usr/src/libappindicator3-1_0.4.92-7_amd64.deb "http://ftp.us.debian.org/debian/pool/main/liba/libappindicator/libappindicator3-1_0.4.92-7_amd64.deb" && \
+  dpkg -i /usr/src/libappindicator3-1_0.4.92-7_amd64.deb ; \
+  apt-get install -f -y && \
+  rm -f /usr/src/libappindicator3-1_0.4.92-7_amd64.deb
+
+# install Chrome browser
+RUN node -p "process.arch === 'arm64' ? 'Not downloading Chrome since we are on arm64: https://crbug.com/677140' : process.exit(1)" || \
+  (wget --no-verbose -O /usr/src/google-chrome-stable_current_amd64.deb "http://dl.google.com/linux/chrome/deb/pool/main/g/google-chrome-stable/google-chrome-stable_116.0.5845.187-1_amd64.deb" && \
+  dpkg -i /usr/src/google-chrome-stable_current_amd64.deb ; \
+  apt-get install -f -y && \
+  rm -f /usr/src/google-chrome-stable_current_amd64.deb)
+
+# "fake" dbus address to prevent errors
+# https://github.com/SeleniumHQ/docker-selenium/issues/87
+ENV DBUS_SESSION_BUS_ADDRESS=/dev/null
+
+# install Firefox browser
+RUN node -p "process.arch === 'arm64' ? 'Not downloading Firefox since we are on arm64: https://bugzilla.mozilla.org/show_bug.cgi?id=1678342' : process.exit(1)" || \
+  (wget --no-verbose -O /tmp/firefox.tar.bz2 https://download-installer.cdn.mozilla.net/pub/firefox/releases/115.0.1/linux-x86_64/en-US/firefox-115.0.1.tar.bz2 && \
+  tar -C /opt -xjf /tmp/firefox.tar.bz2 && \
+  rm /tmp/firefox.tar.bz2 && \
+  ln -fs /opt/firefox/firefox /usr/bin/firefox)
+
+# versions of local tools
+RUN echo  " node version:    $(node -v) \n" \
+  "npm version:     $(npm -v) \n" \
+  "yarn version:    $(yarn -v) \n" \
+  "debian version:  $(cat /etc/debian_version) \n" \
+  "Chrome version:  $(google-chrome --version) \n" \
+  "Firefox version: $(firefox --version) \n" \
+  "Edge version:    n/a \n" \ 
+  "git version:     $(git --version) \n" \
+  "whoami:          $(whoami) \n"
+
+# a few environment variables to make NPM installs easier
+# good colors for most applications
+ENV TERM=xterm
+# avoid million NPM install messages
+ENV npm_config_loglevel=warn
+# allow installing when the main user is root
+ENV npm_config_unsafe_perm=true

--- a/browsers-internal/node18.16.0-chrome116-ff115-edge/Dockerfile
+++ b/browsers-internal/node18.16.0-chrome116-ff115-edge/Dockerfile
@@ -1,61 +1,32 @@
 # build this image with command
-#   docker build -t cypress/browsers-internal:node18.15.0-chrome1114-ff115 .
+#   docker build -t cypress/browsers-internal:node18.16.0-chrome116-ff115-edge --platform linux/amd64 .
 #
-FROM cypress/base-internal:18.16.0
+FROM cypress/browsers-internal:node18.16.0-chrome116-ff115
 
 USER root
-
-RUN node --version
-
-COPY ./global-profile.sh /tmp/global-profile.sh
-RUN cat /tmp/global-profile.sh >> /etc/bash.bashrc && rm /tmp/global-profile.sh
 
 # Install dependencies
 RUN apt-get update && \
   apt-get install -y \
-  fonts-liberation \
-  git \
-  libcurl4 \
-  libcurl3-gnutls \
-  libcurl3-nss \
-  xdg-utils \
-  wget \
-  curl \
-  # chrome dependencies
-  libu2f-udev \
-  # firefox dependencies
-  bzip2 \
-  # add codecs needed for video playback in firefox
-  # https://github.com/cypress-io/cypress-docker-images/issues/150
-  mplayer \
+  # edge dependencies
+  gnupg \
+  dirmngr \
   \
   # clean up
   && rm -rf /var/lib/apt/lists/* \
   && apt-get clean
 
-# install libappindicator3-1 - not included with Debian 11
-RUN wget --no-verbose /usr/src/libappindicator3-1_0.4.92-7_amd64.deb "http://ftp.us.debian.org/debian/pool/main/liba/libappindicator/libappindicator3-1_0.4.92-7_amd64.deb" && \
-  dpkg -i /usr/src/libappindicator3-1_0.4.92-7_amd64.deb ; \
-  apt-get install -f -y && \
-  rm -f /usr/src/libappindicator3-1_0.4.92-7_amd64.deb
-
-# install Chrome browser
-RUN node -p "process.arch === 'arm64' ? 'Not downloading Chrome since we are on arm64: https://crbug.com/677140' : process.exit(1)" || \
-  (wget --no-verbose -O /usr/src/google-chrome-stable_current_amd64.deb "http://dl.google.com/linux/chrome/deb/pool/main/g/google-chrome-stable/google-chrome-stable_116.0.5845.187-1_amd64.deb" && \
-  dpkg -i /usr/src/google-chrome-stable_current_amd64.deb ; \
-  apt-get install -f -y && \
-  rm -f /usr/src/google-chrome-stable_current_amd64.deb)
-
-# "fake" dbus address to prevent errors
-# https://github.com/SeleniumHQ/docker-selenium/issues/87
-ENV DBUS_SESSION_BUS_ADDRESS=/dev/null
-
-# install Firefox browser
-RUN node -p "process.arch === 'arm64' ? 'Not downloading Firefox since we are on arm64: https://bugzilla.mozilla.org/show_bug.cgi?id=1678342' : process.exit(1)" || \
-  (wget --no-verbose -O /tmp/firefox.tar.bz2 https://download-installer.cdn.mozilla.net/pub/firefox/releases/115.0.1/linux-x86_64/en-US/firefox-115.0.1.tar.bz2 && \
-  tar -C /opt -xjf /tmp/firefox.tar.bz2 && \
-  rm /tmp/firefox.tar.bz2 && \
-  ln -fs /opt/firefox/firefox /usr/bin/firefox)
+# install latest Edge
+RUN node -p "process.arch === 'arm64' ? 'Not downloading Edge since we are on arm64: https://techcommunity.microsoft.com/t5/discussions/edge-for-linux-arm64/m-p/1532272' : process.exit(1)" || \
+  (curl https://packages.microsoft.com/keys/microsoft.asc | gpg --dearmor > microsoft.gpg && \
+  install -o root -g root -m 644 microsoft.gpg /etc/apt/trusted.gpg.d/ && \
+  sh -c 'echo "deb [arch=amd64] https://packages.microsoft.com/repos/edge stable main" > /etc/apt/sources.list.d/microsoft-edge-dev.list' && \
+  rm microsoft.gpg && \
+  ## Install Edge
+  apt-get update && \
+  apt-get install -y microsoft-edge-dev && \
+  ## Add a link to the browser that allows Cypress to find it
+  ln -s /usr/bin/microsoft-edge /usr/bin/edge)
 
 # versions of local tools
 RUN echo  " node version:    $(node -v) \n" \
@@ -68,10 +39,3 @@ RUN echo  " node version:    $(node -v) \n" \
   "git version:     $(git --version) \n" \
   "whoami:          $(whoami) \n"
 
-# a few environment variables to make NPM installs easier
-# good colors for most applications
-ENV TERM=xterm
-# avoid million NPM install messages
-ENV npm_config_loglevel=warn
-# allow installing when the main user is root
-ENV npm_config_unsafe_perm=true

--- a/browsers-internal/node18.16.0-chrome116-ff115-edge/README.md
+++ b/browsers-internal/node18.16.0-chrome116-ff115-edge/README.md
@@ -1,4 +1,4 @@
-# cypress/browsers-internal:node18.16.0-chrome116-ff115
+# cypress/browsers-internal:node18.16.0-chrome116-ff115-edge
 
 A complete image with all operating system dependencies for Cypress, and Chrome 116.0.5845.187-1, Firefox 115.0.1, Edge latest browsers.
 

--- a/browsers-internal/node18.16.0-chrome116-ff115-edge/README.md
+++ b/browsers-internal/node18.16.0-chrome116-ff115-edge/README.md
@@ -1,0 +1,18 @@
+# cypress/browsers-internal:node18.16.0-chrome116-ff115
+
+A complete image with all operating system dependencies for Cypress, and Chrome 116.0.5845.187-1, Firefox 115.0.1, Edge undefined browsers.
+
+NOTE: This image is intended for internal use with https://github.com/cypress-io/cypress. It contains a few differences from the factory, such as:
+
+#### Dependency Additions
+* curl
+* build-essentials (to contain `make` and a few other dependencies)
+
+#### Env variables
+* Does not contain the `CACHE_FOLDER` and `FACTORY_DEFAULT_NODE_VERSION` env variables to keep unit tests non environment specific
+
+[Dockerfile](Dockerfile)
+
+**Note:** this image uses the `root` user. You might want to switch to non-root user like `node` when running this container for security
+
+**Note:** Currently, the linux/arm64 build of this image does not contain any browsers except Electron. See https://github.com/cypress-io/cypress-docker-images/issues/695 for more information.

--- a/browsers-internal/node18.16.0-chrome116-ff115-edge/README.md
+++ b/browsers-internal/node18.16.0-chrome116-ff115-edge/README.md
@@ -1,6 +1,6 @@
 # cypress/browsers-internal:node18.16.0-chrome116-ff115
 
-A complete image with all operating system dependencies for Cypress, and Chrome 116.0.5845.187-1, Firefox 115.0.1, Edge undefined browsers.
+A complete image with all operating system dependencies for Cypress, and Chrome 116.0.5845.187-1, Firefox 115.0.1, Edge latest browsers.
 
 NOTE: This image is intended for internal use with https://github.com/cypress-io/cypress. It contains a few differences from the factory, such as:
 

--- a/browsers-internal/node18.16.0-chrome116-ff115-edge/build.sh
+++ b/browsers-internal/node18.16.0-chrome116-ff115-edge/build.sh
@@ -1,0 +1,5 @@
+set e+x
+
+LOCAL_NAME=cypress/browsers-internal:node18.15.0-chrome114-ff115
+echo "Building $LOCAL_NAME"
+docker build -t $LOCAL_NAME .

--- a/browsers-internal/node18.16.0-chrome116-ff115-edge/build.sh
+++ b/browsers-internal/node18.16.0-chrome116-ff115-edge/build.sh
@@ -1,5 +1,5 @@
 set e+x
 
-LOCAL_NAME=cypress/browsers-internal:node18.16.0-chrome114-ff115
+LOCAL_NAME=cypress/browsers-internal:node18.16.0-chrome116-ff115-edge
 echo "Building $LOCAL_NAME"
 docker build -t $LOCAL_NAME .

--- a/browsers-internal/node18.16.0-chrome116-ff115-edge/global-profile.sh
+++ b/browsers-internal/node18.16.0-chrome116-ff115-edge/global-profile.sh
@@ -1,0 +1,11 @@
+if [[ "$(uname -a)" = *"arm"* || "$(uname -a)" = *"aarch64"* ]]; then
+    printf "\e[31m" # red
+    echo "Warning: You are using the beta Arm build of a cypress/browsers or cypress/included image."
+    echo
+    echo "On Arm, non-Electron browsers are not available, because browser vendors are not yet building for Linux arm64."
+    echo "You must use the built-in Electron browser (--browser electron) to run Cypress or find and install unofficial Arm binary builds."
+    echo
+    echo "More details and links to upstream issues for Chrome, Firefox, and Edge can be found at Cypress's issue tracker:"
+    echo "  https://github.com/cypress-io/cypress-docker-images/issues/695"
+    printf "\e[0m" # reset
+fi

--- a/browsers-internal/node18.16.0-chrome116-ff115/Dockerfile
+++ b/browsers-internal/node18.16.0-chrome116-ff115/Dockerfile
@@ -1,0 +1,77 @@
+# build this image with command
+#   docker build -t cypress/browsers-internal:node18.15.0-chrome1114-ff115 .
+#
+FROM cypress/base-internal:18.16.0
+
+USER root
+
+RUN node --version
+
+COPY ./global-profile.sh /tmp/global-profile.sh
+RUN cat /tmp/global-profile.sh >> /etc/bash.bashrc && rm /tmp/global-profile.sh
+
+# Install dependencies
+RUN apt-get update && \
+  apt-get install -y \
+  fonts-liberation \
+  git \
+  libcurl4 \
+  libcurl3-gnutls \
+  libcurl3-nss \
+  xdg-utils \
+  wget \
+  curl \
+  # chrome dependencies
+  libu2f-udev \
+  # firefox dependencies
+  bzip2 \
+  # add codecs needed for video playback in firefox
+  # https://github.com/cypress-io/cypress-docker-images/issues/150
+  mplayer \
+  \
+  # clean up
+  && rm -rf /var/lib/apt/lists/* \
+  && apt-get clean
+
+# install libappindicator3-1 - not included with Debian 11
+RUN wget --no-verbose /usr/src/libappindicator3-1_0.4.92-7_amd64.deb "http://ftp.us.debian.org/debian/pool/main/liba/libappindicator/libappindicator3-1_0.4.92-7_amd64.deb" && \
+  dpkg -i /usr/src/libappindicator3-1_0.4.92-7_amd64.deb ; \
+  apt-get install -f -y && \
+  rm -f /usr/src/libappindicator3-1_0.4.92-7_amd64.deb
+
+# install Chrome browser
+RUN node -p "process.arch === 'arm64' ? 'Not downloading Chrome since we are on arm64: https://crbug.com/677140' : process.exit(1)" || \
+  (wget --no-verbose -O /usr/src/google-chrome-stable_current_amd64.deb "http://dl.google.com/linux/chrome/deb/pool/main/g/google-chrome-stable/google-chrome-stable_116.0.5845.187-1_amd64.deb" && \
+  dpkg -i /usr/src/google-chrome-stable_current_amd64.deb ; \
+  apt-get install -f -y && \
+  rm -f /usr/src/google-chrome-stable_current_amd64.deb)
+
+# "fake" dbus address to prevent errors
+# https://github.com/SeleniumHQ/docker-selenium/issues/87
+ENV DBUS_SESSION_BUS_ADDRESS=/dev/null
+
+# install Firefox browser
+RUN node -p "process.arch === 'arm64' ? 'Not downloading Firefox since we are on arm64: https://bugzilla.mozilla.org/show_bug.cgi?id=1678342' : process.exit(1)" || \
+  (wget --no-verbose -O /tmp/firefox.tar.bz2 https://download-installer.cdn.mozilla.net/pub/firefox/releases/115.0.1/linux-x86_64/en-US/firefox-115.0.1.tar.bz2 && \
+  tar -C /opt -xjf /tmp/firefox.tar.bz2 && \
+  rm /tmp/firefox.tar.bz2 && \
+  ln -fs /opt/firefox/firefox /usr/bin/firefox)
+
+# versions of local tools
+RUN echo  " node version:    $(node -v) \n" \
+  "npm version:     $(npm -v) \n" \
+  "yarn version:    $(yarn -v) \n" \
+  "debian version:  $(cat /etc/debian_version) \n" \
+  "Chrome version:  $(google-chrome --version) \n" \
+  "Firefox version: $(firefox --version) \n" \
+  "Edge version:    n/a \n" \ 
+  "git version:     $(git --version) \n" \
+  "whoami:          $(whoami) \n"
+
+# a few environment variables to make NPM installs easier
+# good colors for most applications
+ENV TERM=xterm
+# avoid million NPM install messages
+ENV npm_config_loglevel=warn
+# allow installing when the main user is root
+ENV npm_config_unsafe_perm=true

--- a/browsers-internal/node18.16.0-chrome116-ff115/Dockerfile
+++ b/browsers-internal/node18.16.0-chrome116-ff115/Dockerfile
@@ -1,5 +1,5 @@
 # build this image with command
-#   docker build -t cypress/browsers-internal:node18.15.0-chrome1114-ff115 .
+#   docker build -t cypress/browsers-internal:node18.16.0-chrome116-ff115 --platform linux/amd64 .
 #
 FROM cypress/base-internal:18.16.0
 

--- a/browsers-internal/node18.16.0-chrome116-ff115/README.md
+++ b/browsers-internal/node18.16.0-chrome116-ff115/README.md
@@ -1,6 +1,6 @@
 # cypress/browsers-internal:node18.15.0-chrome116-ff115
 
-A complete image with all operating system dependencies for Cypress, and Chrome 116.0.5845.187-1, Firefox 115.0.1, Edge undefined browsers.
+A complete image with all operating system dependencies for Cypress, and Chrome 116.0.5845.187-1, Firefox 115.0.1 browsers.
 
 NOTE: This image is intended for internal use with https://github.com/cypress-io/cypress. It contains a few differences from the factory, such as:
 

--- a/browsers-internal/node18.16.0-chrome116-ff115/README.md
+++ b/browsers-internal/node18.16.0-chrome116-ff115/README.md
@@ -1,0 +1,18 @@
+# cypress/browsers-internal:node18.15.0-chrome116-ff115
+
+A complete image with all operating system dependencies for Cypress, and Chrome 116.0.5845.187-1, Firefox 115.0.1, Edge undefined browsers.
+
+NOTE: This image is intended for internal use with https://github.com/cypress-io/cypress. It contains a few differences from the factory, such as:
+
+#### Dependency Additions
+* curl
+* build-essentials (to contain `make` and a few other dependencies)
+
+#### Env variables
+* Does not contain the `CACHE_FOLDER` and `FACTORY_DEFAULT_NODE_VERSION` env variables to keep unit tests non environment specific
+
+[Dockerfile](Dockerfile)
+
+**Note:** this image uses the `root` user. You might want to switch to non-root user like `node` when running this container for security
+
+**Note:** Currently, the linux/arm64 build of this image does not contain any browsers except Electron. See https://github.com/cypress-io/cypress-docker-images/issues/695 for more information.

--- a/browsers-internal/node18.16.0-chrome116-ff115/build.sh
+++ b/browsers-internal/node18.16.0-chrome116-ff115/build.sh
@@ -1,5 +1,5 @@
 set e+x
 
-LOCAL_NAME=cypress/browsers-internal:node18.15.0-chrome114-ff115
+LOCAL_NAME=cypress/browsers-internal:node18.16.0-chrome114-ff115
 echo "Building $LOCAL_NAME"
 docker build -t $LOCAL_NAME .

--- a/browsers-internal/node18.16.0-chrome116-ff115/build.sh
+++ b/browsers-internal/node18.16.0-chrome116-ff115/build.sh
@@ -1,0 +1,5 @@
+set e+x
+
+LOCAL_NAME=cypress/browsers-internal:node18.15.0-chrome114-ff115
+echo "Building $LOCAL_NAME"
+docker build -t $LOCAL_NAME .

--- a/browsers-internal/node18.16.0-chrome116-ff115/build.sh
+++ b/browsers-internal/node18.16.0-chrome116-ff115/build.sh
@@ -1,5 +1,5 @@
 set e+x
 
-LOCAL_NAME=cypress/browsers-internal:node18.16.0-chrome114-ff115
+LOCAL_NAME=cypress/browsers-internal:node18.16.0-chrome116-ff115
 echo "Building $LOCAL_NAME"
 docker build -t $LOCAL_NAME .

--- a/browsers-internal/node18.16.0-chrome116-ff115/global-profile.sh
+++ b/browsers-internal/node18.16.0-chrome116-ff115/global-profile.sh
@@ -1,0 +1,11 @@
+if [[ "$(uname -a)" = *"arm"* || "$(uname -a)" = *"aarch64"* ]]; then
+    printf "\e[31m" # red
+    echo "Warning: You are using the beta Arm build of a cypress/browsers or cypress/included image."
+    echo
+    echo "On Arm, non-Electron browsers are not available, because browser vendors are not yet building for Linux arm64."
+    echo "You must use the built-in Electron browser (--browser electron) to run Cypress or find and install unofficial Arm binary builds."
+    echo
+    echo "More details and links to upstream issues for Chrome, Firefox, and Edge can be found at Cypress's issue tracker:"
+    echo "  https://github.com/cypress-io/cypress-docker-images/issues/695"
+    printf "\e[0m" # reset
+fi

--- a/browsers-internal/node18.17.0-chrome118-ff115-edge/Dockerfile
+++ b/browsers-internal/node18.17.0-chrome118-ff115-edge/Dockerfile
@@ -1,0 +1,41 @@
+# build this image with command
+#   docker build -t cypress/browsers-internal:node18.17.0-chrome118-ff115-edge --platform linux/amd64 .
+#
+FROM cypress/browsers-internal:node18.17.0-chrome118-ff115
+
+USER root
+
+# Install dependencies
+RUN apt-get update && \
+  apt-get install -y \
+  # edge dependencies
+  gnupg \
+  dirmngr \
+  \
+  # clean up
+  && rm -rf /var/lib/apt/lists/* \
+  && apt-get clean
+
+# install latest Edge
+RUN node -p "process.arch === 'arm64' ? 'Not downloading Edge since we are on arm64: https://techcommunity.microsoft.com/t5/discussions/edge-for-linux-arm64/m-p/1532272' : process.exit(1)" || \
+  (curl https://packages.microsoft.com/keys/microsoft.asc | gpg --dearmor > microsoft.gpg && \
+  install -o root -g root -m 644 microsoft.gpg /etc/apt/trusted.gpg.d/ && \
+  sh -c 'echo "deb [arch=amd64] https://packages.microsoft.com/repos/edge stable main" > /etc/apt/sources.list.d/microsoft-edge-dev.list' && \
+  rm microsoft.gpg && \
+  ## Install Edge
+  apt-get update && \
+  apt-get install -y microsoft-edge-dev && \
+  ## Add a link to the browser that allows Cypress to find it
+  ln -s /usr/bin/microsoft-edge /usr/bin/edge)
+
+# versions of local tools
+RUN echo  " node version:    $(node -v) \n" \
+  "npm version:     $(npm -v) \n" \
+  "yarn version:    $(yarn -v) \n" \
+  "debian version:  $(cat /etc/debian_version) \n" \
+  "Chrome version:  $(google-chrome --version) \n" \
+  "Firefox version: $(firefox --version) \n" \
+  "Edge version:    n/a \n" \ 
+  "git version:     $(git --version) \n" \
+  "whoami:          $(whoami) \n"
+

--- a/browsers-internal/node18.17.0-chrome118-ff115-edge/README.md
+++ b/browsers-internal/node18.17.0-chrome118-ff115-edge/README.md
@@ -1,6 +1,6 @@
-# cypress/browsers-internal:node18.16.0-chrome116-ff115
+# cypress/browsers-internal:node18.17.0-chrome118-ff115
 
-A complete image with all operating system dependencies for Cypress, and Chrome 116.0.5845.187-1, Firefox 115.0.1, Edge undefined browsers.
+A complete image with all operating system dependencies for Cypress, and Chrome 118.0.5993.117-1, Firefox 115.0.1, Edge latest browsers.
 
 NOTE: This image is intended for internal use with https://github.com/cypress-io/cypress. It contains a few differences from the factory, such as:
 

--- a/browsers-internal/node18.17.0-chrome118-ff115-edge/README.md
+++ b/browsers-internal/node18.17.0-chrome118-ff115-edge/README.md
@@ -1,0 +1,18 @@
+# cypress/browsers-internal:node18.16.0-chrome116-ff115
+
+A complete image with all operating system dependencies for Cypress, and Chrome 116.0.5845.187-1, Firefox 115.0.1, Edge undefined browsers.
+
+NOTE: This image is intended for internal use with https://github.com/cypress-io/cypress. It contains a few differences from the factory, such as:
+
+#### Dependency Additions
+* curl
+* build-essentials (to contain `make` and a few other dependencies)
+
+#### Env variables
+* Does not contain the `CACHE_FOLDER` and `FACTORY_DEFAULT_NODE_VERSION` env variables to keep unit tests non environment specific
+
+[Dockerfile](Dockerfile)
+
+**Note:** this image uses the `root` user. You might want to switch to non-root user like `node` when running this container for security
+
+**Note:** Currently, the linux/arm64 build of this image does not contain any browsers except Electron. See https://github.com/cypress-io/cypress-docker-images/issues/695 for more information.

--- a/browsers-internal/node18.17.0-chrome118-ff115-edge/build.sh
+++ b/browsers-internal/node18.17.0-chrome118-ff115-edge/build.sh
@@ -1,5 +1,5 @@
 set e+x
 
-LOCAL_NAME=cypress/browsers-internal:node18.16.0-chrome114-ff115
+LOCAL_NAME=cypress/browsers-internal:node18.17.0-chrome118-ff115
 echo "Building $LOCAL_NAME"
 docker build -t $LOCAL_NAME .

--- a/browsers-internal/node18.17.0-chrome118-ff115-edge/build.sh
+++ b/browsers-internal/node18.17.0-chrome118-ff115-edge/build.sh
@@ -1,5 +1,5 @@
 set e+x
 
-LOCAL_NAME=cypress/browsers-internal:node18.17.0-chrome118-ff115
+LOCAL_NAME=cypress/browsers-internal:node18.17.0-chrome118-ff115-edge
 echo "Building $LOCAL_NAME"
 docker build -t $LOCAL_NAME .

--- a/browsers-internal/node18.17.0-chrome118-ff115-edge/global-profile.sh
+++ b/browsers-internal/node18.17.0-chrome118-ff115-edge/global-profile.sh
@@ -1,0 +1,11 @@
+if [[ "$(uname -a)" = *"arm"* || "$(uname -a)" = *"aarch64"* ]]; then
+    printf "\e[31m" # red
+    echo "Warning: You are using the beta Arm build of a cypress/browsers or cypress/included image."
+    echo
+    echo "On Arm, non-Electron browsers are not available, because browser vendors are not yet building for Linux arm64."
+    echo "You must use the built-in Electron browser (--browser electron) to run Cypress or find and install unofficial Arm binary builds."
+    echo
+    echo "More details and links to upstream issues for Chrome, Firefox, and Edge can be found at Cypress's issue tracker:"
+    echo "  https://github.com/cypress-io/cypress-docker-images/issues/695"
+    printf "\e[0m" # reset
+fi

--- a/browsers-internal/node18.17.0-chrome118-ff115/Dockerfile
+++ b/browsers-internal/node18.17.0-chrome118-ff115/Dockerfile
@@ -1,0 +1,77 @@
+# build this image with command
+#   docker build -t cypress/browsers-internal:node18.17.0-chrome118-ff115 --platform linux/amd64 .
+#
+FROM cypress/base-internal:18.17.0
+
+USER root
+
+RUN node --version
+
+COPY ./global-profile.sh /tmp/global-profile.sh
+RUN cat /tmp/global-profile.sh >> /etc/bash.bashrc && rm /tmp/global-profile.sh
+
+# Install dependencies
+RUN apt-get update && \
+  apt-get install -y \
+  fonts-liberation \
+  git \
+  libcurl4 \
+  libcurl3-gnutls \
+  libcurl3-nss \
+  xdg-utils \
+  wget \
+  curl \
+  # chrome dependencies
+  libu2f-udev \
+  # firefox dependencies
+  bzip2 \
+  # add codecs needed for video playback in firefox
+  # https://github.com/cypress-io/cypress-docker-images/issues/150
+  mplayer \
+  \
+  # clean up
+  && rm -rf /var/lib/apt/lists/* \
+  && apt-get clean
+
+# install libappindicator3-1 - not included with Debian 11
+RUN wget --no-verbose /usr/src/libappindicator3-1_0.4.92-7_amd64.deb "http://ftp.us.debian.org/debian/pool/main/liba/libappindicator/libappindicator3-1_0.4.92-7_amd64.deb" && \
+  dpkg -i /usr/src/libappindicator3-1_0.4.92-7_amd64.deb ; \
+  apt-get install -f -y && \
+  rm -f /usr/src/libappindicator3-1_0.4.92-7_amd64.deb
+
+# install Chrome browser
+RUN node -p "process.arch === 'arm64' ? 'Not downloading Chrome since we are on arm64: https://crbug.com/677140' : process.exit(1)" || \
+  (wget --no-verbose -O /usr/src/google-chrome-stable_current_amd64.deb "http://dl.google.com/linux/chrome/deb/pool/main/g/google-chrome-stable/google-chrome-stable_118.0.5993.117-1_amd64.deb" && \
+  dpkg -i /usr/src/google-chrome-stable_current_amd64.deb ; \
+  apt-get install -f -y && \
+  rm -f /usr/src/google-chrome-stable_current_amd64.deb)
+
+# "fake" dbus address to prevent errors
+# https://github.com/SeleniumHQ/docker-selenium/issues/87
+ENV DBUS_SESSION_BUS_ADDRESS=/dev/null
+
+# install Firefox browser
+RUN node -p "process.arch === 'arm64' ? 'Not downloading Firefox since we are on arm64: https://bugzilla.mozilla.org/show_bug.cgi?id=1678342' : process.exit(1)" || \
+  (wget --no-verbose -O /tmp/firefox.tar.bz2 https://download-installer.cdn.mozilla.net/pub/firefox/releases/115.0.1/linux-x86_64/en-US/firefox-115.0.1.tar.bz2 && \
+  tar -C /opt -xjf /tmp/firefox.tar.bz2 && \
+  rm /tmp/firefox.tar.bz2 && \
+  ln -fs /opt/firefox/firefox /usr/bin/firefox)
+
+# versions of local tools
+RUN echo  " node version:    $(node -v) \n" \
+  "npm version:     $(npm -v) \n" \
+  "yarn version:    $(yarn -v) \n" \
+  "debian version:  $(cat /etc/debian_version) \n" \
+  "Chrome version:  $(google-chrome --version) \n" \
+  "Firefox version: $(firefox --version) \n" \
+  "Edge version:    n/a \n" \ 
+  "git version:     $(git --version) \n" \
+  "whoami:          $(whoami) \n"
+
+# a few environment variables to make NPM installs easier
+# good colors for most applications
+ENV TERM=xterm
+# avoid million NPM install messages
+ENV npm_config_loglevel=warn
+# allow installing when the main user is root
+ENV npm_config_unsafe_perm=true

--- a/browsers-internal/node18.17.0-chrome118-ff115/README.md
+++ b/browsers-internal/node18.17.0-chrome118-ff115/README.md
@@ -1,0 +1,18 @@
+# cypress/browsers-internal:node18.15.0-chrome116-ff115
+
+A complete image with all operating system dependencies for Cypress, and Chrome 116.0.5845.187-1, Firefox 115.0.1, Edge undefined browsers.
+
+NOTE: This image is intended for internal use with https://github.com/cypress-io/cypress. It contains a few differences from the factory, such as:
+
+#### Dependency Additions
+* curl
+* build-essentials (to contain `make` and a few other dependencies)
+
+#### Env variables
+* Does not contain the `CACHE_FOLDER` and `FACTORY_DEFAULT_NODE_VERSION` env variables to keep unit tests non environment specific
+
+[Dockerfile](Dockerfile)
+
+**Note:** this image uses the `root` user. You might want to switch to non-root user like `node` when running this container for security
+
+**Note:** Currently, the linux/arm64 build of this image does not contain any browsers except Electron. See https://github.com/cypress-io/cypress-docker-images/issues/695 for more information.

--- a/browsers-internal/node18.17.0-chrome118-ff115/README.md
+++ b/browsers-internal/node18.17.0-chrome118-ff115/README.md
@@ -1,6 +1,6 @@
-# cypress/browsers-internal:node18.15.0-chrome116-ff115
+# cypress/browsers-internal:node18.17.0-chrome118-ff115
 
-A complete image with all operating system dependencies for Cypress, and Chrome 116.0.5845.187-1, Firefox 115.0.1, Edge undefined browsers.
+A complete image with all operating system dependencies for Cypress, and Chrome 118.0.5993.117-1, Firefox 115.0.1
 
 NOTE: This image is intended for internal use with https://github.com/cypress-io/cypress. It contains a few differences from the factory, such as:
 

--- a/browsers-internal/node18.17.0-chrome118-ff115/README.md
+++ b/browsers-internal/node18.17.0-chrome118-ff115/README.md
@@ -1,6 +1,6 @@
 # cypress/browsers-internal:node18.17.0-chrome118-ff115
 
-A complete image with all operating system dependencies for Cypress, and Chrome 118.0.5993.117-1, Firefox 115.0.1
+A complete image with all operating system dependencies for Cypress, and Chrome 118.0.5993.117-1, Firefox 115.0.1 browsers.
 
 NOTE: This image is intended for internal use with https://github.com/cypress-io/cypress. It contains a few differences from the factory, such as:
 

--- a/browsers-internal/node18.17.0-chrome118-ff115/build.sh
+++ b/browsers-internal/node18.17.0-chrome118-ff115/build.sh
@@ -1,5 +1,5 @@
 set e+x
 
-LOCAL_NAME=cypress/browsers-internal:node18.15.0-chrome114-ff115
+LOCAL_NAME=cypress/browsers-internal:node18.17.0-chrome118-ff115
 echo "Building $LOCAL_NAME"
 docker build -t $LOCAL_NAME .

--- a/browsers-internal/node18.17.0-chrome118-ff115/build.sh
+++ b/browsers-internal/node18.17.0-chrome118-ff115/build.sh
@@ -1,5 +1,5 @@
 set e+x
 
-LOCAL_NAME=cypress/browsers-internal:node18.16.0-chrome114-ff115
+LOCAL_NAME=cypress/browsers-internal:node18.15.0-chrome114-ff115
 echo "Building $LOCAL_NAME"
 docker build -t $LOCAL_NAME .

--- a/browsers-internal/node18.17.0-chrome118-ff115/global-profile.sh
+++ b/browsers-internal/node18.17.0-chrome118-ff115/global-profile.sh
@@ -1,0 +1,11 @@
+if [[ "$(uname -a)" = *"arm"* || "$(uname -a)" = *"aarch64"* ]]; then
+    printf "\e[31m" # red
+    echo "Warning: You are using the beta Arm build of a cypress/browsers or cypress/included image."
+    echo
+    echo "On Arm, non-Electron browsers are not available, because browser vendors are not yet building for Linux arm64."
+    echo "You must use the built-in Electron browser (--browser electron) to run Cypress or find and install unofficial Arm binary builds."
+    echo
+    echo "More details and links to upstream issues for Chrome, Firefox, and Edge can be found at Cypress's issue tracker:"
+    echo "  https://github.com/cypress-io/cypress-docker-images/issues/695"
+    printf "\e[0m" # reset
+fi

--- a/browsers-internal/node18.17.1-chrome118-ff115-edge/Dockerfile
+++ b/browsers-internal/node18.17.1-chrome118-ff115-edge/Dockerfile
@@ -1,0 +1,41 @@
+# build this image with command
+#   docker build -t cypress/browsers-internal:node18.17.1-chrome118-ff115-edge --platform linux/amd64 .
+#
+FROM cypress/browsers-internal:node18.17.1-chrome118-ff115
+
+USER root
+
+# Install dependencies
+RUN apt-get update && \
+  apt-get install -y \
+  # edge dependencies
+  gnupg \
+  dirmngr \
+  \
+  # clean up
+  && rm -rf /var/lib/apt/lists/* \
+  && apt-get clean
+
+# install latest Edge
+RUN node -p "process.arch === 'arm64' ? 'Not downloading Edge since we are on arm64: https://techcommunity.microsoft.com/t5/discussions/edge-for-linux-arm64/m-p/1532272' : process.exit(1)" || \
+  (curl https://packages.microsoft.com/keys/microsoft.asc | gpg --dearmor > microsoft.gpg && \
+  install -o root -g root -m 644 microsoft.gpg /etc/apt/trusted.gpg.d/ && \
+  sh -c 'echo "deb [arch=amd64] https://packages.microsoft.com/repos/edge stable main" > /etc/apt/sources.list.d/microsoft-edge-dev.list' && \
+  rm microsoft.gpg && \
+  ## Install Edge
+  apt-get update && \
+  apt-get install -y microsoft-edge-dev && \
+  ## Add a link to the browser that allows Cypress to find it
+  ln -s /usr/bin/microsoft-edge /usr/bin/edge)
+
+# versions of local tools
+RUN echo  " node version:    $(node -v) \n" \
+  "npm version:     $(npm -v) \n" \
+  "yarn version:    $(yarn -v) \n" \
+  "debian version:  $(cat /etc/debian_version) \n" \
+  "Chrome version:  $(google-chrome --version) \n" \
+  "Firefox version: $(firefox --version) \n" \
+  "Edge version:    n/a \n" \ 
+  "git version:     $(git --version) \n" \
+  "whoami:          $(whoami) \n"
+

--- a/browsers-internal/node18.17.1-chrome118-ff115-edge/README.md
+++ b/browsers-internal/node18.17.1-chrome118-ff115-edge/README.md
@@ -1,6 +1,6 @@
-# cypress/browsers-internal:node18.17.1-chrome118-ff115
+# cypress/browsers-internal:node18.17.1-chrome118-ff115-edge
 
-A complete image with all operating system dependencies for Cypress, and Chrome 116.0.5845.187-1, Firefox 115.0.1, Edge undefined browsers.
+A complete image with all operating system dependencies for Cypress, and Chrome 118.0.5993.117-1, Firefox 115.0.1, Edge latest browsers.
 
 NOTE: This image is intended for internal use with https://github.com/cypress-io/cypress. It contains a few differences from the factory, such as:
 

--- a/browsers-internal/node18.17.1-chrome118-ff115-edge/README.md
+++ b/browsers-internal/node18.17.1-chrome118-ff115-edge/README.md
@@ -1,0 +1,18 @@
+# cypress/browsers-internal:node18.17.1-chrome118-ff115
+
+A complete image with all operating system dependencies for Cypress, and Chrome 116.0.5845.187-1, Firefox 115.0.1, Edge undefined browsers.
+
+NOTE: This image is intended for internal use with https://github.com/cypress-io/cypress. It contains a few differences from the factory, such as:
+
+#### Dependency Additions
+* curl
+* build-essentials (to contain `make` and a few other dependencies)
+
+#### Env variables
+* Does not contain the `CACHE_FOLDER` and `FACTORY_DEFAULT_NODE_VERSION` env variables to keep unit tests non environment specific
+
+[Dockerfile](Dockerfile)
+
+**Note:** this image uses the `root` user. You might want to switch to non-root user like `node` when running this container for security
+
+**Note:** Currently, the linux/arm64 build of this image does not contain any browsers except Electron. See https://github.com/cypress-io/cypress-docker-images/issues/695 for more information.

--- a/browsers-internal/node18.17.1-chrome118-ff115-edge/build.sh
+++ b/browsers-internal/node18.17.1-chrome118-ff115-edge/build.sh
@@ -1,5 +1,5 @@
 set e+x
 
-LOCAL_NAME=cypress/browsers-internal:node18.16.0-chrome114-ff115
+LOCAL_NAME=cypress/browsers-internal:node18.17.0-chrome118-ff115
 echo "Building $LOCAL_NAME"
 docker build -t $LOCAL_NAME .

--- a/browsers-internal/node18.17.1-chrome118-ff115-edge/build.sh
+++ b/browsers-internal/node18.17.1-chrome118-ff115-edge/build.sh
@@ -1,5 +1,5 @@
 set e+x
 
-LOCAL_NAME=cypress/browsers-internal:node18.17.0-chrome118-ff115
+LOCAL_NAME=cypress/browsers-internal:node18.17.1-chrome118-ff115-edge
 echo "Building $LOCAL_NAME"
 docker build -t $LOCAL_NAME .

--- a/browsers-internal/node18.17.1-chrome118-ff115-edge/global-profile.sh
+++ b/browsers-internal/node18.17.1-chrome118-ff115-edge/global-profile.sh
@@ -1,0 +1,11 @@
+if [[ "$(uname -a)" = *"arm"* || "$(uname -a)" = *"aarch64"* ]]; then
+    printf "\e[31m" # red
+    echo "Warning: You are using the beta Arm build of a cypress/browsers or cypress/included image."
+    echo
+    echo "On Arm, non-Electron browsers are not available, because browser vendors are not yet building for Linux arm64."
+    echo "You must use the built-in Electron browser (--browser electron) to run Cypress or find and install unofficial Arm binary builds."
+    echo
+    echo "More details and links to upstream issues for Chrome, Firefox, and Edge can be found at Cypress's issue tracker:"
+    echo "  https://github.com/cypress-io/cypress-docker-images/issues/695"
+    printf "\e[0m" # reset
+fi

--- a/browsers-internal/node18.17.1-chrome118-ff115/Dockerfile
+++ b/browsers-internal/node18.17.1-chrome118-ff115/Dockerfile
@@ -1,0 +1,77 @@
+# build this image with command
+#   docker build -t cypress/browsers-internal:node18.17.1-chrome118-ff115 --platform linux/amd64 .
+#
+FROM cypress/base-internal:18.17.1
+
+USER root
+
+RUN node --version
+
+COPY ./global-profile.sh /tmp/global-profile.sh
+RUN cat /tmp/global-profile.sh >> /etc/bash.bashrc && rm /tmp/global-profile.sh
+
+# Install dependencies
+RUN apt-get update && \
+  apt-get install -y \
+  fonts-liberation \
+  git \
+  libcurl4 \
+  libcurl3-gnutls \
+  libcurl3-nss \
+  xdg-utils \
+  wget \
+  curl \
+  # chrome dependencies
+  libu2f-udev \
+  # firefox dependencies
+  bzip2 \
+  # add codecs needed for video playback in firefox
+  # https://github.com/cypress-io/cypress-docker-images/issues/150
+  mplayer \
+  \
+  # clean up
+  && rm -rf /var/lib/apt/lists/* \
+  && apt-get clean
+
+# install libappindicator3-1 - not included with Debian 11
+RUN wget --no-verbose /usr/src/libappindicator3-1_0.4.92-7_amd64.deb "http://ftp.us.debian.org/debian/pool/main/liba/libappindicator/libappindicator3-1_0.4.92-7_amd64.deb" && \
+  dpkg -i /usr/src/libappindicator3-1_0.4.92-7_amd64.deb ; \
+  apt-get install -f -y && \
+  rm -f /usr/src/libappindicator3-1_0.4.92-7_amd64.deb
+
+# install Chrome browser
+RUN node -p "process.arch === 'arm64' ? 'Not downloading Chrome since we are on arm64: https://crbug.com/677140' : process.exit(1)" || \
+  (wget --no-verbose -O /usr/src/google-chrome-stable_current_amd64.deb "http://dl.google.com/linux/chrome/deb/pool/main/g/google-chrome-stable/google-chrome-stable_118.0.5993.117-1_amd64.deb" && \
+  dpkg -i /usr/src/google-chrome-stable_current_amd64.deb ; \
+  apt-get install -f -y && \
+  rm -f /usr/src/google-chrome-stable_current_amd64.deb)
+
+# "fake" dbus address to prevent errors
+# https://github.com/SeleniumHQ/docker-selenium/issues/87
+ENV DBUS_SESSION_BUS_ADDRESS=/dev/null
+
+# install Firefox browser
+RUN node -p "process.arch === 'arm64' ? 'Not downloading Firefox since we are on arm64: https://bugzilla.mozilla.org/show_bug.cgi?id=1678342' : process.exit(1)" || \
+  (wget --no-verbose -O /tmp/firefox.tar.bz2 https://download-installer.cdn.mozilla.net/pub/firefox/releases/115.0.1/linux-x86_64/en-US/firefox-115.0.1.tar.bz2 && \
+  tar -C /opt -xjf /tmp/firefox.tar.bz2 && \
+  rm /tmp/firefox.tar.bz2 && \
+  ln -fs /opt/firefox/firefox /usr/bin/firefox)
+
+# versions of local tools
+RUN echo  " node version:    $(node -v) \n" \
+  "npm version:     $(npm -v) \n" \
+  "yarn version:    $(yarn -v) \n" \
+  "debian version:  $(cat /etc/debian_version) \n" \
+  "Chrome version:  $(google-chrome --version) \n" \
+  "Firefox version: $(firefox --version) \n" \
+  "Edge version:    n/a \n" \ 
+  "git version:     $(git --version) \n" \
+  "whoami:          $(whoami) \n"
+
+# a few environment variables to make NPM installs easier
+# good colors for most applications
+ENV TERM=xterm
+# avoid million NPM install messages
+ENV npm_config_loglevel=warn
+# allow installing when the main user is root
+ENV npm_config_unsafe_perm=true

--- a/browsers-internal/node18.17.1-chrome118-ff115/README.md
+++ b/browsers-internal/node18.17.1-chrome118-ff115/README.md
@@ -1,6 +1,6 @@
 # cypress/browsers-internal:node18.17.1-chrome118-ff115
 
-A complete image with all operating system dependencies for Cypress, and Chrome 118.0.5993.117-1, Firefox 115.0.1
+A complete image with all operating system dependencies for Cypress, and Chrome 118.0.5993.117-1, Firefox 115.0.1 browsers.
 
 NOTE: This image is intended for internal use with https://github.com/cypress-io/cypress. It contains a few differences from the factory, such as:
 

--- a/browsers-internal/node18.17.1-chrome118-ff115/README.md
+++ b/browsers-internal/node18.17.1-chrome118-ff115/README.md
@@ -1,0 +1,18 @@
+# cypress/browsers-internal:node18.17.1-chrome118-ff115
+
+A complete image with all operating system dependencies for Cypress, and Chrome 116.0.5845.187-1, Firefox 115.0.1, Edge undefined browsers.
+
+NOTE: This image is intended for internal use with https://github.com/cypress-io/cypress. It contains a few differences from the factory, such as:
+
+#### Dependency Additions
+* curl
+* build-essentials (to contain `make` and a few other dependencies)
+
+#### Env variables
+* Does not contain the `CACHE_FOLDER` and `FACTORY_DEFAULT_NODE_VERSION` env variables to keep unit tests non environment specific
+
+[Dockerfile](Dockerfile)
+
+**Note:** this image uses the `root` user. You might want to switch to non-root user like `node` when running this container for security
+
+**Note:** Currently, the linux/arm64 build of this image does not contain any browsers except Electron. See https://github.com/cypress-io/cypress-docker-images/issues/695 for more information.

--- a/browsers-internal/node18.17.1-chrome118-ff115/README.md
+++ b/browsers-internal/node18.17.1-chrome118-ff115/README.md
@@ -1,6 +1,6 @@
 # cypress/browsers-internal:node18.17.1-chrome118-ff115
 
-A complete image with all operating system dependencies for Cypress, and Chrome 116.0.5845.187-1, Firefox 115.0.1, Edge undefined browsers.
+A complete image with all operating system dependencies for Cypress, and Chrome 118.0.5993.117-1, Firefox 115.0.1
 
 NOTE: This image is intended for internal use with https://github.com/cypress-io/cypress. It contains a few differences from the factory, such as:
 

--- a/browsers-internal/node18.17.1-chrome118-ff115/build.sh
+++ b/browsers-internal/node18.17.1-chrome118-ff115/build.sh
@@ -1,5 +1,5 @@
 set e+x
 
-LOCAL_NAME=cypress/browsers-internal:node18.15.0-chrome114-ff115
+LOCAL_NAME=cypress/browsers-internal:node18.17.1-chrome118-ff115
 echo "Building $LOCAL_NAME"
 docker build -t $LOCAL_NAME .

--- a/browsers-internal/node18.17.1-chrome118-ff115/build.sh
+++ b/browsers-internal/node18.17.1-chrome118-ff115/build.sh
@@ -1,5 +1,5 @@
 set e+x
 
-LOCAL_NAME=cypress/browsers-internal:node18.16.0-chrome114-ff115
+LOCAL_NAME=cypress/browsers-internal:node18.15.0-chrome114-ff115
 echo "Building $LOCAL_NAME"
 docker build -t $LOCAL_NAME .

--- a/browsers-internal/node18.17.1-chrome118-ff115/global-profile.sh
+++ b/browsers-internal/node18.17.1-chrome118-ff115/global-profile.sh
@@ -1,0 +1,11 @@
+if [[ "$(uname -a)" = *"arm"* || "$(uname -a)" = *"aarch64"* ]]; then
+    printf "\e[31m" # red
+    echo "Warning: You are using the beta Arm build of a cypress/browsers or cypress/included image."
+    echo
+    echo "On Arm, non-Electron browsers are not available, because browser vendors are not yet building for Linux arm64."
+    echo "You must use the built-in Electron browser (--browser electron) to run Cypress or find and install unofficial Arm binary builds."
+    echo
+    echo "More details and links to upstream issues for Chrome, Firefox, and Edge can be found at Cypress's issue tracker:"
+    echo "  https://github.com/cypress-io/cypress-docker-images/issues/695"
+    printf "\e[0m" # reset
+fi


### PR DESCRIPTION
These are prerequisite images for the Electron 27 upgrade.