### PR TITLE
docs: remove global profile from contributing

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -162,7 +162,7 @@ In CI, the images are built and tested in real `arm64` and `x64` architectures. 
 └─────────────────────────────────────────────┘
 ```
 
-A current limitation is that no `arm64` images have browser binaries - see https://github.com/cypress-io/cypress-docker-images/issues/695 for details. [`global-profile.sh`](./scripts/for-images/global-profile.sh) is placed in `/etc/bash.bashrc`, so Arm Docker users will see a warning about this limitation.
+A current limitation is that no `arm64` images have browser binaries - see https://github.com/cypress-io/cypress-docker-images/issues/695 for details.
 
 ### Updating images to add `linux/arm64`
 
@@ -220,5 +220,3 @@ When following these steps, you may get into a state where you have cached copie
     ```
 12. Delete the `tmp` tag.
 </details>
-
-


### PR DESCRIPTION
## Issue

[CONTRIBUTING > Multi-Architecture Support](https://github.com/cypress-io/cypress-docker-images/blob/master/CONTRIBUTING.md#multi-architecture-support) contains the paragraph:

> A current limitation is that no `arm64` images have browser binaries - see https://github.com/cypress-io/cypress-docker-images/issues/695 for details. [`global-profile.sh`](https://github.com/cypress-io/cypress-docker-images/blob/master/scripts/for-images/global-profile.sh) is placed in `/etc/bash.bashrc`, so Arm Docker users will see a warning about this limitation.

The second sentence links to https://github.com/cypress-io/cypress-docker-images/blob/master/scripts/for-images/global-profile.sh and produces a "404 -page not found" error.

- PR https://github.com/cypress-io/cypress-docker-images/pull/812 removed the file [scripts/for-images/global-profile.sh](https://github.com/cypress-io/cypress-docker-images/blob/master/scripts/for-images/global-profile.sh) and the description referring to this file is obsolete.

## Change

Remove the second sentence (below) in the above paragraph from [CONTRIBUTING > Multi-Architecture Support](https://github.com/cypress-io/cypress-docker-images/blob/master/CONTRIBUTING.md#multi-architecture-support):

> [`global-profile.sh`](https://github.com/cypress-io/cypress-docker-images/blob/master/scripts/for-images/global-profile.sh) is placed in `/etc/bash.bashrc`, so Arm Docker users will see a warning about this limitation.