### PR TITLE
chore(deps): update to yarn 1.22.22

### DIFF
--- a/factory/.env
+++ b/factory/.env
@@ -14,7 +14,7 @@ FACTORY_DEFAULT_NODE_VERSION='20.13.1'
 NODE_VERSION="${FACTORY_DEFAULT_NODE_VERSION}"
 
 # Update this to deploy the docker factory if you make changes to factory.Dockerfile or install scripts
-FACTORY_VERSION='3.5.6'
+FACTORY_VERSION='3.5.7'
 
 # Chrome versions: https://www.ubuntuupdates.org/package/google_chrome/stable/main/base/google-chrome-stable
 CHROME_VERSION='125.0.6422.60-1'
@@ -28,8 +28,9 @@ EDGE_VERSION='125.0.2535.51-1'
 # Firefox versions: https://download-installer.cdn.mozilla.net/pub/firefox/releases/
 FIREFOX_VERSION='126.0'
 
-# Yarn versions: https://www.npmjs.com/package/yarn
-YARN_VERSION='1.22.19'
+# Yarn versions: https://www.npmjs.com/package/yarn and
+# https://classic.yarnpkg.com/latest-version
+YARN_VERSION='1.22.22'
 
 # Webkit versions: https://www.npmjs.com/package/playwright-webkit
 # TODO: Globally installed webkit currently isn't found, see issue https://github.com/cypress-io/cypress/issues/25344

--- a/factory/CHANGELOG.md
+++ b/factory/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Change log
 
+## 3.5.7
+
+* Updated Yarn (v1 Classic) version from `1.22.19` to `1.22.22`. Addressed in [#1071](https://github.com/cypress-io/cypress-docker-images/pull/1071)
+
 ## 3.5.6
 
 * Updated default node version from `20.13.0` to `20.13.1`. Addressed in [#1059](https://github.com/cypress-io/cypress-docker-images/pull/1059)


### PR DESCRIPTION
- closes https://github.com/cypress-io/cypress-docker-images/issues/1036
- supersedes https://github.com/cypress-io/cypress-docker-images/pull/1037

## Issue

- The stable version of Yarn v1 Classic has changed from `1.22.19` to `1.22.22`
- If Yarn v1 Classic `1.22.19` is used under Node.js `21` or later, it shows deprecation warnings. This issue is resolved in the stable version `1.22.22` (see issue https://github.com/yarnpkg/yarn/issues/9013).

## Change

In [factory/.env](https://github.com/cypress-io/cypress-docker-images/blob/master/factory/.env)

1. Update `FACTORY_VERSION` to `3.5.7`
2. Update `YARN_VERSION` to `1.22.22`

## References

- Yarn release [v1.22.22](https://github.com/yarnpkg/yarn/releases/tag/v1.22.22)
- https://classic.yarnpkg.com/latest-version shows `1.22.22` to be the `latest` (`stable`) version
- https://classic.yarnpkg.com/en/docs/install shows Classic Stable: `v1.22.22`