### PR TITLE
docs: remove obsolete problem post-install hook

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,20 +67,6 @@ If you want to use the `cypress/included` image, read [Run Cypress with a single
 
 ## Common problems
 
-### Cannot run post-install hook
-
-Some versions of Node.js restrict running the `postinstall` hook with the following error message:
-
-```text
-lifecycle realworld@1.0.0~postinstall: cannot run in wd realworld@1.0.0
-```
-
-In that case run install with `npm install --unsafe-perm` flag, or set an environment variable in the container
-
-```shell
-npm_config_unsafe_perm: true
-```
-
 ### Blank screen in Chrome
 
 When running headed tests with X11 forwarding in Cypress v4 you might see a blank Chrome screen. Try disabling memory sharing by setting the following environment variables:


### PR DESCRIPTION
## Issue

[README > Common problems > Cannot run post-install hook](https://github.com/cypress-io/cypress-docker-images#cannot-run-post-install-hook) recommends using  `npm install --unsafe-perm`.

## Background

Currently the minimum supported version of Node.js is `18.x`. The note relates to `npm` rather than `Node.js` itself. `npm` is bundled in `Node.js`.

The lowest Node.js `18.x` version is [Node.js 18.0.0](https://nodejs.org/en/blog/release/v18.0.0) which bundles npm `8.6.0`.

The [npm CHANGELOG 7.0.0 > All Lifecycle Scripts](https://github.com/npm/cli/blob/release/v7/CHANGELOG.md#all-lifecycle-scripts) says:
> The `user`, `group`, `uid`, `gid`, and `unsafe-perms` configurations are  no longer relevant. When npm is run as root, scripts are always run with the effective `uid` and `gid` of the working directory owner.

The lowest version of npm currently supported is `8.6.0` (see above). The conclusion is that the problem no longer applies to any currently supported version of `npm` and therefore the problem description is obsolete.

## Change

Remove the obsolete section [README > Common problems > Cannot run post-install hook](https://github.com/cypress-io/cypress-docker-images#cannot-run-post-install-hook).
