### PR TITLE
update factory for 13.6.5 cypress release with updated browsers

### DIFF
--- a/factory/.env
+++ b/factory/.env
@@ -17,16 +17,16 @@ NODE_VERSION="${FACTORY_DEFAULT_NODE_VERSION}"
 FACTORY_VERSION='3.5.1'
 
 # Chrome versions: https://www.ubuntuupdates.org/package/google_chrome/stable/main/base/google-chrome-stable
-CHROME_VERSION='121.0.6167.85-1'
+CHROME_VERSION='121.0.6167.184-1'
 
 # Cypress versions: https://www.npmjs.com/package/cypress
-CYPRESS_VERSION='13.6.4'
+CYPRESS_VERSION='13.6.5'
 
 # Edge versions: https://packages.microsoft.com/repos/edge/pool/main/m/microsoft-edge-stable/
-EDGE_VERSION='121.0.2277.83-1'
+EDGE_VERSION='121.0.2277.128-1'
 
 # Firefox versions: https://download-installer.cdn.mozilla.net/pub/firefox/releases/
-FIREFOX_VERSION='120.0'
+FIREFOX_VERSION='123.0'
 
 # Yarn versions: https://www.npmjs.com/package/yarn
 YARN_VERSION='1.22.19'


### PR DESCRIPTION
updates docker factory with cypress `13.6.5` and updates browsers to latest stable