### PR TITLE
docs: add missing bind mounts

### DIFF
--- a/included/README.md
+++ b/included/README.md
@@ -33,7 +33,7 @@ $ docker run -it --entrypoint=cypress cypress/included:13.10.0 run --help
 To run a single spec using Chrome browser:
 
 ```shell
-$ docker run -it --entrypoint=cypress cypress/included:13.10.0 run --spec cypress/e2e/spec-a.cy.js --browser chrome
+$ docker run -it -v .:/e2e -w /e2e --entrypoint=cypress cypress/included:13.10.0 run --spec cypress/e2e/spec.cy.js --browser chrome
 ```
 
 ## Entry
@@ -93,7 +93,7 @@ System Memory: 5.16 GB free 4.09 GB
 If you want to provide Cypress command line arguments, specify the entry point and the arguments. For example to run tests with recording and parallel mode using custom build ID "abc123" we can use:
 
 ```shell
-$ docker run -it --entrypoint=cypress cypress/included:13.10.0   run --record --parallel --ci-build-id abc123
+$ docker run -it -v .:/e2e -w /e2e --entrypoint=cypress cypress/included:13.10.0 run --record --parallel --ci-build-id abc123
 ```
 
 ## Keep the container


### PR DESCRIPTION
## Issue

The following examples in [included/README.md](https://github.com/cypress-io/cypress-docker-images/blob/master/included/README.md) will not run, since they are missing bind mounts to a Cypress project:

- [Arguments > run a single spec](https://github.com/cypress-io/cypress-docker-images/tree/master/included#arguments)
- [Entry with arguments](https://github.com/cypress-io/cypress-docker-images/tree/master/included#entry-with-arguments)

## Change

- [Arguments > run a single spec](https://github.com/cypress-io/cypress-docker-images/tree/master/included#arguments)
  - Add `-v .:/e2e -w /e2e` to the command line.
  - Change the spec path and name to `cypress/e2e/spec.cy.js` for compatibility with the default Cypress example spec name.
- [Entry with arguments](https://github.com/cypress-io/cypress-docker-images/tree/master/included#entry-with-arguments)
  - Add `-v .:/e2e -w /e2e` to the command line.
