### PR TITLE
docs: fix link to print-debug-logs

### DIFF
--- a/included/README.md
+++ b/included/README.md
@@ -12,7 +12,7 @@ $ docker run -it -v $PWD:/e2e -w /e2e cypress/included:13.10.0
 
 ## Debug
 
-If you want to see the [Cypress debug logs](https://on.cypress.io/debugging#Print-DEBUG-logs) during the run, pass environment variable `DEBUG`:
+If you want to see the [Cypress debug logs](https://on.cypress.io/troubleshooting#Print-DEBUG-logs) during the run, pass the environment variable setting `DEBUG=cypress:*`:
 
 ```text
 $ docker run -it -v $PWD:/e2e -w /e2e -e DEBUG=cypress:* cypress/included:13.10.0


### PR DESCRIPTION
## Issue

The [included/README > Debug](https://github.com/cypress-io/cypress-docker-images/blob/master/included/README.md#debug) section includes a link to https://on.cypress.io/debugging#Print-DEBUG-logs. The section `Print-DEBUG-logs` is however no longer at that location, so the link does not present the expected material. No error message is given in this case, since the page exists and only the bookmark is missing from the page.

## Change

The intended section resides at https://docs.cypress.io/guides/references/troubleshooting#Print-DEBUG-logs.

Since the vanity-link<br>https://on.cypress.io/troubleshooting#Print-DEBUG-logs also leads to<br>https://docs.cypress.io/guides/references/troubleshooting#Print-DEBUG-logs, replace the incorrect link with the vanity one<br><br>https://on.cypress.io/troubleshooting#Print-DEBUG-logs

in the [included/README > Debug](https://github.com/cypress-io/cypress-docker-images/blob/master/included/README.md#debug) section.
