### PR TITLE
docs: fix restrict cpu example

### DIFF
--- a/included/README.md
+++ b/included/README.md
@@ -160,10 +160,10 @@ docker run --rm  # remove container after finish
 
 ## Restrict CPU
 
-If you want to simulate slow container, run the Docker container with `--cpus` parameter, for example, let's debug the browser detection problems when the CPU is (very) slow:
+If you want to simulate a slow container, run the Docker container with the `--cpus` parameter, for example, let's debug possible browser detection problems when the CPU is slow:
 
 ```shell
-docker run -it -v .:/e2e -w /e2e --cpus=0.02   -e DEBUG=cypress:launcher --entrypoint=cypress   cypress/included:13.10.0 info
+docker run -it --cpus=0.2 -e DEBUG=cypress:launcher:* --entrypoint=cypress cypress/included:13.10.0 info
 ```
 
 ## Alternate users


### PR DESCRIPTION
## Issue

The example [included > Restrict CPU](https://github.com/cypress-io/cypress-docker-images/tree/master/included#restrict-cpu)

> docker run -it -v .:/e2e -w /e2e --cpus=0.02   -e DEBUG=cypress:launcher --entrypoint=cypress   cypress/included:13.10.0 info

takes a long time to run, produces no debug output and unnecessarily uses bind mount.

## Change

In the example [included > Restrict CPU](https://github.com/cypress-io/cypress-docker-images/tree/master/included#restrict-cpu)

1. Remove the bind mount `-v .:/e2e -w /e2e`
2. Increase CPUs available by factor of 10 to `--cpus=0.2`
3. Set the `DEBUG` environment variable to `DEBUG=cypress:launcher:*`

to use:

```shell
docker run -it --cpus=0.2 -e DEBUG=cypress:launcher:* --entrypoint=cypress cypress/included:13.10.0 info
```

## Verification

On Ubuntu `24.04.4` LTS

- Execution time: 20s (compared to 1s without throttling)
- Debug output: yes
