### PR TITLE
chore: remove obsolete compose v1 file format version

### DIFF
--- a/factory/docker-compose.yml
+++ b/factory/docker-compose.yml
@@ -1,5 +1,3 @@
-version: '3.8'
-
 # REPO_PREFIX is used in CI to deploy to other docker registries than dockerhub.
 
 services:

--- a/factory/test-project/docker-compose.yml
+++ b/factory/test-project/docker-compose.yml
@@ -1,5 +1,3 @@
-version: '3'
-
 ## To run these tests you must export the environment variables in /factory/.env with `set -a && . ../.env && set +a`
 
 services:


### PR DESCRIPTION
## Issue

The repo uses an obsolete `version` file format definition in Docker compose files:

- [factory/docker-compose.yml](https://github.com/cypress-io/cypress-docker-images/blob/master/factory/docker-compose.yml) specifies `version: '3.8'` file format.
- [factory/test-project/docker-compose.yml](https://github.com/cypress-io/cypress-docker-images/blob/master/factory/test-project/docker-compose.yml) specifies `version: '3'` file format.

Docker Compose outputs the following warning message when run:
> `version` is obsolete

## Background

The `version` definition belongs to the Compose V1 specification and is no longer supported. Compose V1 is no longer included in current releases of Docker Desktop and the final release was in May 2021.

Compose V2, the current version, released in 2020, ignores the `version` top-level element in the `compose.yml` file. See [Compose history](https://docs.docker.com/compose/intro/history/#introduction) and [Version top-level element (obsolete)](https://docs.docker.com/compose/compose-file/04-version-and-name/#version-top-level-element-obsolete).

## Change

Remove the obsolete `version:` file format definition from

- [factory/docker-compose.yml](https://github.com/cypress-io/cypress-docker-images/blob/master/factory/docker-compose.yml)
- [factory/test-project/docker-compose.yml](https://github.com/cypress-io/cypress-docker-images/blob/master/factory/test-project/docker-compose.yml)

## Verification

On Ubunu `22.04.4` LTS, Node.js `v20.13.1` LTS

Execute:

```shell
cd factory
docker compose build factory
docker compose build
```

and confirm that all images are built without errors or warnings. Continue with

```shell
cd test-project
set -a && . ../.env && set +a
docker compose run test-base
```

and confirm that the image builds without errors or warnings and runs successfully.
