### PR TITLE
ci: update circleci runner

### DIFF
--- a/circle.yml
+++ b/circle.yml
@@ -3,7 +3,7 @@
 version: 2.1
 
 orbs:
-    node: circleci/node@5.0.0
+    node: circleci/node@5.2.0
 
 commands:
     expand-env-file:
@@ -43,7 +43,7 @@ commands:
 jobs:
     check-factory-versions:
         machine:
-            image: ubuntu-2204:2022.10.2
+            image: ubuntu-2204:2024.04.4
         steps:
             - checkout
             - expand-env-file
@@ -138,7 +138,7 @@ jobs:
                   working_directory: factory/test-project
     check-node-override-version:
         machine:
-            image: ubuntu-2204:2022.10.2
+            image: ubuntu-2204:2024.04.4
         steps:
             - checkout
             - expand-env-file
@@ -164,7 +164,7 @@ jobs:
                   working_directory: factory/test-project
     test-image:
         machine:
-            image: ubuntu-2204:2022.10.2
+            image: ubuntu-2204:2024.04.4
         parameters:
             target:
                 type: string
@@ -194,7 +194,7 @@ jobs:
 
     push:
         machine:
-            image: ubuntu-2204:2022.10.2
+            image: ubuntu-2204:2024.04.4
         parameters:
             target:
                 type: string


### PR DESCRIPTION
## Issue

CircleCI runs are exhibiting flakiness including with network connections.

## Status

The CircleCI workflow [circle.yml](https://github.com/cypress-io/cypress-docker-images/blob/master/circle.yml) is based on the usage of

```yml
orbs:
    node: circleci/node@5.0.0
```

and

```yml
        machine:
            image: ubuntu-2204:2022.10.2
```

1. The current version of [circleci/node](https://circleci.com/developer/orbs/orb/circleci/node) is [circleci/node@5.2.0](https://github.com/CircleCI-Public/node-orb/releases/tag/v5.2.0) released on Jan 4, 2024. The tag for `circleci/node@5.0.0` is dated Dec 20, 2021.

2. The machine image [ubuntu-2204](https://circleci.com/developer/machine/image/ubuntu-2204) is tagged with the release date `2022.10.2` i.e. Oct 2, 2022.

## Change

It is possible, but not guaranteed, that updating the runner environment may improve the success rate of CircleCI runs.

Update to:

```yml
orbs:
    node: circleci/node@5.2.0
```

and

```yml
        machine:
            image: ubuntu-2204:2024.04.4
```
