### PR TITLE
docs: migrate examples to relative bind mounts

### DIFF
--- a/included/README.md
+++ b/included/README.md
@@ -7,7 +7,7 @@
 This image should be enough to run Cypress tests headlessly or in the interactive mode with a single Docker command like this:
 
 ```shell
-$ docker run -it -v $PWD:/e2e -w /e2e cypress/included:13.10.0
+$ docker run -it -v .:/e2e -w /e2e cypress/included:13.10.0
 ```
 
 ## Debug
@@ -15,7 +15,7 @@ $ docker run -it -v $PWD:/e2e -w /e2e cypress/included:13.10.0
 If you want to see the [Cypress debug logs](https://on.cypress.io/troubleshooting#Print-DEBUG-logs) during the run, pass the environment variable setting `DEBUG=cypress:*`:
 
 ```text
-$ docker run -it -v $PWD:/e2e -w /e2e -e DEBUG=cypress:* cypress/included:13.10.0
+$ docker run -it -v .:/e2e -w /e2e -e DEBUG=cypress:* cypress/included:13.10.0
   cypress:cli:cli cli starts with arguments ["/usr/local/bin/node","/usr/local/bin/cypress","run"] +0ms
   cypress:cli NODE_OPTIONS is not set +0ms
   cypress:cli:cli program parsing arguments +3ms
@@ -103,7 +103,7 @@ Every time you run `docker run` you spawn a new container. That container then s
 If you are running a lot of tests again and again, you might start the container once using Bash as the entrypoint, instead of the default `cypress` command. Then you can execute the `cypress run` or any other commands, while still in the same container:
 
 ```text
-$ docker run -it -v $PWD:/e2e -w /e2e --entrypoint=/bin/bash cypress/included:13.10.0
+$ docker run -it -v .:/e2e -w /e2e --entrypoint=/bin/bash cypress/included:13.10.0
 # we are inside the container
 # let's run the tests
 root@814ed01841fe:/e2e# cypress run
@@ -117,7 +117,7 @@ root@814ed01841fe:/e2e# cypress run
 If you want to use a different browser (assuming it is installed in the container) use:
 
 ```text
-$ docker run -it -v $PWD:/e2e -w /e2e --entrypoint=cypress cypress/included:13.10.0 run --browser chrome
+$ docker run -it -v .:/e2e -w /e2e --entrypoint=cypress cypress/included:13.10.0 run --browser chrome
 
 DevTools listening on ws://127.0.0.1:45315/devtools/browser/0c510bb9-b365-49e7-8a99-67f3c69e1ab9
 
@@ -163,7 +163,7 @@ docker run --rm  # remove container after finish
 If you want to simulate slow container, run the Docker container with `--cpus` parameter, for example, let's debug the browser detection problems when the CPU is (very) slow:
 
 ```shell
-docker run -it -v $PWD:/e2e -w /e2e --cpus=0.02   -e DEBUG=cypress:launcher --entrypoint=cypress   cypress/included:13.10.0 info
+docker run -it -v .:/e2e -w /e2e --cpus=0.02   -e DEBUG=cypress:launcher --entrypoint=cypress   cypress/included:13.10.0 info
 ```
 
 ## Alternate users


### PR DESCRIPTION
- closes https://github.com/cypress-io/cypress-docker-images/issues/589

## Issues

This issue concerns the syntax used in the [included/README](https://github.com/cypress-io/cypress-docker-images/blob/master/included/README.md) examples for [Bind mounts](https://docs.docker.com/storage/bind-mounts/) of Cypress projects using the CLI option `-v` and the environment variable `PWD` (Print Working Directory), for example:

> `$ docker run -it -v $PWD:/e2e -w /e2e cypress/included:13.10.0`

1. If the path of the current working directory represented by `PWD` contains spaces, then the command fails with an error message:

    ```text
    docker: invalid reference format
    ```

2. If the syntax `-v $PWD:/e2e` is used on Windows PowerShell then the command fails with an error message:

    ```text
    At line:1 char:21
    + $ docker run -it -v $PWD:/e2e -w /e2e cypress/included:13.10.0
    +                     ~~~~~
    Variable reference is not valid. ':' was not followed by a valid variable name character. Consider using ${} to delimit the name.
        + CategoryInfo          : ParserError: (:) [], ParentContainsErrorRecordException
        + FullyQualifiedErrorId : InvalidVariableReferenceWithDrive
    ```

## Relative paths

[`docker container run`](https://docs.docker.com/reference/cli/docker/container/run/) with alias `docker run` provides the option [Mount volume (-v)](https://docs.docker.com/reference/cli/docker/container/run/#volume) with relative paths as described in the Docker documentation:

> As of Docker Engine version 23, you can use relative paths on the host.
>
> `docker  run  -v ./content:/content -w /content -i -t  ubuntu pwd`

- [Docker Engine 23.0.0](https://docs.docker.com/engine/release-notes/23.0/#bug-fixes-and-enhancements-6) was released on Feb 1, 2023. The current version is
- [Docker Engine 26.0.2](https://docs.docker.com/engine/release-notes/26.0/) released on Apr 18, 2024.

Relative paths can replace the use of the environment variable `PWD`. This avoids problems with `PWD`, enabling equivalent functionality and it simplifies the command line examples.

## Change

Change all examples using `docker run` with mount volume `-v` using `PWD` to instead use the relative path `.`, so for example:

> `$ docker run -it -v $PWD:/e2e -w /e2e cypress/included:13.10.0`

is changed to

> `$ docker run -it -v .:/e2e -w /e2e cypress/included:13.10.0`

## Verification

### Ubuntu

On Ubuntu `22.04.4` LTS with Docker Desktop for Linux `v4.30.0`

```shell
mkdir "cy example"
cd "cy example"
git init
npm init -y
npm install cypress
npx cypress open
```

- Select "E2E Testing"
- Select "Continue"
- Select "Electron" and "Start E2E Testing in Electron"
- Select "Create new spec"
- Select "Create spec"
- Exit all Cypress windows

```shell
rm -rf node_modules package*.json
docker run -it -v .:/e2e -w /e2e cypress/included
```

Confirm that Cypress runs successfully.

### Windows

On Windows `11 23H2` with Docker Desktop for Windows `v4.30.0`

Test as for Ubuntu (described above) using:
- cmd prompt
- PowerShell

On Git Bash test with:

```shell
MSYS_NO_PATHCONV=1 docker run -it -v .:/e2e -w /e2e cypress/included
```
