### PR TITLE
chore: update factory to cypress 13.8.1

### DIFF
--- a/factory/.env
+++ b/factory/.env
@@ -20,13 +20,13 @@ FACTORY_VERSION='3.5.4'
 CHROME_VERSION='124.0.6367.60-1'
 
 # Cypress versions: https://www.npmjs.com/package/cypress
-CYPRESS_VERSION='13.8.0'
+CYPRESS_VERSION='13.8.1'
 
 # Edge versions: https://packages.microsoft.com/repos/edge/pool/main/m/microsoft-edge-stable/
 EDGE_VERSION='124.0.2478.51-1'
 
 # Firefox versions: https://download-installer.cdn.mozilla.net/pub/firefox/releases/
-FIREFOX_VERSION='125.0.1'
+FIREFOX_VERSION='125.0.2'
 
 # Yarn versions: https://www.npmjs.com/package/yarn
 YARN_VERSION='1.22.19'


### PR DESCRIPTION
also includes updating firefox from 125.0.1 to 125.0.2