### PR TITLE
Add unzip to factory

### DIFF
--- a/factory/.env
+++ b/factory/.env
@@ -14,7 +14,7 @@ FACTORY_DEFAULT_NODE_VERSION='20.11.0'
 NODE_VERSION="${FACTORY_DEFAULT_NODE_VERSION}"
 
 # Update this to deploy the docker factory if you make changes to factory.Dockerfile or install scripts
-FACTORY_VERSION='3.5.0'
+FACTORY_VERSION='3.5.1'
 
 # Chrome versions: https://www.ubuntuupdates.org/package/google_chrome/stable/main/base/google-chrome-stable
 CHROME_VERSION='121.0.6167.85-1'

--- a/factory/CHANGELOG.md
+++ b/factory/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Change log
 
+## 3.5.1
+
+* Added `unzip` to factory. Addressed in [#1015](https://github.com/cypress-io/cypress-docker-images/pull/1015)
+
 ## 3.5.0
 
 * Updated default node version from `20.10.0` to `20.11.0`. Addressed in [#1012](https://github.com/cypress-io/cypress-docker-images/pull/1012)
@@ -9,8 +13,8 @@
 * Updated default node version from `20.9.0` to `20.10.0`. Addressed in [#999](https://github.com/cypress-io/cypress-docker-images/pull/999)
 
 ## 3.3.0
+
 * **Fixed:** Issue with temporary file cleanup due to extra character in temp Debian package file path. Addressed in [#998](https://github.com/cypress-io/cypress-docker-images/pull/998)
- 
 
 ## 3.2.0
 
@@ -27,10 +31,10 @@
 
 * Added `openssl` and `ca-certificates` to factory. Addressed in [#920](https://github.com/cypress-io/cypress-docker-images/pull/920)
 
-
 ## 2.4.0
 
 * Updated default node version from `18.16.0` to `18.16.1`. Addressed in [#906](https://github.com/cypress-io/cypress-docker-images/pull/906)
+
 ## 2.3.0
 
 * Updated default node version from `18.15.0` to `18.16.0`. Addressed in [#881](https://github.com/cypress-io/cypress-docker-images/pull/881)

--- a/factory/factory.Dockerfile
+++ b/factory/factory.Dockerfile
@@ -58,7 +58,9 @@ RUN ls -la /root \
     # build only dependancies: removed in onbuild step
     bzip2 \
     gnupg \
-    dirmngr
+    dirmngr \
+    # Needed by cypress installation 'unzip.js' script
+    unzip
 
 # Copy install scripts into container, these will be deleted in an onbuild step later.
 COPY ./installScripts /opt/installScripts


### PR DESCRIPTION
This is an attempt to solve: https://github.com/cypress-io/cypress-docker-images/issues/1013

This is based on the documentation in README/CONTRIBUTING, but I might have misunderstood something, please let me know if that is the case.

After making these changes, I ran the following (for some reason, the images built with 'included' does not seem to work, and I am unsure why): 

```
$docker compose build factory

[+] Building 2.2s (8/8) FINISHED                                                                                                                                                                                             docker:default
 => [factory internal] load build definition from factory.Dockerfile                                                                                                                                                                   0.0s
 => => transferring dockerfile: 4.92kB                                                                                                                                                                                                 0.0s
 => [factory internal] load metadata for docker.io/library/debian:bullseye-slim                                                                                                                                                        2.2s
 => [factory internal] load .dockerignore                                                                                                                                                                                              0.0s
 => => transferring context: 2B                                                                                                                                                                                                        0.0s
 => [factory 1/3] FROM docker.io/library/debian:bullseye-slim@sha256:c6d9e246479d56687c1a579a7a0336956a5ce6f2bc26bd7925b0c7405e81dbff                                                                                                  0.0s
 => [factory internal] load build context                                                                                                                                                                                              0.0s
 => => transferring context: 1.14kB                                                                                                                                                                                                    0.0s
 => CACHED [factory 2/3] RUN ls -la /root   && chmod 777 /root   && apt-get update   && apt-get install --no-install-recommends -y     xvfb     libglib2.0-0     libnss3     libatk1.0-0     libatk-bridge2.0-0     libcups2     libg  0.0s
 => CACHED [factory 3/3] COPY ./installScripts /opt/installScripts                                                                                                                                                                     0.0s
 => [factory] exporting to image                                                                                                                                                                                                       0.0s
 => => exporting layers                                                                                                                                                                                                                0.0s
 => => writing image sha256:198c7b4cf37b64c61667309afb4923763dc4a52507fc360bb5c7c32fdb5c4253                                                                                                                                           0.0s
 => => naming to docker.io/cypress/factory                                                                                                                                                                                             0.0s
 => => naming to docker.io/cypress/factory:latest                                                                                                                                                                                      0.0s
 => => naming to docker.io/cypress/factory:3.5.1

$ docker-compose build browsers

[+] Building 2.4s (12/12) FINISHED                                                                                                                                                                                           docker:default
 => [browsers internal] load build definition from Dockerfile                                                                                                                                                                          0.0s
 => => transferring dockerfile: 372B                                                                                                                                                                                                   0.0s
 => [browsers internal] load metadata for docker.io/cypress/factory:3.5.1                                                                                                                                                              0.0s
 => [browsers internal] load .dockerignore                                                                                                                                                                                             0.0s
 => => transferring context: 2B                                                                                                                                                                                                        0.0s
 => [browsers default_image 1/1] FROM docker.io/cypress/factory:3.5.1                                                                                                                                                                  0.0s
 => CACHED [browsers default_image 2/1] RUN bash /opt/installScripts/node/install-node-version.sh 20.11.0                                                                                                                              0.0s
 => CACHED [browsers default_image 3/1] RUN node /opt/installScripts/yarn/install-yarn-version.js 1.22.19                                                                                                                              0.0s
 => CACHED [browsers default_image 4/1] RUN node /opt/installScripts/chrome/install-chrome-version.js 121.0.6167.85-1                                                                                                                  0.0s
 => CACHED [browsers default_image 5/1] RUN node /opt/installScripts/edge/install-edge-version.js 121.0.2277.83-1                                                                                                                      0.0s
 => CACHED [browsers default_image 6/1] RUN node /opt/installScripts/firefox/install-firefox-version.js 120.0                                                                                                                          0.0s
 => [browsers default_image 7/1] RUN node /opt/installScripts/cypress/install-cypress-version.js ${CYPRESS_VERSION}                                                                                                                    0.3s
 => [browsers default_image 8/1] RUN apt-get purge -y --auto-remove     curl     bzip2     gnupg     dirmngr  && rm -rf /usr/share/doc   && rm -rf /usr/share/man   && rm -rf /var/lib/apt/lists/*   && rm -rf /opt/installScripts     2.1s
 => [browsers] exporting to image                                                                                                                                                                                                      0.0s
 => => exporting layers                                                                                                                                                                                                                0.0s
 => => writing image sha256:6ec5f82f945214d52f8dca0c088a31f6333222a8b86802ec475c970187d0be04                                                                                                                                           0.0s
 => => naming to docker.io/cypress/browsers                                                                                                                                                                                            0.0s
 => => naming to docker.io/cypress/browsers:latest                                                                                                                                                                                     0.0s
 => => naming to docker.io/cypress/browsers:node-20.11.0-chrome-121.0.6167.85-1-ff-120.0-edge-121.0.2277.83-1                                                                                                                          0.0s

$ docker run -it sha256:6ec5f82f945214d52f8dca0c088a31f6333222a8b86802ec475c970187d0be04

$ root@a52685de7248:/# unzip
UnZip 6.00 of 20 April 2009, by Debian. Original by Info-ZIP.

Usage: unzip [-Z] [-opts[modifiers]] file[.zip] [list] [-x xlist] [-d exdir]
  Default action is to extract files in list, except those in xlist, to exdir;
  file[.zip] may be a wildcard.  -Z => ZipInfo mode ("unzip -Z" for usage).

  -p  extract files to pipe, no messages     -l  list files (short format)
  -f  freshen existing files, create none    -t  test compressed archive data
  -u  update files, create if necessary      -z  display archive comment only
  -v  list verbosely/show version info       -T  timestamp archive to latest
  -x  exclude files that follow (in xlist)   -d  extract files into exdir
modifiers:
  -n  never overwrite existing files         -q  quiet mode (-qq => quieter)
  -o  overwrite files WITHOUT prompting      -a  auto-convert any text files
  -j  junk paths (do not make directories)   -aa treat ALL files as text
  -U  use escapes for all non-ASCII Unicode  -UU ignore any Unicode fields
  -C  match filenames case-insensitively     -L  make (some) names lowercase
  -X  restore UID/GID info                   -V  retain VMS version numbers
  -K  keep setuid/setgid/tacky permissions   -M  pipe through "more" pager
See "unzip -hh" or unzip.txt for more help.  Examples:
  unzip data1 -x joe   => extract all files except joe from zipfile data1.zip
  unzip -p foo | more  => send contents of foo.zip via pipe into program more
  unzip -fo foo ReadMe => quietly replace existing ReadMe if archive file newer
root@a52685de7248:/# exit

```