### PR TITLE
fix: remove obsolete environment variable npm_config_unsafe_perm

### DIFF
--- a/factory/.env
+++ b/factory/.env
@@ -14,7 +14,7 @@ FACTORY_DEFAULT_NODE_VERSION='20.13.1'
 NODE_VERSION="${FACTORY_DEFAULT_NODE_VERSION}"
 
 # Update this to deploy the docker factory if you make changes to factory.Dockerfile or install scripts
-FACTORY_VERSION='4.0.0'
+FACTORY_VERSION='4.0.1'
 
 # Chrome versions: https://www.ubuntuupdates.org/package/google_chrome/stable/main/base/google-chrome-stable
 CHROME_VERSION='125.0.6422.60-1'

--- a/factory/CHANGELOG.md
+++ b/factory/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Change log
 
+## 4.0.1
+
+* Removed obsolete environment variable `npm_config_unsafe_perm`, not used or needed in npm `v7` and later. Addressed in [#1078](https://github.com/cypress-io/cypress-docker-images/pull/1078)
+
 ## 4.0.0
 
 * Updated Debian base image to `debian:12-slim` (codename `bookworm`). Addressed in [#1057](https://github.com/cypress-io/cypress-docker-images/pull/1057)

--- a/factory/factory.Dockerfile
+++ b/factory/factory.Dockerfile
@@ -11,8 +11,6 @@ ENV DBUS_SESSION_BUS_ADDRESS=/dev/null \
   TERM=xterm \
   # avoid million NPM install messages
   npm_config_loglevel=warn \
-  # allow installing when the main user is root
-  npm_config_unsafe_perm=true \
   # avoid too many progress messages
   # https://github.com/cypress-io/cypress/issues/1243
   CI=1 \


### PR DESCRIPTION
- follows on from https://github.com/cypress-io/cypress-docker-images/pull/1077

## Issue

https://github.com/cypress-io/cypress-docker-images/blob/b32255e644878bdbdf88e209f827c2ae47e24095/factory/factory.Dockerfile#L14-L15  sets an environment variable:

```text
npm_config_unsafe_perm: true
```

This environment variable is obsolete.

## Background

The lowest supported Node.js version is [Node.js 18.0.0](https://nodejs.org/en/blog/release/v18.0.0) which bundles npm `8.6.0`. (See [Node.js Release schedule](https://github.com/nodejs/release#release-schedule).)

The [npm CHANGELOG 7.0.0 > All Lifecycle Scripts](https://github.com/npm/cli/blob/release/v7/CHANGELOG.md#all-lifecycle-scripts) says:
> The `user`, `group`, `uid`, `gid`, and `unsafe-perms` configurations are  no longer relevant. When npm is run as root, scripts are always run with the effective `uid` and `gid` of the working directory owner.

The environment variable `npm_config_unsafe_perm` is no longer needed or used, since the current lowest supported version of npm (`8.6.0`) is higher than the version where its used was removed (`7.0.0`). Even considering [Node.js 16.0.0](https://github.com/nodejs/node/blob/main/doc/changelogs/CHANGELOG_V16.md#2021-04-20-version-1600-current-bethgriggs) the lowest npm version is `7.10.0`, which is already higher than the version where `unsafe_perm` was removed.

## Change

Remove the environment variable `npm_config_unsafe_perm` from the [factory/factory.Dockerfile](https://github.com/cypress-io/cypress-docker-images/blob/master/factory/factory.Dockerfile) file.

Bump `FACTORY_VERSION`.

## Verification

```shell
cd factory
docker compose build factory
docker compose build
cd test-project
set -a && . ../.env && set +a
docker compose run test-factory-all-included
docker compose run test-factory-cypress-included-electron-non-root-user
```
