### PR TITLE
chore: remove obsolete script definitions

### DIFF
--- a/package.json
+++ b/package.json
@@ -8,10 +8,6 @@
     "test": "test"
   },
   "scripts": {
-    "build": "node ./scripts/generate-config",
-    "add:base": "node ./scripts/generate-base-image",
-    "add:browser": "node ./scripts/generate-browser-image",
-    "add:included": "node ./scripts/generate-included-image",
     "check:markdown": "find . -type f -name '*.md' ! -path './node_modules/*' ! -path './examples/*' | xargs -L1 npx markdown-link-check -c markdownLinkConfig.json --quiet",
     "format": "prettier --write .",
     "test": "jest",


### PR DESCRIPTION
## Issue

[package.json](https://github.com/cypress-io/cypress-docker-images/blob/master/package.json) contains several script definitions which refer to script sources that no longer exist.

https://github.com/cypress-io/cypress-docker-images/blob/b9525720b9e4e44ee7ded7f974dae89cc0dfd6f3/package.json#L10-L14

- The script sources were removed as part of PR https://github.com/cypress-io/cypress-docker-images/pull/812

## Change

Remove the following obsolete script definitions from [package.json](https://github.com/cypress-io/cypress-docker-images/blob/master/package.json):

- `build`
- `add:base`
- `add:browser`
- `add:included`
