### PR TITLE
feat: publish set of node.js 18.20.3 images

### DIFF
--- a/circle.yml
+++ b/circle.yml
@@ -342,7 +342,7 @@ workflows:
                 filters:
                     branches:
                         only:  # only branches matching the below regex filters will run
-                            - master
+                            - 13.10.0-node-18.20.3-publish
                 requires:
                     - "Push Factory Image"
                     - base
@@ -354,7 +354,7 @@ workflows:
                 filters:
                     branches:
                         only:  # only branches matching the below regex filters will run
-                            - master
+                            - 13.10.0-node-18.20.3-publish
                 requires:
                     - "Push Factory Image"
                     - browsers
@@ -366,7 +366,7 @@ workflows:
                 filters:
                     branches:
                         only:  # only branches matching the below regex filters will run
-                            - master
+                            - 13.10.0-node-18.20.3-publish
                 requires:
                     - "Push Factory Image"
                     - included

--- a/factory/.env
+++ b/factory/.env
@@ -8,7 +8,7 @@
 BASE_IMAGE='debian:12-slim'
 
 # Node Versions: https://nodejs.org/en/download/releases/
-FACTORY_DEFAULT_NODE_VERSION='20.13.1'
+FACTORY_DEFAULT_NODE_VERSION='18.20.3'
 
 # Node Versions: https://nodejs.org/en/download/releases/
 NODE_VERSION="${FACTORY_DEFAULT_NODE_VERSION}"


### PR DESCRIPTION
ON HOLD waiting for feature branch `13.10.0-node-18.20.3-publish` to be created

- closes https://github.com/cypress-io/cypress-docker-images/issues/1082
- closes https://github.com/cypress-io/cypress-docker-images/issues/1050

## Issue

Current Cypress Docker images which include Node.js `18.x` are using [18.16.1](https://github.com/nodejs/node/blob/main/doc/changelogs/CHANGELOG_V18.md#2023-06-20-version-18161-hydrogen-lts-rafaelgss) which is now almost one year old.
The current latest Node.js 18.x version is [18.20.3](https://github.com/nodejs/node/blob/main/doc/changelogs/CHANGELOG_V18.md#2024-05-21-version-18203-hydrogen-lts-richardlau) released on May 21, 2024.

## Change

Refresh Current Cypress Docker images `cypress/base`, `cypress/browsers` and `cypress/included` using the current latest Node.js `18.x` version [18.20.3](https://github.com/nodejs/node/blob/main/doc/changelogs/CHANGELOG_V18.md#2024-05-21-version-18203-hydrogen-lts-richardlau) combined with the latest default values for OS (Debian 12), Yarn (`1.22.22`), browser and Cypress versions as defined in [factory/.env](https://github.com/cypress-io/cypress-docker-images/blob/master/factory/.env).

(No new `cypress/factory` is published. This is not necessary or desired.)

## Verification

```bash
cd factory
docker compose build factory
docker compose build included
cd test-project
set -a && . ../.env && set +a
docker compose run test-factory-all-included
```
