### PR TITLE
docs: fix README Examples issues

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,16 +54,7 @@ Don't see the exact combination of Cypress, Node.js and browser versions you nee
 
 ## Examples
 
-These images have all dependencies necessary to install and run Cypress. Just install your npm dependencies (including Cypress) and run the tests. We utilize many of these docker images in our own projects, with different CI providers.
-
-[Check out our docs for examples.](https://on.cypress.io/docker)
-
-If you want to use the `cypress/included` image, read [Run Cypress with a single Docker command](https://www.cypress.io/blog/2019/05/02/run-cypress-with-a-single-docker-command/)
-
-- [examples/included-as-non-root](examples/included-as-non-root) shows how to build a new Docker image on top of `cypress/included` image and run the tests as non-root user `node`.
-- [examples/included-as-non-root-alternative](examples/included-as-non-root-alternative) shows another approach to allow built-in non-root user `node` to run tests using `cypress/included` image.
-- [examples/included-as-non-root-mapped](examples/included-as-non-root-mapped) shows how to build a Docker image on top of `cypress/included` that runs with a non-root user that matches the id of the user on the host machine. This way, the permissions on any files created during the test run match the user's permissions on the host machine.
-- [examples/included-with-plugins](examples/included-with-plugins) shows how to use locally installed [Cypress plugins](https://on.cypress.io/plugins) while running `cypress/included` image.
+Check out the [README](./included/README.md) document in the [included](./included) directory for examples of how to use `cypress/included` images. (As described above, these images include all operating system dependencies, Cypress, and some browsers installed globally.)
 
 ## Common problems
 

--- a/included/README.md
+++ b/included/README.md
@@ -138,11 +138,7 @@ DevTools listening on ws://127.0.0.1:45315/devtools/browser/0c510bb9-b365-49e7-8
 
 ## Default user
 
-By default, the included images run as `root` user. You can switch the user to the second user in the image `node` or custom-mapped user, see [examples section](https://github.com/cypress-io/cypress-docker-images#examples). Starting with `cypress/included:3.8.1` we set permissions on the globally installed Cypress and set binary cache variable to allow other users read and execute access. Thus you will be able to run Cypress as non-root user by using `-u node`
-
-```shell
-$ docker run -it -v $PWD/src:/test -w /test -u node cypress/included:13.10.0
-```
+By default, `cypress/included` images run as `root` user. You can switch to the non-root user `node` in the image or to a custom-mapped user, see the [Alternate users](#alternate-users) section below.
 
 ## GitHub Action
 
@@ -169,3 +165,17 @@ If you want to simulate slow container, run the Docker container with `--cpus` p
 ```shell
 docker run -it -v $PWD:/e2e -w /e2e --cpus=0.02   -e DEBUG=cypress:launcher --entrypoint=cypress   cypress/included:13.10.0 info
 ```
+
+## Alternate users
+
+The following examples are built on `cypress/included:3.8.0` and have not yet been updated to demonstrate current Cypress versions:
+
+- [examples/included-as-non-root](../examples/included-as-non-root) shows how to build a new Docker image on top of `cypress/included` image and run the tests as non-root user `node`.
+- [examples/included-as-non-root-alternative](../examples/included-as-non-root-alternative) shows another approach to allow built-in non-root user `node` to run tests using `cypress/included` image.
+- [examples/included-as-non-root-mapped](../examples/included-as-non-root-mapped) shows how to build a Docker image on top of `cypress/included` that runs with a non-root user that matches the id of the user on the host machine. This way, the permissions on any files created during the test run match the user's permissions on the host machine.
+
+## Using plugins
+
+The following example is built on `cypress/included:3.8.0` and has not yet been updated to demonstrate current Cypress versions:
+
+- [examples/included-with-plugins](../examples/included-with-plugins) shows how to use locally installed [Cypress plugins](https://on.cypress.io/plugins) while running `cypress/included` image.


### PR DESCRIPTION
## Issues

In the [README > Examples](https://github.com/cypress-io/cypress-docker-images/blob/master/README.md#examples) section ...

- The first paragraph
  - is not referring to examples, so it is misplaced in this section
  - misleadingly says you need to install Cypress which is not true for `cypress/included`
- The link to [Check out our docs for examples.](https://on.cypress.io/docker) links to https://on.cypress.io/docker where there are no examples to be found.
- The following paragraph refers to an outdated legacy blog (see also PR https://github.com/cypress-io/cypress-docker-images/pull/1070):
  > If you want to use the `cypress/included` image, read [Run Cypress with a single Docker command](https://www.cypress.io/blog/2019/05/02/run-cypress-with-a-single-docker-command/)
- The set of 4 examples in the [examples](https://github.com/cypress-io/cypress-docker-images/tree/master/examples) directory are based on `cypress/included:3.8.0`. This is a legacy version and the Cypress Docker images were generated before the introduction of `cypress/factory`. The issues, that the examples set out to address, take on a different form under non-legacy (current) versions of `cypress/included:13.x` generated through the `cypress/factory` process.
- Providing only examples for `cypress/included` is unbalanced, when there are no examples listed for using `cypress/base` or `cypress/browsers`.

## Changes

In the [README > Examples](https://github.com/cypress-io/cypress-docker-images/blob/master/README.md#examples) section ...

1. Remove the first three paragraphs.
2. Replace with a link to the [included/README](https://github.com/cypress-io/cypress-docker-images/blob/master/included/README.md).
3. Move the legacy `examples/included*` to the [included/README](https://github.com/cypress-io/cypress-docker-images/blob/master/included/README.md) and mark them as legacy for the time being.
4. Rework the [included/README > Default user](https://github.com/cypress-io/cypress-docker-images/blob/master/included/README.md#default-user) section and refer to the moved examples to avoid duplication.
