### PR TITLE
chore: release cypress 13.11.0 related docker images and update factory

### DIFF
--- a/factory/.env
+++ b/factory/.env
@@ -23,7 +23,7 @@ CHROME_VERSION='125.0.6422.141-1'
 CYPRESS_VERSION='13.11.0'
 
 # Edge versions: https://packages.microsoft.com/repos/edge/pool/main/m/microsoft-edge-stable/
-EDGE_VERSION='125.0.2535.79-1'
+EDGE_VERSION='125.0.2535.85-1'
 
 # Firefox versions: https://download-installer.cdn.mozilla.net/pub/firefox/releases/
 FIREFOX_VERSION='126.0.1'

--- a/factory/.env
+++ b/factory/.env
@@ -8,25 +8,25 @@
 BASE_IMAGE='debian:12-slim'
 
 # Node Versions: https://nodejs.org/en/download/releases/
-FACTORY_DEFAULT_NODE_VERSION='20.13.1'
+FACTORY_DEFAULT_NODE_VERSION='20.14.0'
 
 # Node Versions: https://nodejs.org/en/download/releases/
 NODE_VERSION="${FACTORY_DEFAULT_NODE_VERSION}"
 
 # Update this to deploy the docker factory if you make changes to factory.Dockerfile or install scripts
-FACTORY_VERSION='4.0.1'
+FACTORY_VERSION='4.0.2'
 
 # Chrome versions: https://www.ubuntuupdates.org/package/google_chrome/stable/main/base/google-chrome-stable
-CHROME_VERSION='125.0.6422.60-1'
+CHROME_VERSION='125.0.6422.141-1'
 
 # Cypress versions: https://www.npmjs.com/package/cypress
-CYPRESS_VERSION='13.10.0'
+CYPRESS_VERSION='13.11.0'
 
 # Edge versions: https://packages.microsoft.com/repos/edge/pool/main/m/microsoft-edge-stable/
-EDGE_VERSION='125.0.2535.51-1'
+EDGE_VERSION='125.0.2535.79-1'
 
 # Firefox versions: https://download-installer.cdn.mozilla.net/pub/firefox/releases/
-FIREFOX_VERSION='126.0'
+FIREFOX_VERSION='126.0.1'
 
 # Yarn versions: https://www.npmjs.com/package/yarn and
 # https://classic.yarnpkg.com/latest-version

--- a/factory/CHANGELOG.md
+++ b/factory/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Change log
 
+## 4.0.2
+
+* Updated default node version from `20.13.1` to `20.14.0`. Addressed in [#1097](https://github.com/cypress-io/cypress-docker-images/pull/1097)
+
 ## 4.0.1
 
 * Removed obsolete environment variable `npm_config_unsafe_perm`, not used or needed in npm `v7` and later. Addressed in [#1078](https://github.com/cypress-io/cypress-docker-images/pull/1078)


### PR DESCRIPTION
- updates Node LTS to `20.14.0`
- chrome to `125.0.6422.141-1`
- edge to `125.0.2535.85-1`
- firefox to `126.0.1`
- cypress to `13.11.0`