### PR TITLE
feat: release 13.7.1

### DIFF
--- a/factory/.env
+++ b/factory/.env
@@ -17,16 +17,16 @@ NODE_VERSION="${FACTORY_DEFAULT_NODE_VERSION}"
 FACTORY_VERSION='3.5.1'
 
 # Chrome versions: https://www.ubuntuupdates.org/package/google_chrome/stable/main/base/google-chrome-stable
-CHROME_VERSION='121.0.6167.184-1'
+CHROME_VERSION='123.0.6312.58-1'
 
 # Cypress versions: https://www.npmjs.com/package/cypress
-CYPRESS_VERSION='13.7.0'
+CYPRESS_VERSION='13.7.1'
 
 # Edge versions: https://packages.microsoft.com/repos/edge/pool/main/m/microsoft-edge-stable/
-EDGE_VERSION='121.0.2277.128-1'
+EDGE_VERSION='122.0.2365.92-1'
 
 # Firefox versions: https://download-installer.cdn.mozilla.net/pub/firefox/releases/
-FIREFOX_VERSION='123.0'
+FIREFOX_VERSION='124.0'
 
 # Yarn versions: https://www.npmjs.com/package/yarn
 YARN_VERSION='1.22.19'

--- a/factory/.env
+++ b/factory/.env
@@ -8,13 +8,13 @@
 BASE_IMAGE='debian:bullseye-slim'
 
 # Node Versions: https://nodejs.org/en/download/releases/
-FACTORY_DEFAULT_NODE_VERSION='20.11.0'
+FACTORY_DEFAULT_NODE_VERSION='20.11.1'
 
 # Node Versions: https://nodejs.org/en/download/releases/
 NODE_VERSION="${FACTORY_DEFAULT_NODE_VERSION}"
 
 # Update this to deploy the docker factory if you make changes to factory.Dockerfile or install scripts
-FACTORY_VERSION='3.5.1'
+FACTORY_VERSION='3.5.2'
 
 # Chrome versions: https://www.ubuntuupdates.org/package/google_chrome/stable/main/base/google-chrome-stable
 CHROME_VERSION='123.0.6312.58-1'

--- a/factory/CHANGELOG.md
+++ b/factory/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Change log
 
+## 3.5.2
+
+* Updated default node version from `20.11.0` to `20.11.1`. Addressed in [#1025](https://github.com/cypress-io/cypress-docker-images/pull/1025)
+
 ## 3.5.1
 
 * Added `unzip` to factory. Addressed in [#1015](https://github.com/cypress-io/cypress-docker-images/pull/1015)


### PR DESCRIPTION
updates cypress to 13.7.1 and bumps the browser images to latest available. Also bumps node from `20.11.0` to `20.11.1` which requires a patch bump.  