### PR TITLE
chore: add 18.18.2 chrome 125 firefore 126 related browser images

### DIFF
--- a/browsers-internal/node18.18.2-chrome125-ff126-edge/Dockerfile
+++ b/browsers-internal/node18.18.2-chrome125-ff126-edge/Dockerfile
@@ -1,0 +1,41 @@
+# build this image with command
+#   docker build -t cypress/browsers-internal:node18.18.2-chrome125-ff126-edge --platform linux/amd64 .
+#
+FROM cypress/browsers-internal:node18.18.2-chrome125-ff126
+
+USER root
+
+# Install dependencies
+RUN apt-get update && \
+  apt-get install -y \
+  # edge dependencies
+  gnupg \
+  dirmngr \
+  \
+  # clean up
+  && rm -rf /var/lib/apt/lists/* \
+  && apt-get clean
+
+# install latest Edge
+RUN node -p "process.arch === 'arm64' ? 'Not downloading Edge since we are on arm64: https://techcommunity.microsoft.com/t5/discussions/edge-for-linux-arm64/m-p/1532272' : process.exit(1)" || \
+  (curl https://packages.microsoft.com/keys/microsoft.asc | gpg --dearmor > microsoft.gpg && \
+  install -o root -g root -m 644 microsoft.gpg /etc/apt/trusted.gpg.d/ && \
+  sh -c 'echo "deb [arch=amd64] https://packages.microsoft.com/repos/edge stable main" > /etc/apt/sources.list.d/microsoft-edge-dev.list' && \
+  rm microsoft.gpg && \
+  ## Install Edge
+  apt-get update && \
+  apt-get install -y microsoft-edge-dev && \
+  ## Add a link to the browser that allows Cypress to find it
+  ln -s /usr/bin/microsoft-edge /usr/bin/edge)
+
+# versions of local tools
+RUN echo  " node version:    $(node -v) \n" \
+  "npm version:     $(npm -v) \n" \
+  "yarn version:    $(yarn -v) \n" \
+  "debian version:  $(cat /etc/debian_version) \n" \
+  "Chrome version:  $(google-chrome --version) \n" \
+  "Firefox version: $(firefox --version) \n" \
+  "Edge version:    n/a \n" \ 
+  "git version:     $(git --version) \n" \
+  "whoami:          $(whoami) \n"
+

--- a/browsers-internal/node18.18.2-chrome125-ff126-edge/README.md
+++ b/browsers-internal/node18.18.2-chrome125-ff126-edge/README.md
@@ -1,0 +1,18 @@
+# cypress/browsers-internal:node18.18.2-chrome125-ff126-edge
+
+A complete image with all operating system dependencies for Cypress, and Chrome 125.0.6422.60-1, Firefox 126.0, Edge latest browsers.
+
+NOTE: This image is intended for internal use with https://github.com/cypress-io/cypress. It contains a few differences from the factory, such as:
+
+#### Dependency Additions
+* curl
+* build-essentials (to contain `make` and a few other dependencies)
+
+#### Env variables
+* Does not contain the `CACHE_FOLDER` and `FACTORY_DEFAULT_NODE_VERSION` env variables to keep unit tests non environment specific
+
+[Dockerfile](Dockerfile)
+
+**Note:** this image uses the `root` user. You might want to switch to non-root user like `node` when running this container for security
+
+**Note:** Currently, the linux/arm64 build of this image does not contain any browsers except Electron. See https://github.com/cypress-io/cypress-docker-images/issues/695 for more information.

--- a/browsers-internal/node18.18.2-chrome125-ff126-edge/build.sh
+++ b/browsers-internal/node18.18.2-chrome125-ff126-edge/build.sh
@@ -1,0 +1,5 @@
+set e+x
+
+LOCAL_NAME=cypress/browsers-internal:node18.18.2-chrome125-ff126-edge
+echo "Building $LOCAL_NAME"
+docker build -t $LOCAL_NAME .

--- a/browsers-internal/node18.18.2-chrome125-ff126-edge/global-profile.sh
+++ b/browsers-internal/node18.18.2-chrome125-ff126-edge/global-profile.sh
@@ -1,0 +1,11 @@
+if [[ "$(uname -a)" = *"arm"* || "$(uname -a)" = *"aarch64"* ]]; then
+    printf "\e[31m" # red
+    echo "Warning: You are using the beta Arm build of a cypress/browsers or cypress/included image."
+    echo
+    echo "On Arm, non-Electron browsers are not available, because browser vendors are not yet building for Linux arm64."
+    echo "You must use the built-in Electron browser (--browser electron) to run Cypress or find and install unofficial Arm binary builds."
+    echo
+    echo "More details and links to upstream issues for Chrome, Firefox, and Edge can be found at Cypress's issue tracker:"
+    echo "  https://github.com/cypress-io/cypress-docker-images/issues/695"
+    printf "\e[0m" # reset
+fi

--- a/browsers-internal/node18.18.2-chrome125-ff126/Dockerfile
+++ b/browsers-internal/node18.18.2-chrome125-ff126/Dockerfile
@@ -1,0 +1,77 @@
+# build this image with command
+#   docker build -t cypress/browsers-internal:node18.18.2-chrome125-ff126 --platform linux/amd64 .
+#
+FROM cypress/base-internal:18.18.2
+
+USER root
+
+RUN node --version
+
+COPY ./global-profile.sh /tmp/global-profile.sh
+RUN cat /tmp/global-profile.sh >> /etc/bash.bashrc && rm /tmp/global-profile.sh
+
+# Install dependencies
+RUN apt-get update && \
+  apt-get install -y \
+  fonts-liberation \
+  git \
+  libcurl4 \
+  libcurl3-gnutls \
+  libcurl3-nss \
+  xdg-utils \
+  wget \
+  curl \
+  # chrome dependencies
+  libu2f-udev \
+  # firefox dependencies
+  bzip2 \
+  # add codecs needed for video playback in firefox
+  # https://github.com/cypress-io/cypress-docker-images/issues/150
+  mplayer \
+  \
+  # clean up
+  && rm -rf /var/lib/apt/lists/* \
+  && apt-get clean
+
+# install libappindicator3-1 - not included with Debian 11
+RUN wget --no-verbose /usr/src/libappindicator3-1_0.4.92-7_amd64.deb "http://ftp.us.debian.org/debian/pool/main/liba/libappindicator/libappindicator3-1_0.4.92-7_amd64.deb" && \
+  dpkg -i /usr/src/libappindicator3-1_0.4.92-7_amd64.deb ; \
+  apt-get install -f -y && \
+  rm -f /usr/src/libappindicator3-1_0.4.92-7_amd64.deb
+
+# install Chrome browser
+RUN node -p "process.arch === 'arm64' ? 'Not downloading Chrome since we are on arm64: https://crbug.com/677140' : process.exit(1)" || \
+  (wget --no-verbose -O /usr/src/google-chrome-stable_current_amd64.deb "http://dl.google.com/linux/chrome/deb/pool/main/g/google-chrome-stable/google-chrome-stable_125.0.6422.60-1_amd64.deb" && \
+  dpkg -i /usr/src/google-chrome-stable_current_amd64.deb ; \
+  apt-get install -f -y && \
+  rm -f /usr/src/google-chrome-stable_current_amd64.deb)
+
+# "fake" dbus address to prevent errors
+# https://github.com/SeleniumHQ/docker-selenium/issues/87
+ENV DBUS_SESSION_BUS_ADDRESS=/dev/null
+
+# install Firefox browser
+RUN node -p "process.arch === 'arm64' ? 'Not downloading Firefox since we are on arm64: https://bugzilla.mozilla.org/show_bug.cgi?id=1678342' : process.exit(1)" || \
+  (wget --no-verbose -O /tmp/firefox.tar.bz2 https://download-installer.cdn.mozilla.net/pub/firefox/releases/126.0/linux-x86_64/en-US/firefox-126.0.tar.bz2 && \
+  tar -C /opt -xjf /tmp/firefox.tar.bz2 && \
+  rm /tmp/firefox.tar.bz2 && \
+  ln -fs /opt/firefox/firefox /usr/bin/firefox)
+
+# versions of local tools
+RUN echo  " node version:    $(node -v) \n" \
+  "npm version:     $(npm -v) \n" \
+  "yarn version:    $(yarn -v) \n" \
+  "debian version:  $(cat /etc/debian_version) \n" \
+  "Chrome version:  $(google-chrome --version) \n" \
+  "Firefox version: $(firefox --version) \n" \
+  "Edge version:    n/a \n" \ 
+  "git version:     $(git --version) \n" \
+  "whoami:          $(whoami) \n"
+
+# a few environment variables to make NPM installs easier
+# good colors for most applications
+ENV TERM=xterm
+# avoid million NPM install messages
+ENV npm_config_loglevel=warn
+# allow installing when the main user is root
+ENV npm_config_unsafe_perm=true

--- a/browsers-internal/node18.18.2-chrome125-ff126/README.md
+++ b/browsers-internal/node18.18.2-chrome125-ff126/README.md
@@ -1,0 +1,18 @@
+# cypress/browsers-internal:node18.18.2-chrome125-ff126
+
+A complete image with all operating system dependencies for Cypress, and Chrome 125.0.6422.60-1, Firefox 126.0 browsers.
+
+NOTE: This image is intended for internal use with https://github.com/cypress-io/cypress. It contains a few differences from the factory, such as:
+
+#### Dependency Additions
+* curl
+* build-essentials (to contain `make` and a few other dependencies)
+
+#### Env variables
+* Does not contain the `CACHE_FOLDER` and `FACTORY_DEFAULT_NODE_VERSION` env variables to keep unit tests non environment specific
+
+[Dockerfile](Dockerfile)
+
+**Note:** this image uses the `root` user. You might want to switch to non-root user like `node` when running this container for security
+
+**Note:** Currently, the linux/arm64 build of this image does not contain any browsers except Electron. See https://github.com/cypress-io/cypress-docker-images/issues/695 for more information.

--- a/browsers-internal/node18.18.2-chrome125-ff126/build.sh
+++ b/browsers-internal/node18.18.2-chrome125-ff126/build.sh
@@ -1,0 +1,5 @@
+set e+x
+
+LOCAL_NAME=cypress/browsers-internal:node18.18.2-chrome125-ff126
+echo "Building $LOCAL_NAME"
+docker build -t $LOCAL_NAME .

--- a/browsers-internal/node18.18.2-chrome125-ff126/global-profile.sh
+++ b/browsers-internal/node18.18.2-chrome125-ff126/global-profile.sh
@@ -1,0 +1,11 @@
+if [[ "$(uname -a)" = *"arm"* || "$(uname -a)" = *"aarch64"* ]]; then
+    printf "\e[31m" # red
+    echo "Warning: You are using the beta Arm build of a cypress/browsers or cypress/included image."
+    echo
+    echo "On Arm, non-Electron browsers are not available, because browser vendors are not yet building for Linux arm64."
+    echo "You must use the built-in Electron browser (--browser electron) to run Cypress or find and install unofficial Arm binary builds."
+    echo
+    echo "More details and links to upstream issues for Chrome, Firefox, and Edge can be found at Cypress's issue tracker:"
+    echo "  https://github.com/cypress-io/cypress-docker-images/issues/695"
+    printf "\e[0m" # reset
+fi


### PR DESCRIPTION
adds 18.18.2 chrome 125 firefore 126 related browser images for the cypress app's update to Electron 28