### PR TITLE
chore: release 13.7.3 

### DIFF
--- a/factory/.env
+++ b/factory/.env
@@ -8,22 +8,22 @@
 BASE_IMAGE='debian:bullseye-slim'
 
 # Node Versions: https://nodejs.org/en/download/releases/
-FACTORY_DEFAULT_NODE_VERSION='20.12.0'
+FACTORY_DEFAULT_NODE_VERSION='20.12.2'
 
 # Node Versions: https://nodejs.org/en/download/releases/
 NODE_VERSION="${FACTORY_DEFAULT_NODE_VERSION}"
 
 # Update this to deploy the docker factory if you make changes to factory.Dockerfile or install scripts
-FACTORY_VERSION='3.5.3'
+FACTORY_VERSION='3.5.4'
 
 # Chrome versions: https://www.ubuntuupdates.org/package/google_chrome/stable/main/base/google-chrome-stable
-CHROME_VERSION='123.0.6312.86-1'
+CHROME_VERSION='123.0.6312.122-1'
 
 # Cypress versions: https://www.npmjs.com/package/cypress
-CYPRESS_VERSION='13.7.2'
+CYPRESS_VERSION='13.7.3'
 
 # Edge versions: https://packages.microsoft.com/repos/edge/pool/main/m/microsoft-edge-stable/
-EDGE_VERSION='123.0.2420.65-1'
+EDGE_VERSION='123.0.2420.81-1'
 
 # Firefox versions: https://download-installer.cdn.mozilla.net/pub/firefox/releases/
 FIREFOX_VERSION='124.0.2'

--- a/factory/CHANGELOG.md
+++ b/factory/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Change log
 
+## 3.5.4
+
+* Updated default node version from `20.12.0` to `20.12.2`. Addressed in [#1032](https://github.com/cypress-io/cypress-docker-images/pull/1032)
+
 ## 3.5.3
 
 * Updated default node version from `20.11.1` to `20.12.0`. Addressed in [#1029](https://github.com/cypress-io/cypress-docker-images/pull/1029)


### PR DESCRIPTION
updates Cypress to 13.7.3 and updates browsers to latest and node to latest LTS