### PR TITLE
Revert "ci: update circleci runner (#1079)"

### DIFF
--- a/circle.yml
+++ b/circle.yml
@@ -3,7 +3,7 @@
 version: 2.1
 
 orbs:
-    node: circleci/node@5.2.0
+    node: circleci/node@5.0.0
 
 commands:
     expand-env-file:
@@ -43,7 +43,7 @@ commands:
 jobs:
     check-factory-versions:
         machine:
-            image: ubuntu-2204:2024.04.4
+            image: ubuntu-2204:2022.10.2
         steps:
             - checkout
             - expand-env-file
@@ -138,7 +138,7 @@ jobs:
                   working_directory: factory/test-project
     check-node-override-version:
         machine:
-            image: ubuntu-2204:2024.04.4
+            image: ubuntu-2204:2022.10.2
         steps:
             - checkout
             - expand-env-file
@@ -164,7 +164,7 @@ jobs:
                   working_directory: factory/test-project
     test-image:
         machine:
-            image: ubuntu-2204:2024.04.4
+            image: ubuntu-2204:2022.10.2
         parameters:
             target:
                 type: string
@@ -194,7 +194,7 @@ jobs:
 
     push:
         machine:
-            image: ubuntu-2204:2024.04.4
+            image: ubuntu-2204:2022.10.2
         parameters:
             target:
                 type: string


### PR DESCRIPTION
- relates to issue https://github.com/cypress-io/cypress-docker-images/issues/1093

## Issue

Breaking changes in https://github.com/docker/buildx have caused a compatibility issue with the 4 year old [docker-image-not-found@1.1.1](https://www.npmjs.com/package/docker-image-not-found/v/1.1.1) from the https://github.com/cypress-io/docker-image-not-found repo.

`docker-image-not-found` is unable to parse the manifest and cannot determine whether a version has been published or not.

See also

- https://github.com/docker/buildx/issues/1964
- https://github.com/docker/buildx/issues/1509

## Change

- Revert PR https://github.com/cypress-io/cypress-docker-images/pull/1079

| CircleCI Component                                                                    | PR 1709                 | revert to               |
| ------------------------------------------------------------------------------------- | ----------------------- | ----------------------- |
| [circleci/node](https://circleci.com/developer/orbs/orb/circleci/node)                | `5.2.0`                 | `5.0.0`                 |
| [machine image ubuntu-2204](https://circleci.com/developer/machine/image/ubuntu-2204) | `ubuntu-2204:2024.04.4` | `ubuntu-2204:2022.10.2` |
| Docker                                                                                | `26.0.2`                | `20.10.18`              |
| Docker buildx                                                                         | `v0.13.1`               | `v0.9.1`                |

## References

- [Linux Machine Executor Update - 2022 October Q4 Update](https://discuss.circleci.com/t/linux-machine-executor-update-2022-october-q4-update/45753)
- [Docker Engine 20.10.18 release notes](https://docs.docker.com/engine/release-notes/20.10/#201018)
- [Linux Machine Executor - 2024 Q2 Update (Including CUDA)](https://discuss.circleci.com/t/linux-machine-executor-2024-q2-update-including-cuda/50844)
- [Docker Engine 26.0 release notes](https://docs.docker.com/engine/release-notes/26.0/)
- [Docker buildx releases](https://github.com/docker/buildx/releases)
