### PR TITLE
docs: remove base readme obsolete information

### DIFF
--- a/base/README.md
+++ b/base/README.md
@@ -5,31 +5,3 @@
 > Docker images that include all operating system dependencies necessary to run Cypress, **but NOT Cypress itself** and no pre-installed browsers. See [cypress/included](../included) images if you need Cypress pre-installed in the image. See [cypress/browsers](../browsers) images if you need some browsers pre-installed in the image.
 
 Each tag is named after the Node version or OS it is built on.
-
-> **Note** All Base Images install the latest versions of NPM & Yarn.
-
-## ⚠️ Node.js Support
-
-Cypress 4.0+ no longer supports Node.js versions below 8.0.0. See our [Migration Guide](https://on.cypress.io/migration-guide#Node-js-8-support).
-
-Using 6.x images is not recommended, and we do not plan to release new versions of Cypress tested on Node.js below 8.0.0.
-
-## Information
-
-Node release schedule at [nodejs/Release](https://github.com/nodejs/Release) and one can find LTS versions using [nvm](https://github.com/creationix/nvm) tool
-
-```text
-nvm ls-remote | grep LTS
-...
-  v8.16.1   (LTS: Carbon)
-  v8.16.2   (LTS: Carbon)
-  v8.17.0   (Latest LTS: Carbon)
-...
-  v10.18.0   (LTS: Dubnium)
-  v10.18.1   (LTS: Dubnium)
-  v10.19.0   (Latest LTS: Dubnium)
-...
-  v12.14.1   (LTS: Erbium)
-  v12.15.0   (LTS: Erbium)
-  v12.16.0   (Latest LTS: Erbium)
-```


### PR DESCRIPTION
## Issue

[base/README.md](https://github.com/cypress-io/cypress-docker-images/blob/master/base/README.md) contains outdated information:

- base images do not install the latest versions of NPM & Yarn
  - npm is bundled with Node.js. Often the bundled version of npm lags behind the latest version of npm.
  - Yarn is not the latest version. It is the frozen Yarn v1 Classic version defined in [factory/.env](https://github.com/cypress-io/cypress-docker-images/blob/master/factory/.env) (currently `1.22.19`). The latest Yarn Modern version is [4.2.2](https://github.com/yarnpkg/berry/releases/tag/%40yarnpkg%2Fcli%2F4.2.2).
- The sections referring to Node.js are discussing legacy Cypress versions and versions of Node.js which are no longer under support

## Change

Remove the outdated information from [base/README.md](https://github.com/cypress-io/cypress-docker-images/blob/master/base/README.md)
