### PR TITLE
docs: update README Firefox not found example

### DIFF
--- a/README.md
+++ b/README.md
@@ -102,7 +102,7 @@ Browser: firefox was not found on your system or is not supported by Cypress.
 Can't run because you've entered an invalid browser name.
 ```
 
-To resolve this, the container needs to run with user id `1001`. 
+To resolve this, the container needs to run with user id `1001`.
 
 One example using the [cypress-io/github-action](https://github.com/cypress-io/github-action)
 
@@ -112,12 +112,12 @@ on: push
 jobs:
   cypress-run:
     runs-on: ubuntu-22.04
-    container: 
-     image: cypress/browsers:node18.12.0-chrome106-ff106
-     options: --user 1001  
+    container:
+      image: cypress/browsers:node18.12.0-chrome106-ff106
+      options: --user 1001
     steps:
-      - uses: actions/checkout@v3
-      - uses: cypress-io/github-action@v5
+      - uses: actions/checkout@v4
+      - uses: cypress-io/github-action@v6
         with:
           browser: firefox
 ```


### PR DESCRIPTION
## Issue

[README > Firefox not found](https://github.com/cypress-io/cypress-docker-images/blob/master/README.md#firefox-not-found) refers to outdated GitHub JavaScript action versions, which use the deprecated / end-of-life `node16` version:

```yml
name: E2E in custom container
on: push
jobs:
  cypress-run:
    runs-on: ubuntu-22.04
    container:
     image: cypress/browsers:node18.12.0-chrome106-ff106
     options: --user 1001
    steps:
      - uses: actions/checkout@v3
      - uses: cypress-io/github-action@v5
        with:
          browser: firefox
```

- [actions/checkout@v3](https://github.com/actions/checkout/tree/v3) using `node16`
- [cypress-io/github-action@v5]()

## Change

Update the example in [README > Firefox not found](https://github.com/cypress-io/cypress-docker-images/blob/master/README.md#firefox-not-found) to use latest and supported versions:

- [actions/checkout@v4](https://github.com/actions/checkout/tree/v4)
- [cypress-io/github-action@v6](https://github.com/cypress-io/github-action/tree/v6)