### PR TITLE
build node 22 images

### DIFF
--- a/circle.yml
+++ b/circle.yml
@@ -330,6 +330,7 @@ workflows:
                     branches:
                         only:  # only branches matching the below regex filters will run
                             - master
+                            - chore/build_node22_images
                 requires:
                     - factory
                     - factory-arm
@@ -343,6 +344,7 @@ workflows:
                     branches:
                         only:  # only branches matching the below regex filters will run
                             - master
+                            - chore/build_node22_images
                 requires:
                     - "Push Factory Image"
                     - base
@@ -355,6 +357,7 @@ workflows:
                     branches:
                         only:  # only branches matching the below regex filters will run
                             - master
+                            - chore/build_node22_images
                 requires:
                     - "Push Factory Image"
                     - browsers
@@ -367,6 +370,7 @@ workflows:
                     branches:
                         only:  # only branches matching the below regex filters will run
                             - master
+                            - chore/build_node22_images
                 requires:
                     - "Push Factory Image"
                     - included

--- a/factory/.env
+++ b/factory/.env
@@ -8,7 +8,7 @@
 BASE_IMAGE='debian:bullseye-slim'
 
 # Node Versions: https://nodejs.org/en/download/releases/
-FACTORY_DEFAULT_NODE_VERSION='20.12.2'
+FACTORY_DEFAULT_NODE_VERSION='22.0.0'
 
 # Node Versions: https://nodejs.org/en/download/releases/
 NODE_VERSION="${FACTORY_DEFAULT_NODE_VERSION}"


### PR DESCRIPTION
builds node 22 base image for use in the cypress repo. These images are published manually but creating this pull request as an artifact that can be referenced for posterity if needed