### PR TITLE
update factory with cypress 13.10.0 release

### DIFF
--- a/factory/.env
+++ b/factory/.env
@@ -8,25 +8,25 @@
 BASE_IMAGE='debian:bullseye-slim'
 
 # Node Versions: https://nodejs.org/en/download/releases/
-FACTORY_DEFAULT_NODE_VERSION='20.13.0'
+FACTORY_DEFAULT_NODE_VERSION='20.13.1'
 
 # Node Versions: https://nodejs.org/en/download/releases/
 NODE_VERSION="${FACTORY_DEFAULT_NODE_VERSION}"
 
 # Update this to deploy the docker factory if you make changes to factory.Dockerfile or install scripts
-FACTORY_VERSION='3.5.5'
+FACTORY_VERSION='3.5.6'
 
 # Chrome versions: https://www.ubuntuupdates.org/package/google_chrome/stable/main/base/google-chrome-stable
-CHROME_VERSION='124.0.6367.155-1'
+CHROME_VERSION='125.0.6422.60-1'
 
 # Cypress versions: https://www.npmjs.com/package/cypress
-CYPRESS_VERSION='13.9.0'
+CYPRESS_VERSION='13.10.0'
 
 # Edge versions: https://packages.microsoft.com/repos/edge/pool/main/m/microsoft-edge-stable/
-EDGE_VERSION='124.0.2478.80-1'
+EDGE_VERSION='125.0.2535.51-1'
 
 # Firefox versions: https://download-installer.cdn.mozilla.net/pub/firefox/releases/
-FIREFOX_VERSION='125.0.3'
+FIREFOX_VERSION='126.0'
 
 # Yarn versions: https://www.npmjs.com/package/yarn
 YARN_VERSION='1.22.19'

--- a/factory/CHANGELOG.md
+++ b/factory/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Change log
 
+## 3.5.6
+
+* Updated default node version from `20.13.0` to `20.13.1`. Addressed in [#1059](https://github.com/cypress-io/cypress-docker-images/pull/1059)
+
 ## 3.5.5
 
 * Updated default node version from `20.12.2` to `20.13.0`. Addressed in [#1045](https://github.com/cypress-io/cypress-docker-images/pull/1045)


### PR DESCRIPTION
updates browsers and node version along with Cypress 13.10.0 for the docker factory