### PR TITLE
chore: bump factory 3.5.0

### DIFF
--- a/factory/.env
+++ b/factory/.env
@@ -8,25 +8,25 @@
 BASE_IMAGE='debian:bullseye-slim'
 
 # Node Versions: https://nodejs.org/en/download/releases/
-FACTORY_DEFAULT_NODE_VERSION='20.10.0'
+FACTORY_DEFAULT_NODE_VERSION='20.11.0'
 
 # Node Versions: https://nodejs.org/en/download/releases/
 NODE_VERSION="${FACTORY_DEFAULT_NODE_VERSION}"
 
 # Update this to deploy the docker factory if you make changes to factory.Dockerfile or install scripts
-FACTORY_VERSION='3.4.0'
+FACTORY_VERSION='3.5.0'
 
 # Chrome versions: https://www.ubuntuupdates.org/package/google_chrome/stable/main/base/google-chrome-stable
 CHROME_VERSION='121.0.6167.85-1'
 
 # Cypress versions: https://www.npmjs.com/package/cypress
-CYPRESS_VERSION='13.6.3'
+CYPRESS_VERSION='13.6.4'
 
 # Edge versions: https://packages.microsoft.com/repos/edge/pool/main/m/microsoft-edge-stable/
-EDGE_VERSION='118.0.2088.46-1'
+EDGE_VERSION='121.0.2277.83-1'
 
 # Firefox versions: https://download-installer.cdn.mozilla.net/pub/firefox/releases/
-FIREFOX_VERSION='118.0.2'
+FIREFOX_VERSION='120.0'
 
 # Yarn versions: https://www.npmjs.com/package/yarn
 YARN_VERSION='1.22.19'

--- a/factory/CHANGELOG.md
+++ b/factory/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Change log
 
+## 3.5.0
+
+* Updated default node version from `20.10.0` to `20.11.0`. Addressed in [#1012](https://github.com/cypress-io/cypress-docker-images/pull/1012)
+
 ## 3.4.0
 
 * Updated default node version from `20.9.0` to `20.10.0`. Addressed in [#999](https://github.com/cypress-io/cypress-docker-images/pull/999)


### PR DESCRIPTION
includes updated browsers, cypress version, and node LTS