### PR TITLE
chore: node 20.11.0 (LTS), edge 109.0.1518.70-1, firefox 122.0

### DIFF
--- a/factory/.env
+++ b/factory/.env
@@ -8,13 +8,13 @@
 BASE_IMAGE='debian:bullseye-slim'
 
 # Node Versions: https://nodejs.org/en/download/releases/
-FACTORY_DEFAULT_NODE_VERSION='20.10.0'
+FACTORY_DEFAULT_NODE_VERSION='20.11.0'
 
 # Node Versions: https://nodejs.org/en/download/releases/
 NODE_VERSION="${FACTORY_DEFAULT_NODE_VERSION}"
 
 # Update this to deploy the docker factory if you make changes to factory.Dockerfile or install scripts
-FACTORY_VERSION='3.4.0'
+FACTORY_VERSION='3.5.0'
 
 # Chrome versions: https://www.ubuntuupdates.org/package/google_chrome/stable/main/base/google-chrome-stable
 CHROME_VERSION='121.0.6167.85-1'

--- a/factory/.env
+++ b/factory/.env
@@ -23,10 +23,10 @@ CHROME_VERSION='121.0.6167.85-1'
 CYPRESS_VERSION='13.6.3'
 
 # Edge versions: https://packages.microsoft.com/repos/edge/pool/main/m/microsoft-edge-stable/
-EDGE_VERSION='118.0.2088.46-1'
+EDGE_VERSION='109.0.1518.70-1'
 
 # Firefox versions: https://download-installer.cdn.mozilla.net/pub/firefox/releases/
-FIREFOX_VERSION='118.0.2'
+FIREFOX_VERSION='122.0'
 
 # Yarn versions: https://www.npmjs.com/package/yarn
 YARN_VERSION='1.22.19'

--- a/factory/CHANGELOG.md
+++ b/factory/CHANGELOG.md
@@ -3,6 +3,8 @@
 ## 3.5.0
 
 * Updated default node version from `20.10.0` to `20.11.0`. Addressed in [#1010](https://github.com/cypress-io/cypress-docker-images/pull/1010)
+* Updated edge version from `118.0.2088.46-1` to `109.0.1518.70-1`. Addressed in [#1010](https://github.com/cypress-io/cypress-docker-images/pull/1010)
+* Updated firefox version from `118.0.2` to `122.0`. Addressed in [#1010](https://github.com/cypress-io/cypress-docker-images/pull/1010)
 
 ## 3.4.0
 

--- a/factory/CHANGELOG.md
+++ b/factory/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Change log
 
+## 3.5.0
+
+* Updated default node version from `20.10.0` to `20.11.0`. Addressed in [#1010](https://github.com/cypress-io/cypress-docker-images/pull/1010)
+
 ## 3.4.0
 
 * Updated default node version from `20.9.0` to `20.10.0`. Addressed in [#999](https://github.com/cypress-io/cypress-docker-images/pull/999)


### PR DESCRIPTION
**Updates**

- Node to `20.11.0` ([current LTS](https://nodejs.org/en))
- Edge to `109.0.1518.70-1` ([latest stable](https://packages.microsoft.com/repos/edge/pool/main/m/microsoft-edge-stable/))
- Firefox to `122.0` ([latest stable](https://www.mozilla.org/en-US/firefox/releases/))

