### PR TITLE
chore: add ubuntu 24 image

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -65,6 +65,8 @@ In general, `factory/.env` master should contain the latest versions we official
 
 ![](https://github.com/cypress-io/cypress/assets/1271364/85507060-acc3-48b5-bc16-4160c4620e1e)
 
+If you need to test that the image works with Cypress, you can follow this [gist](https://gist.github.com/AtofStryker/da2e94e8535cffeebf676b6399f96b47) if on a MacOS machine which might prove helpful when debugging image dependencies.
+
 ## Releasing a new factory version
 
 To release a new [factory](/factory/README.md), open a PR with the desired changes to the [factory.Dockerfile](/factory/factory.Dockerfile) or [installScripts](/factory/installScripts/). After making changes, note the changes in the factory [CHANGELOG](/factory/CHANGELOG.md) and bump the `FACTORY_VERSION` in the [.env](/factory/.env) file to trigger a new release.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -65,7 +65,22 @@ In general, `factory/.env` master should contain the latest versions we official
 
 ![](https://github.com/cypress-io/cypress/assets/1271364/85507060-acc3-48b5-bc16-4160c4620e1e)
 
-If you need to test that the image works with Cypress, you can follow this [gist](https://gist.github.com/AtofStryker/da2e94e8535cffeebf676b6399f96b47) if on a MacOS machine which might prove helpful when debugging image dependencies.
+#### To forward X11 from inside a docker container to a host running macOS
+
+If you need to test that the image works with Cypress, you can follow these instructions if on a MacOS machine, which might prove helpful when debugging image dependencies:
+
+1. Install XQuartz: https://www.xquartz.org/
+2. Launch XQuartz.  Under the XQuartz menu, select Settings
+3. Go to the security tab and ensure "Allow connections from network clients" is checked.
+4. From the XQuarts terminal, run `xhost + ${hostname}` to allow connections to the macOS host
+5. From the XQuarts terminal, Setup a HOSTNAME env var `` export HOSTNAME="host.docker.internal:0" ``
+6. From the XQuarts terminal, run your docker image like such:
+
+```bash
+docker run --rm -it -e DISPLAY="host.docker.internal:0" -v /tmp/.X11-unix:/tmp/.X11-unix --entrypoint bash <YOUR_IMAGE_TAG>
+ ```
+
+ When executing `npx cypress open` from the docker container, the display should now be visible!
 
 ## Releasing a new factory version
 

--- a/base-internal/ubuntu24-node18/Dockerfile
+++ b/base-internal/ubuntu24-node18/Dockerfile
@@ -1,0 +1,67 @@
+FROM ubuntu:24.04
+
+RUN apt-get update && \
+  apt-get install -y apt-transport-https ca-certificates curl gnupg
+RUN mkdir -p /etc/apt/keyrings
+RUN curl -fsSL https://deb.nodesource.com/gpgkey/nodesource-repo.gpg.key | gpg --dearmor -o /etc/apt/keyrings/nodesource.gpg
+RUN echo "deb [signed-by=/etc/apt/keyrings/nodesource.gpg] https://deb.nodesource.com/node_18.x nodistro main" | tee /etc/apt/sources.list.d/nodesource.list
+RUN apt-get update && apt-get install -y nodejs
+
+# Install latest NPM and Yarn
+RUN npm install -g npm@latest
+RUN npm install -g yarn@latest
+
+# install additional native dependencies build tools
+RUN apt install -y build-essential
+
+# install Git client
+RUN apt-get install -y git
+# install unzip utility to speed up Cypress unzips
+# https://github.com/cypress-io/cypress/releases/tag/v3.8.0
+RUN apt-get install -y unzip
+
+# avoid any prompts
+ENV DEBIAN_FRONTEND noninteractive
+# install tzdata package
+RUN apt-get install -y tzdata
+# set your timezone
+RUN ln -fs /usr/share/zoneinfo/America/New_York /etc/localtime
+RUN dpkg-reconfigure --frontend noninteractive tzdata
+
+# install Cypress dependencies (separate commands to avoid time outs)
+RUN apt-get install -y \
+    libatk1.0-0 \
+    libgtk2.0-0 \
+    libglib2.0-0 \
+    libatk-bridge2.0-0 \
+    libcups2 \
+    libgtk-3-0 \
+    libgbm1 
+RUN apt-get install -y \
+    libnotify-dev
+RUN apt-get install -y \
+    libnss3 \
+    libxss1
+RUN apt-get install -y \
+    libasound2t64 \
+    xvfb
+
+# a few environment variables to make NPM installs easier
+# good colors for most applications
+ENV TERM xterm
+# avoid million NPM install messages
+ENV npm_config_loglevel warn
+# allow installing when the main user is root
+ENV npm_config_unsafe_perm true
+
+# versions of local tools
+RUN echo  " node version:    $(node -v) \n" \
+  "npm version:     $(npm -v) \n" \
+  "yarn version:    $(yarn -v) \n" \
+  "debian version:  $(cat /etc/debian_version) \n" \
+  "user:            $(whoami) \n" \
+  "git:             $(git --version) \n"
+
+RUN echo "More version info"
+RUN cat /etc/lsb-release
+RUN cat /etc/os-release

--- a/base-internal/ubuntu24-node18/Dockerfile
+++ b/base-internal/ubuntu24-node18/Dockerfile
@@ -1,11 +1,19 @@
 FROM ubuntu:24.04
 
+# set up NodeJS
 RUN apt-get update && \
   apt-get install -y apt-transport-https ca-certificates curl gnupg
 RUN mkdir -p /etc/apt/keyrings
 RUN curl -fsSL https://deb.nodesource.com/gpgkey/nodesource-repo.gpg.key | gpg --dearmor -o /etc/apt/keyrings/nodesource.gpg
 RUN echo "deb [signed-by=/etc/apt/keyrings/nodesource.gpg] https://deb.nodesource.com/node_18.x nodistro main" | tee /etc/apt/sources.list.d/nodesource.list
 RUN apt-get update && apt-get install -y nodejs
+
+# set up Python 3.11
+RUN apt-get install software-properties-common -y
+RUN add-apt-repository ppa:deadsnakes/ppa
+RUN apt-get update && apt-get upgrade -y
+RUN apt-get install g++ make python3.11 -y
+ENV NODE_GYP_FORCE_PYTHON=/usr/bin/python3.11
 
 # Install latest NPM and Yarn
 RUN npm install -g npm@latest
@@ -31,12 +39,13 @@ RUN dpkg-reconfigure --frontend noninteractive tzdata
 # install Cypress dependencies (separate commands to avoid time outs)
 RUN apt-get install -y \
     libatk1.0-0 \
-    libgtk2.0-0 \
+    libgtk2.0-0t64 \
     libglib2.0-0 \
     libatk-bridge2.0-0 \
     libcups2 \
-    libgtk-3-0 \
-    libgbm1 
+    libgtk-3-0t64 \
+    libgbm1 \
+    libgbm-dev
 RUN apt-get install -y \
     libnotify-dev
 RUN apt-get install -y \
@@ -44,8 +53,9 @@ RUN apt-get install -y \
     libxss1
 RUN apt-get install -y \
     libasound2t64 \
+    libxtst6 \
+    xauth \
     xvfb
-
 # a few environment variables to make NPM installs easier
 # good colors for most applications
 ENV TERM xterm

--- a/base-internal/ubuntu24-node18/README.md
+++ b/base-internal/ubuntu24-node18/README.md
@@ -1,0 +1,22 @@
+# cypress/base-internal:ubuntu24-node18
+
+Image with Ubuntu 24.04 and Node 18.x.x. To be used internally by Cypress.io and is not intended for public use.
+
+```
+node version:    v18.x.x
+npm version:
+yarn version:
+debian version:
+user:            root
+git:             git version 2.20.1
+DISTRIB_ID=Ubuntu
+DISTRIB_RELEASE=24.04
+DISTRIB_CODENAME=noble
+DISTRIB_DESCRIPTION="Ubuntu 24.04"
+NAME="Ubuntu"
+VERSION="24.04 (Noble Numbat)"
+ID=ubuntu
+ID_LIKE=debian
+PRETTY_NAME="Ubuntu 24.04"
+VERSION_ID="24.04"
+```

--- a/base-internal/ubuntu24-node18/build.sh
+++ b/base-internal/ubuntu24-node18/build.sh
@@ -1,0 +1,7 @@
+set e+x
+
+# build image with Cypress dependencies
+LOCAL_NAME=cypress/base-internal:ubuntu24-node18
+
+echo "Building $LOCAL_NAME"
+docker build -t $LOCAL_NAME .


### PR DESCRIPTION
since Nobel Numbat is available, we should add the image under test in the [cypress repo](https://github.com/cypress-io/cypress/blob/develop/system-tests/test-binary/ci_environments_spec.ts#L34) since we test the last two major versions unofficially of ubuntu. See related https://github.com/cypress-io/cypress/pull/29412