### PR TITLE
chore: fix failing contributing links

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -84,7 +84,7 @@ docker run --rm -it -e DISPLAY="host.docker.internal:0" -v /tmp/.X11-unix:/tmp/.
 
 ## Releasing a new factory version
 
-To release a new [factory](/factory/README.md), open a PR with the desired changes to the [factory.Dockerfile](/factory/factory.Dockerfile) or [installScripts](/factory/installScripts/). After making changes, note the changes in the factory [CHANGELOG](/factory/CHANGELOG.md) and bump the `FACTORY_VERSION` in the [.env](/factory/.env) file to trigger a new release.
+To release a new [factory](./factory/README.md), open a PR with the desired changes to the [factory.Dockerfile](./factory/factory.Dockerfile) or [installScripts](./factory/installScripts/). After making changes, note the changes in the factory [CHANGELOG](./factory/CHANGELOG.md) and bump the `FACTORY_VERSION` in the [.env](./factory/.env) file to trigger a new release.
 
 ## Minimize image sizes
 


### PR DESCRIPTION
## Issue

[CONTRIBUTING.md](https://github.com/cypress-io/cypress-docker-images/blob/master/CONTRIBUTING.md) fails `markdown-link-check`.

```text
  ERROR: 5 dead links found!
  [✖] /factory/README.md → Status: 400
  [✖] /factory/factory.Dockerfile → Status: 400
  [✖] /factory/installScripts/ → Status: 400
  [✖] /factory/CHANGELOG.md → Status: 400
  [✖] /factory/.env → Status: 400
```

## Change

Make failing links relative e.g.

`/factory/README.md` => `./factory/README.md`

## Verification

```shell
npm ci
npx markdown-link-check CONTRIBUTING.md
```
