### PR TITLE
chore: update to cypress 13.10.0 example specs

### DIFF
--- a/factory/test-project/cypress.config.js
+++ b/factory/test-project/cypress.config.js
@@ -6,10 +6,4 @@ module.exports = defineConfig({
       // implement node event listeners here
     },
   },
-  component: {
-    setupNodeEvents(on, config) {
-      // implement node event listeners here
-    },
-  },
-  experimentalWebKitSupport: true,
 });

--- a/factory/test-project/cypress/e2e/2-advanced-examples/actions.cy.js
+++ b/factory/test-project/cypress/e2e/2-advanced-examples/actions.cy.js
@@ -9,50 +9,51 @@ context('Actions', () => {
 
   it('.type() - type into a DOM element', () => {
     // https://on.cypress.io/type
-    cy.get('.action-email')
-      .type('fake@email.com').should('have.value', 'fake@email.com')
+    cy.get('.action-email').type('fake@email.com')
+    cy.get('.action-email').should('have.value', 'fake@email.com')
 
-      // .type() with special character sequences
-      .type('{leftarrow}{rightarrow}{uparrow}{downarrow}')
-      .type('{del}{selectall}{backspace}')
+    // .type() with special character sequences
+    cy.get('.action-email').type('{leftarrow}{rightarrow}{uparrow}{downarrow}')
+    cy.get('.action-email').type('{del}{selectall}{backspace}')
 
-      // .type() with key modifiers
-      .type('{alt}{option}') //these are equivalent
-      .type('{ctrl}{control}') //these are equivalent
-      .type('{meta}{command}{cmd}') //these are equivalent
-      .type('{shift}')
+    // .type() with key modifiers
+    cy.get('.action-email').type('{alt}{option}') //these are equivalent
+    cy.get('.action-email').type('{ctrl}{control}') //these are equivalent
+    cy.get('.action-email').type('{meta}{command}{cmd}') //these are equivalent
+    cy.get('.action-email').type('{shift}')
 
-      // Delay each keypress by 0.1 sec
-      .type('slow.typing@email.com', { delay: 100 })
-      .should('have.value', 'slow.typing@email.com')
+    // Delay each keypress by 0.1 sec
+    cy.get('.action-email').type('slow.typing@email.com', { delay: 100 })
+    cy.get('.action-email').should('have.value', 'slow.typing@email.com')
 
     cy.get('.action-disabled')
       // Ignore error checking prior to type
       // like whether the input is visible or disabled
       .type('disabled error checking', { force: true })
-      .should('have.value', 'disabled error checking')
+    cy.get('.action-disabled').should('have.value', 'disabled error checking')
   })
 
   it('.focus() - focus on a DOM element', () => {
     // https://on.cypress.io/focus
     cy.get('.action-focus').focus()
-      .should('have.class', 'focus')
+    cy.get('.action-focus').should('have.class', 'focus')
       .prev().should('have.attr', 'style', 'color: orange;')
   })
 
   it('.blur() - blur off a DOM element', () => {
     // https://on.cypress.io/blur
-    cy.get('.action-blur').type('About to blur').blur()
-      .should('have.class', 'error')
+    cy.get('.action-blur').type('About to blur')
+    cy.get('.action-blur').blur()
+    cy.get('.action-blur').should('have.class', 'error')
       .prev().should('have.attr', 'style', 'color: red;')
   })
 
   it('.clear() - clears an input or textarea element', () => {
     // https://on.cypress.io/clear
     cy.get('.action-clear').type('Clear this text')
-      .should('have.value', 'Clear this text')
-      .clear()
-      .should('have.value', '')
+    cy.get('.action-clear').should('have.value', 'Clear this text')
+    cy.get('.action-clear').clear()
+    cy.get('.action-clear').should('have.value', '')
   })
 
   it('.submit() - submit a form', () => {
@@ -61,7 +62,7 @@ context('Actions', () => {
       .find('[type="text"]').type('HALFOFF')
 
     cy.get('.action-form').submit()
-      .next().should('contain', 'Your form has been submitted!')
+    cy.get('.action-form').next().should('contain', 'Your form has been submitted!')
   })
 
   it('.click() - click on a DOM element', () => {
@@ -97,13 +98,13 @@ context('Actions', () => {
     // that controls where the click occurs :)
 
     cy.get('#action-canvas')
-      .click(80, 75) // click 80px on x coord and 75px on y coord
-      .click(170, 75)
-      .click(80, 165)
-      .click(100, 185)
-      .click(125, 190)
-      .click(150, 185)
-      .click(170, 165)
+    cy.get('#action-canvas').click(80, 75) // click 80px on x coord and 75px on y coord
+    cy.get('#action-canvas').click(170, 75)
+    cy.get('#action-canvas').click(80, 165)
+    cy.get('#action-canvas').click(100, 185)
+    cy.get('#action-canvas').click(125, 190)
+    cy.get('#action-canvas').click(150, 185)
+    cy.get('#action-canvas').click(170, 165)
 
     // click multiple elements by passing multiple: true
     cy.get('.action-labels>.label').click({ multiple: true })
@@ -117,7 +118,8 @@ context('Actions', () => {
 
     // Our app has a listener on 'dblclick' event in our 'scripts.js'
     // that hides the div and shows an input on double click
-    cy.get('.action-div').dblclick().should('not.be.visible')
+    cy.get('.action-div').dblclick()
+    cy.get('.action-div').should('not.be.visible')
     cy.get('.action-input-hidden').should('be.visible')
   })
 
@@ -126,7 +128,8 @@ context('Actions', () => {
 
     // Our app has a listener on 'contextmenu' event in our 'scripts.js'
     // that hides the div and shows an input on right click
-    cy.get('.rightclick-action-div').rightclick().should('not.be.visible')
+    cy.get('.rightclick-action-div').rightclick()
+    cy.get('.rightclick-action-div').should('not.be.visible')
     cy.get('.rightclick-action-input-hidden').should('be.visible')
   })
 
@@ -135,26 +138,26 @@ context('Actions', () => {
 
     // By default, .check() will check all
     // matching checkbox or radio elements in succession, one after another
-    cy.get('.action-checkboxes [type="checkbox"]').not('[disabled]')
-      .check().should('be.checked')
+    cy.get('.action-checkboxes [type="checkbox"]').not('[disabled]').check()
+    cy.get('.action-checkboxes [type="checkbox"]').not('[disabled]').should('be.checked')
 
-    cy.get('.action-radios [type="radio"]').not('[disabled]')
-      .check().should('be.checked')
+    cy.get('.action-radios [type="radio"]').not('[disabled]').check()
+    cy.get('.action-radios [type="radio"]').not('[disabled]').should('be.checked')
 
     // .check() accepts a value argument
-    cy.get('.action-radios [type="radio"]')
-      .check('radio1').should('be.checked')
+    cy.get('.action-radios [type="radio"]').check('radio1')
+    cy.get('.action-radios [type="radio"]').should('be.checked')
 
     // .check() accepts an array of values
-    cy.get('.action-multiple-checkboxes [type="checkbox"]')
-      .check(['checkbox1', 'checkbox2']).should('be.checked')
+    cy.get('.action-multiple-checkboxes [type="checkbox"]').check(['checkbox1', 'checkbox2'])
+    cy.get('.action-multiple-checkboxes [type="checkbox"]').should('be.checked')
 
     // Ignore error checking prior to checking
-    cy.get('.action-checkboxes [disabled]')
-      .check({ force: true }).should('be.checked')
+    cy.get('.action-checkboxes [disabled]').check({ force: true })
+    cy.get('.action-checkboxes [disabled]').should('be.checked')
 
-    cy.get('.action-radios [type="radio"]')
-      .check('radio3', { force: true }).should('be.checked')
+    cy.get('.action-radios [type="radio"]').check('radio3', { force: true })
+    cy.get('.action-radios [type="radio"]').should('be.checked')
   })
 
   it('.uncheck() - uncheck a checkbox element', () => {
@@ -164,21 +167,32 @@ context('Actions', () => {
     // checkbox elements in succession, one after another
     cy.get('.action-check [type="checkbox"]')
       .not('[disabled]')
-      .uncheck().should('not.be.checked')
+      .uncheck()
+    cy.get('.action-check [type="checkbox"]')
+      .not('[disabled]')
+      .should('not.be.checked')
 
     // .uncheck() accepts a value argument
     cy.get('.action-check [type="checkbox"]')
       .check('checkbox1')
-      .uncheck('checkbox1').should('not.be.checked')
+    cy.get('.action-check [type="checkbox"]')
+      .uncheck('checkbox1')
+    cy.get('.action-check [type="checkbox"][value="checkbox1"]')
+      .should('not.be.checked')
 
     // .uncheck() accepts an array of values
     cy.get('.action-check [type="checkbox"]')
       .check(['checkbox1', 'checkbox3'])
-      .uncheck(['checkbox1', 'checkbox3']).should('not.be.checked')
+    cy.get('.action-check [type="checkbox"]')
+      .uncheck(['checkbox1', 'checkbox3'])
+    cy.get('.action-check [type="checkbox"][value="checkbox1"]')
+      .should('not.be.checked')
+    cy.get('.action-check [type="checkbox"][value="checkbox3"]')
+      .should('not.be.checked')
 
     // Ignore error checking prior to unchecking
-    cy.get('.action-check [disabled]')
-      .uncheck({ force: true }).should('not.be.checked')
+    cy.get('.action-check [disabled]').uncheck({ force: true })
+    cy.get('.action-check [disabled]').should('not.be.checked')
   })
 
   it('.select() - select an option in a <select> element', () => {
@@ -196,17 +210,20 @@ context('Actions', () => {
 
     cy.get('.action-select-multiple')
       .select(['apples', 'oranges', 'bananas'])
+    cy.get('.action-select-multiple')
       // when getting multiple values, invoke "val" method first
       .invoke('val')
       .should('deep.equal', ['fr-apples', 'fr-oranges', 'fr-bananas'])
 
     // Select option(s) with matching value
     cy.get('.action-select').select('fr-bananas')
+    cy.get('.action-select')
       // can attach an assertion right away to the element
       .should('have.value', 'fr-bananas')
 
     cy.get('.action-select-multiple')
       .select(['fr-apples', 'fr-oranges', 'fr-bananas'])
+    cy.get('.action-select-multiple')
       .invoke('val')
       .should('deep.equal', ['fr-apples', 'fr-oranges', 'fr-bananas'])
 
@@ -227,6 +244,7 @@ context('Actions', () => {
 
     // scroll the button into view, as if the user had scrolled
     cy.get('#scroll-horizontal button').scrollIntoView()
+    cy.get('#scroll-horizontal button')
       .should('be.visible')
 
     cy.get('#scroll-vertical button')
@@ -234,6 +252,7 @@ context('Actions', () => {
 
     // Cypress handles the scroll direction needed
     cy.get('#scroll-vertical button').scrollIntoView()
+    cy.get('#scroll-vertical button')
       .should('be.visible')
 
     cy.get('#scroll-both button')
@@ -241,6 +260,7 @@ context('Actions', () => {
 
     // Cypress knows to scroll to the right and down
     cy.get('#scroll-both button').scrollIntoView()
+    cy.get('#scroll-both button')
       .should('be.visible')
   })
 
@@ -255,7 +275,9 @@ context('Actions', () => {
     // the value and trigger the 'change' event
     cy.get('.trigger-input-range')
       .invoke('val', 25)
+    cy.get('.trigger-input-range')
       .trigger('change')
+    cy.get('.trigger-input-range')
       .get('input[type=range]').siblings('p')
       .should('have.text', '25')
   })

--- a/factory/test-project/cypress/e2e/2-advanced-examples/connectors.cy.js
+++ b/factory/test-project/cypress/e2e/2-advanced-examples/connectors.cy.js
@@ -24,12 +24,13 @@ context('Connectors', () => {
   it('.invoke() - invoke a function on the current subject', () => {
     // our div is hidden in our script.js
     // $('.connectors-div').hide()
+    cy.get('.connectors-div').should('be.hidden')
 
     // https://on.cypress.io/invoke
-    cy.get('.connectors-div').should('be.hidden')
-      // call the jquery method 'show' on the 'div.container'
-      .invoke('show')
-      .should('be.visible')
+    // call the jquery method 'show' on the 'div.container'
+    cy.get('.connectors-div').invoke('show')
+
+    cy.get('.connectors-div').should('be.visible')
   })
 
   it('.spread() - spread an array as individual args to callback function', () => {

--- a/factory/test-project/cypress/e2e/2-advanced-examples/cookies.cy.js
+++ b/factory/test-project/cypress/e2e/2-advanced-examples/cookies.cy.js
@@ -19,7 +19,7 @@ context('Cookies', () => {
     cy.getCookie('token').should('have.property', 'value', '123ABC')
   })
 
-  it('cy.getCookies() - get browser cookies', () => {
+  it('cy.getCookies() - get browser cookies for the current domain', () => {
     // https://on.cypress.io/getcookies
     cy.getCookies().should('be.empty')
 
@@ -34,6 +34,32 @@ context('Cookies', () => {
       expect(cookies[0]).to.have.property('secure', false)
       expect(cookies[0]).to.have.property('domain')
       expect(cookies[0]).to.have.property('path')
+    })
+  })
+
+  it('cy.getAllCookies() - get all browser cookies', () => {
+    // https://on.cypress.io/getallcookies
+    cy.getAllCookies().should('be.empty')
+
+    cy.setCookie('key', 'value')
+    cy.setCookie('key', 'value', { domain: '.example.com' })
+
+    // cy.getAllCookies() yields an array of cookies
+    cy.getAllCookies().should('have.length', 2).should((cookies) => {
+      // each cookie has these properties
+      expect(cookies[0]).to.have.property('name', 'key')
+      expect(cookies[0]).to.have.property('value', 'value')
+      expect(cookies[0]).to.have.property('httpOnly', false)
+      expect(cookies[0]).to.have.property('secure', false)
+      expect(cookies[0]).to.have.property('domain')
+      expect(cookies[0]).to.have.property('path')
+
+      expect(cookies[1]).to.have.property('name', 'key')
+      expect(cookies[1]).to.have.property('value', 'value')
+      expect(cookies[1]).to.have.property('httpOnly', false)
+      expect(cookies[1]).to.have.property('secure', false)
+      expect(cookies[1]).to.have.property('domain', '.example.com')
+      expect(cookies[1]).to.have.property('path')
     })
   })
 
@@ -56,12 +82,12 @@ context('Cookies', () => {
     cy.getCookie('token').should('have.property', 'value', '123ABC')
 
     // cy.clearCookies() yields null
-    cy.clearCookie('token').should('be.null')
+    cy.clearCookie('token')
 
     cy.getCookie('token').should('be.null')
   })
 
-  it('cy.clearCookies() - clear browser cookies', () => {
+  it('cy.clearCookies() - clear browser cookies for the current domain', () => {
     // https://on.cypress.io/clearcookies
     cy.getCookies().should('be.empty')
 
@@ -73,5 +99,20 @@ context('Cookies', () => {
     cy.clearCookies()
 
     cy.getCookies().should('be.empty')
+  })
+
+  it('cy.clearAllCookies() - clear all browser cookies', () => {
+    // https://on.cypress.io/clearallcookies
+    cy.getAllCookies().should('be.empty')
+
+    cy.setCookie('key', 'value')
+    cy.setCookie('key', 'value', { domain: '.example.com' })
+
+    cy.getAllCookies().should('have.length', 2)
+
+    // cy.clearAllCookies() yields null
+    cy.clearAllCookies()
+
+    cy.getAllCookies().should('be.empty')
   })
 })

--- a/factory/test-project/cypress/e2e/2-advanced-examples/cypress_api.cy.js
+++ b/factory/test-project/cypress/e2e/2-advanced-examples/cypress_api.cy.js
@@ -1,182 +1,185 @@
 /// <reference types="cypress" />
 
-context('Cypress.Commands', () => {
-  beforeEach(() => {
-    cy.visit('https://example.cypress.io/cypress-api')
-  })
+context('Cypress APIs', () => {
 
-  // https://on.cypress.io/custom-commands
+  context('Cypress.Commands', () => {
+    beforeEach(() => {
+      cy.visit('https://example.cypress.io/cypress-api')
+    })
 
-  it('.add() - create a custom command', () => {
-    Cypress.Commands.add('console', {
-      prevSubject: true,
-    }, (subject, method) => {
+    // https://on.cypress.io/custom-commands
+
+    it('.add() - create a custom command', () => {
+      Cypress.Commands.add('console', {
+        prevSubject: true,
+      }, (subject, method) => {
       // the previous subject is automatically received
       // and the commands arguments are shifted
 
-      // allow us to change the console method used
-      method = method || 'log'
+        // allow us to change the console method used
+        method = method || 'log'
 
-      // log the subject to the console
-      console[method]('The subject is', subject)
+        // log the subject to the console
+        console[method]('The subject is', subject)
 
-      // whatever we return becomes the new subject
-      // we don't want to change the subject so
-      // we return whatever was passed in
-      return subject
-    })
+        // whatever we return becomes the new subject
+        // we don't want to change the subject so
+        // we return whatever was passed in
+        return subject
+      })
 
-    cy.get('button').console('info').then(($button) => {
+      cy.get('button').console('info').then(($button) => {
       // subject is still $button
+      })
     })
   })
-})
 
-context('Cypress.Cookies', () => {
-  beforeEach(() => {
-    cy.visit('https://example.cypress.io/cypress-api')
+  context('Cypress.Cookies', () => {
+    beforeEach(() => {
+      cy.visit('https://example.cypress.io/cypress-api')
+    })
+
+    // https://on.cypress.io/cookies
+    it('.debug() - enable or disable debugging', () => {
+      Cypress.Cookies.debug(true)
+
+      // Cypress will now log in the console when
+      // cookies are set or cleared
+      cy.setCookie('fakeCookie', '123ABC')
+      cy.clearCookie('fakeCookie')
+      cy.setCookie('fakeCookie', '123ABC')
+      cy.clearCookie('fakeCookie')
+      cy.setCookie('fakeCookie', '123ABC')
+    })
   })
 
-  // https://on.cypress.io/cookies
-  it('.debug() - enable or disable debugging', () => {
-    Cypress.Cookies.debug(true)
+  context('Cypress.arch', () => {
+    beforeEach(() => {
+      cy.visit('https://example.cypress.io/cypress-api')
+    })
 
-    // Cypress will now log in the console when
-    // cookies are set or cleared
-    cy.setCookie('fakeCookie', '123ABC')
-    cy.clearCookie('fakeCookie')
-    cy.setCookie('fakeCookie', '123ABC')
-    cy.clearCookie('fakeCookie')
-    cy.setCookie('fakeCookie', '123ABC')
-  })
-})
-
-context('Cypress.arch', () => {
-  beforeEach(() => {
-    cy.visit('https://example.cypress.io/cypress-api')
-  })
-
-  it('Get CPU architecture name of underlying OS', () => {
+    it('Get CPU architecture name of underlying OS', () => {
     // https://on.cypress.io/arch
-    expect(Cypress.arch).to.exist
-  })
-})
-
-context('Cypress.config()', () => {
-  beforeEach(() => {
-    cy.visit('https://example.cypress.io/cypress-api')
+      expect(Cypress.arch).to.exist
+    })
   })
 
-  it('Get and set configuration options', () => {
+  context('Cypress.config()', () => {
+    beforeEach(() => {
+      cy.visit('https://example.cypress.io/cypress-api')
+    })
+
+    it('Get and set configuration options', () => {
     // https://on.cypress.io/config
-    let myConfig = Cypress.config()
+      let myConfig = Cypress.config()
 
-    expect(myConfig).to.have.property('animationDistanceThreshold', 5)
-    expect(myConfig).to.have.property('baseUrl', null)
-    expect(myConfig).to.have.property('defaultCommandTimeout', 4000)
-    expect(myConfig).to.have.property('requestTimeout', 5000)
-    expect(myConfig).to.have.property('responseTimeout', 30000)
-    expect(myConfig).to.have.property('viewportHeight', 660)
-    expect(myConfig).to.have.property('viewportWidth', 1000)
-    expect(myConfig).to.have.property('pageLoadTimeout', 60000)
-    expect(myConfig).to.have.property('waitForAnimations', true)
+      expect(myConfig).to.have.property('animationDistanceThreshold', 5)
+      expect(myConfig).to.have.property('baseUrl', null)
+      expect(myConfig).to.have.property('defaultCommandTimeout', 4000)
+      expect(myConfig).to.have.property('requestTimeout', 5000)
+      expect(myConfig).to.have.property('responseTimeout', 30000)
+      expect(myConfig).to.have.property('viewportHeight', 660)
+      expect(myConfig).to.have.property('viewportWidth', 1000)
+      expect(myConfig).to.have.property('pageLoadTimeout', 60000)
+      expect(myConfig).to.have.property('waitForAnimations', true)
 
-    expect(Cypress.config('pageLoadTimeout')).to.eq(60000)
+      expect(Cypress.config('pageLoadTimeout')).to.eq(60000)
 
-    // this will change the config for the rest of your tests!
-    Cypress.config('pageLoadTimeout', 20000)
+      // this will change the config for the rest of your tests!
+      Cypress.config('pageLoadTimeout', 20000)
 
-    expect(Cypress.config('pageLoadTimeout')).to.eq(20000)
+      expect(Cypress.config('pageLoadTimeout')).to.eq(20000)
 
-    Cypress.config('pageLoadTimeout', 60000)
-  })
-})
-
-context('Cypress.dom', () => {
-  beforeEach(() => {
-    cy.visit('https://example.cypress.io/cypress-api')
+      Cypress.config('pageLoadTimeout', 60000)
+    })
   })
 
-  // https://on.cypress.io/dom
-  it('.isHidden() - determine if a DOM element is hidden', () => {
-    let hiddenP = Cypress.$('.dom-p p.hidden').get(0)
-    let visibleP = Cypress.$('.dom-p p.visible').get(0)
+  context('Cypress.dom', () => {
+    beforeEach(() => {
+      cy.visit('https://example.cypress.io/cypress-api')
+    })
 
-    // our first paragraph has css class 'hidden'
-    expect(Cypress.dom.isHidden(hiddenP)).to.be.true
-    expect(Cypress.dom.isHidden(visibleP)).to.be.false
+    // https://on.cypress.io/dom
+    it('.isHidden() - determine if a DOM element is hidden', () => {
+      let hiddenP = Cypress.$('.dom-p p.hidden').get(0)
+      let visibleP = Cypress.$('.dom-p p.visible').get(0)
+
+      // our first paragraph has css class 'hidden'
+      expect(Cypress.dom.isHidden(hiddenP)).to.be.true
+      expect(Cypress.dom.isHidden(visibleP)).to.be.false
+    })
   })
-})
 
-context('Cypress.env()', () => {
-  beforeEach(() => {
-    cy.visit('https://example.cypress.io/cypress-api')
-  })
+  context('Cypress.env()', () => {
+    beforeEach(() => {
+      cy.visit('https://example.cypress.io/cypress-api')
+    })
 
-  // We can set environment variables for highly dynamic values
+    // We can set environment variables for highly dynamic values
 
-  // https://on.cypress.io/environment-variables
-  it('Get environment variables', () => {
+    // https://on.cypress.io/environment-variables
+    it('Get environment variables', () => {
     // https://on.cypress.io/env
     // set multiple environment variables
-    Cypress.env({
-      host: 'veronica.dev.local',
-      api_server: 'http://localhost:8888/v1/',
+      Cypress.env({
+        host: 'veronica.dev.local',
+        api_server: 'http://localhost:8888/v1/',
+      })
+
+      // get environment variable
+      expect(Cypress.env('host')).to.eq('veronica.dev.local')
+
+      // set environment variable
+      Cypress.env('api_server', 'http://localhost:8888/v2/')
+      expect(Cypress.env('api_server')).to.eq('http://localhost:8888/v2/')
+
+      // get all environment variable
+      expect(Cypress.env()).to.have.property('host', 'veronica.dev.local')
+      expect(Cypress.env()).to.have.property('api_server', 'http://localhost:8888/v2/')
+    })
+  })
+
+  context('Cypress.log', () => {
+    beforeEach(() => {
+      cy.visit('https://example.cypress.io/cypress-api')
     })
 
-    // get environment variable
-    expect(Cypress.env('host')).to.eq('veronica.dev.local')
-
-    // set environment variable
-    Cypress.env('api_server', 'http://localhost:8888/v2/')
-    expect(Cypress.env('api_server')).to.eq('http://localhost:8888/v2/')
-
-    // get all environment variable
-    expect(Cypress.env()).to.have.property('host', 'veronica.dev.local')
-    expect(Cypress.env()).to.have.property('api_server', 'http://localhost:8888/v2/')
-  })
-})
-
-context('Cypress.log', () => {
-  beforeEach(() => {
-    cy.visit('https://example.cypress.io/cypress-api')
-  })
-
-  it('Control what is printed to the Command Log', () => {
+    it('Control what is printed to the Command Log', () => {
     // https://on.cypress.io/cypress-log
-  })
-})
-
-context('Cypress.platform', () => {
-  beforeEach(() => {
-    cy.visit('https://example.cypress.io/cypress-api')
+    })
   })
 
-  it('Get underlying OS name', () => {
+  context('Cypress.platform', () => {
+    beforeEach(() => {
+      cy.visit('https://example.cypress.io/cypress-api')
+    })
+
+    it('Get underlying OS name', () => {
     // https://on.cypress.io/platform
-    expect(Cypress.platform).to.be.exist
-  })
-})
-
-context('Cypress.version', () => {
-  beforeEach(() => {
-    cy.visit('https://example.cypress.io/cypress-api')
+      expect(Cypress.platform).to.be.exist
+    })
   })
 
-  it('Get current version of Cypress being run', () => {
+  context('Cypress.version', () => {
+    beforeEach(() => {
+      cy.visit('https://example.cypress.io/cypress-api')
+    })
+
+    it('Get current version of Cypress being run', () => {
     // https://on.cypress.io/version
-    expect(Cypress.version).to.be.exist
-  })
-})
-
-context('Cypress.spec', () => {
-  beforeEach(() => {
-    cy.visit('https://example.cypress.io/cypress-api')
+      expect(Cypress.version).to.be.exist
+    })
   })
 
-  it('Get current spec information', () => {
+  context('Cypress.spec', () => {
+    beforeEach(() => {
+      cy.visit('https://example.cypress.io/cypress-api')
+    })
+
+    it('Get current spec information', () => {
     // https://on.cypress.io/spec
     // wrap the object so we can inspect it easily by clicking in the command log
-    cy.wrap(Cypress.spec).should('include.keys', ['name', 'relative', 'absolute'])
+      cy.wrap(Cypress.spec).should('include.keys', ['name', 'relative', 'absolute'])
+    })
   })
 })

--- a/factory/test-project/cypress/e2e/2-advanced-examples/files.cy.js
+++ b/factory/test-project/cypress/e2e/2-advanced-examples/files.cy.js
@@ -7,9 +7,7 @@ const requiredExample = require('../../fixtures/example')
 context('Files', () => {
   beforeEach(() => {
     cy.visit('https://example.cypress.io/commands/files')
-  })
 
-  beforeEach(() => {
     // load example.json fixture file and store
     // in the test context object
     cy.fixture('example.json').as('example')

--- a/factory/test-project/cypress/e2e/2-advanced-examples/navigation.cy.js
+++ b/factory/test-project/cypress/e2e/2-advanced-examples/navigation.cy.js
@@ -39,7 +39,6 @@ context('Navigation', () => {
     // https://on.cypress.io/visit
 
     // Visit any sub-domain of your current domain
-
     // Pass options to the visit
     cy.visit('https://example.cypress.io/commands/navigation', {
       timeout: 50000, // increase total time for the visit to resolve
@@ -52,5 +51,5 @@ context('Navigation', () => {
         expect(typeof contentWindow === 'object').to.be.true
       },
     })
-    })
+  })
 })

--- a/factory/test-project/cypress/e2e/2-advanced-examples/spies_stubs_clocks.cy.js
+++ b/factory/test-project/cypress/e2e/2-advanced-examples/spies_stubs_clocks.cy.js
@@ -1,6 +1,4 @@
 /// <reference types="cypress" />
-// remove no check once Cypress.sinon is typed
-// https://github.com/cypress-io/cypress/issues/6720
 
 context('Spies, Stubs, and Clock', () => {
   it('cy.spy() - wrap a method in a spy', () => {
@@ -69,30 +67,33 @@ context('Spies, Stubs, and Clock', () => {
   it('cy.clock() - control time in the browser', () => {
     // https://on.cypress.io/clock
 
-    // create the date in UTC so its always the same
+    // create the date in UTC so it's always the same
     // no matter what local timezone the browser is running in
     const now = new Date(Date.UTC(2017, 2, 14)).getTime()
 
     cy.clock(now)
     cy.visit('https://example.cypress.io/commands/spies-stubs-clocks')
     cy.get('#clock-div').click()
+    cy.get('#clock-div')
       .should('have.text', '1489449600')
   })
 
   it('cy.tick() - move time in the browser', () => {
     // https://on.cypress.io/tick
 
-    // create the date in UTC so its always the same
+    // create the date in UTC so it's always the same
     // no matter what local timezone the browser is running in
     const now = new Date(Date.UTC(2017, 2, 14)).getTime()
 
     cy.clock(now)
     cy.visit('https://example.cypress.io/commands/spies-stubs-clocks')
     cy.get('#tick-div').click()
+    cy.get('#tick-div')
       .should('have.text', '1489449600')
 
     cy.tick(10000) // 10 seconds passed
     cy.get('#tick-div').click()
+    cy.get('#tick-div')
       .should('have.text', '1489449610')
   })
 

--- a/factory/test-project/cypress/e2e/2-advanced-examples/storage.cy.js
+++ b/factory/test-project/cypress/e2e/2-advanced-examples/storage.cy.js
@@ -10,43 +10,48 @@ context('Local Storage / Session Storage', () => {
 
   it('cy.clearLocalStorage() - clear all data in localStorage for the current origin', () => {
     // https://on.cypress.io/clearlocalstorage
-    cy.get('.ls-btn').click().should(() => {
+    cy.get('.ls-btn').click()
+    cy.get('.ls-btn').should(() => {
       expect(localStorage.getItem('prop1')).to.eq('red')
       expect(localStorage.getItem('prop2')).to.eq('blue')
       expect(localStorage.getItem('prop3')).to.eq('magenta')
     })
 
-    // clearLocalStorage() yields the localStorage object
-    cy.clearLocalStorage().should((ls) => {
-      expect(ls.getItem('prop1')).to.be.null
-      expect(ls.getItem('prop2')).to.be.null
-      expect(ls.getItem('prop3')).to.be.null
+    cy.clearLocalStorage()
+    cy.getAllLocalStorage().should(() => {
+      expect(localStorage.getItem('prop1')).to.be.null
+      expect(localStorage.getItem('prop2')).to.be.null
+      expect(localStorage.getItem('prop3')).to.be.null
     })
 
-    cy.get('.ls-btn').click().should(() => {
+    cy.get('.ls-btn').click()
+    cy.get('.ls-btn').should(() => {
       expect(localStorage.getItem('prop1')).to.eq('red')
       expect(localStorage.getItem('prop2')).to.eq('blue')
       expect(localStorage.getItem('prop3')).to.eq('magenta')
     })
 
     // Clear key matching string in localStorage
-    cy.clearLocalStorage('prop1').should((ls) => {
-      expect(ls.getItem('prop1')).to.be.null
-      expect(ls.getItem('prop2')).to.eq('blue')
-      expect(ls.getItem('prop3')).to.eq('magenta')
+    cy.clearLocalStorage('prop1')
+    cy.getAllLocalStorage().should(() => {
+      expect(localStorage.getItem('prop1')).to.be.null
+      expect(localStorage.getItem('prop2')).to.eq('blue')
+      expect(localStorage.getItem('prop3')).to.eq('magenta')
     })
 
-    cy.get('.ls-btn').click().should(() => {
+    cy.get('.ls-btn').click()
+    cy.get('.ls-btn').should(() => {
       expect(localStorage.getItem('prop1')).to.eq('red')
       expect(localStorage.getItem('prop2')).to.eq('blue')
       expect(localStorage.getItem('prop3')).to.eq('magenta')
     })
 
     // Clear keys matching regex in localStorage
-    cy.clearLocalStorage(/prop1|2/).should((ls) => {
-      expect(ls.getItem('prop1')).to.be.null
-      expect(ls.getItem('prop2')).to.be.null
-      expect(ls.getItem('prop3')).to.eq('magenta')
+    cy.clearLocalStorage(/prop1|2/)
+    cy.getAllLocalStorage().should(() => {
+      expect(localStorage.getItem('prop1')).to.be.null
+      expect(localStorage.getItem('prop2')).to.be.null
+      expect(localStorage.getItem('prop3')).to.eq('magenta')
     })
   })
 
@@ -72,10 +77,11 @@ context('Local Storage / Session Storage', () => {
     cy.get('.ls-btn').click()
 
     // clearAllLocalStorage() yields null
-    cy.clearAllLocalStorage().should(() => {
-      expect(sessionStorage.getItem('prop1')).to.be.null
-      expect(sessionStorage.getItem('prop2')).to.be.null
-      expect(sessionStorage.getItem('prop3')).to.be.null
+    cy.clearAllLocalStorage()
+    cy.getAllLocalStorage().should(() => {
+      expect(localStorage.getItem('prop1')).to.be.null
+      expect(localStorage.getItem('prop2')).to.be.null
+      expect(localStorage.getItem('prop3')).to.be.null
     })
   })
 
@@ -101,7 +107,8 @@ context('Local Storage / Session Storage', () => {
     cy.get('.ls-btn').click()
 
     // clearAllSessionStorage() yields null
-    cy.clearAllSessionStorage().should(() => {
+    cy.clearAllSessionStorage()
+    cy.getAllSessionStorage().should(() => {
       expect(sessionStorage.getItem('prop4')).to.be.null
       expect(sessionStorage.getItem('prop5')).to.be.null
       expect(sessionStorage.getItem('prop6')).to.be.null

--- a/factory/test-project/cypress/e2e/2-advanced-examples/utilities.cy.js
+++ b/factory/test-project/cypress/e2e/2-advanced-examples/utilities.cy.js
@@ -19,10 +19,9 @@ context('Utilities', () => {
     // https://on.cypress.io/$
     let $li = Cypress.$('.utility-jquery li:first')
 
-    cy.wrap($li)
-      .should('not.have.class', 'active')
-      .click()
-      .should('have.class', 'active')
+    cy.wrap($li).should('not.have.class', 'active')
+    cy.wrap($li).click()
+    cy.wrap($li).should('have.class', 'active')
   })
 
   it('Cypress.Blob - blob utilities and base64 string conversion', () => {
@@ -41,7 +40,7 @@ context('Utilities', () => {
         $div.append(img)
 
         cy.get('.utility-blob img').click()
-          .should('have.attr', 'src', dataUrl)
+        cy.get('.utility-blob img').should('have.attr', 'src', dataUrl)
       })
     })
   })

--- a/factory/test-project/cypress/e2e/2-advanced-examples/viewport.cy.js
+++ b/factory/test-project/cypress/e2e/2-advanced-examples/viewport.cy.js
@@ -1,5 +1,4 @@
 /// <reference types="cypress" />
-
 context('Viewport', () => {
   beforeEach(() => {
     cy.visit('https://example.cypress.io/commands/viewport')

--- a/factory/test-project/cypress/e2e/2-advanced-examples/waiting.cy.js
+++ b/factory/test-project/cypress/e2e/2-advanced-examples/waiting.cy.js
@@ -1,5 +1,4 @@
 /// <reference types="cypress" />
-
 context('Waiting', () => {
   beforeEach(() => {
     cy.visit('https://example.cypress.io/commands/waiting')


### PR DESCRIPTION
## Issue

The example specs in [factory/test-project](https://github.com/cypress-io/cypress-docker-images/tree/master/factory/test-project) are out of date and not aligned to Cypress `13.10.0`. There have been a number of corrections made to the upstream source [cypress-io/cypress-example-kitchensink](https://github.com/cypress-io/cypress-example-kitchensink).

## Change

- Recreate [factory/test-project/cypress](https://github.com/cypress-io/cypress-docker-images/tree/master/factory/test-project/cypress)