### PR TITLE
chore: update test-project package.json

### DIFF
--- a/factory/test-project/package.json
+++ b/factory/test-project/package.json
@@ -1,10 +1,8 @@
 {
   "name": "test-project",
   "version": "1.0.0",
-  "description": "",
+  "description": "Test project for Cypress Docker images",
   "scripts": {
     "test": "cypress run"
-  },
-  "author": "",
-  "license": "ISC"
+  }
 }


### PR DESCRIPTION
## Issue

[factory/test-project/package.json](https://github.com/cypress-io/cypress-docker-images/blob/master/factory/test-project/package.json) has several minor issues:

The `description` and `author` fields are blank. The `license` field is incorrectly showing `ISC`.

## Changes

Make corrections to [factory/test-project/package.json](https://github.com/cypress-io/cypress-docker-images/blob/master/factory/test-project/package.json):

1. Add a description "Test project for Cypress Docker images"
2. Remove the `author` and `license` fields. The test-project is never published separately and the repo itself is licensed with the [MIT license](https://github.com/cypress-io/cypress-docker-images/blob/master/LICENSE)

## Verification

On Ubuntu `22.04.4` LTS, Node.js `20.13.1` LTS

execute:

```shell
cd factory/test-project
npm install cypress@latest --no-package-lock
npm test
npm uninstall cypress --no-package-lock
```

and confirm that all tests run successfully.
