### PR TITLE
feat: publish set of node.js 18.20.3 images

### DIFF
--- a/circle.yml
+++ b/circle.yml
@@ -329,7 +329,7 @@ workflows:
                 filters:
                     branches:
                         only:  # only branches matching the below regex filters will run
-                            - master
+                            - 13.11.0-node-18.20.3-publish
                 requires:
                     - factory
                     - factory-arm

--- a/circle.yml
+++ b/circle.yml
@@ -342,7 +342,7 @@ workflows:
                 filters:
                     branches:
                         only:  # only branches matching the below regex filters will run
-                            - master
+                            - 13.11.0-node-18.20.3-publish
                 requires:
                     - "Push Factory Image"
                     - base
@@ -354,7 +354,7 @@ workflows:
                 filters:
                     branches:
                         only:  # only branches matching the below regex filters will run
-                            - master
+                            - 13.11.0-node-18.20.3-publish
                 requires:
                     - "Push Factory Image"
                     - browsers
@@ -366,7 +366,7 @@ workflows:
                 filters:
                     branches:
                         only:  # only branches matching the below regex filters will run
-                            - master
+                            - 13.11.0-node-18.20.3-publish
                 requires:
                     - "Push Factory Image"
                     - included

--- a/factory/.env
+++ b/factory/.env
@@ -8,7 +8,7 @@
 BASE_IMAGE='debian:12-slim'
 
 # Node Versions: https://nodejs.org/en/download/releases/
-FACTORY_DEFAULT_NODE_VERSION='20.14.0'
+FACTORY_DEFAULT_NODE_VERSION='18.20.3'
 
 # Node Versions: https://nodejs.org/en/download/releases/
 NODE_VERSION="${FACTORY_DEFAULT_NODE_VERSION}"

--- a/factory/docker-compose.yml
+++ b/factory/docker-compose.yml
@@ -12,7 +12,7 @@ services:
         BASE_IMAGE: ${BASE_IMAGE}
         FACTORY_DEFAULT_NODE_VERSION: ${FACTORY_DEFAULT_NODE_VERSION}
       tags:
-       - ${REPO_PREFIX-}cypress/factory:latest
+      #  - ${REPO_PREFIX-}cypress/factory:latest
        - ${REPO_PREFIX-}cypress/factory:${FACTORY_VERSION}
     command: node -v
 
@@ -31,7 +31,7 @@ services:
         YARN_VERSION: ${YARN_VERSION}
         # WEBKIT_VERSION: ${WEBKIT_VERSION}
       tags:
-       - ${REPO_PREFIX-}cypress/included:latest
+      #  - ${REPO_PREFIX-}cypress/included:latest
        - ${REPO_PREFIX-}cypress/included:${INCLUDED_IMAGE_SHORT_TAG}
        - ${REPO_PREFIX-}cypress/included:${INCLUDED_IMAGE_TAG}
     command: node -v
@@ -49,7 +49,7 @@ services:
         FIREFOX_VERSION: ${FIREFOX_VERSION}
         EDGE_VERSION: ${EDGE_VERSION}
       tags:
-       - ${REPO_PREFIX-}cypress/browsers:latest
+      #  - ${REPO_PREFIX-}cypress/browsers:latest
        - ${REPO_PREFIX-}cypress/browsers:${BROWSERS_IMAGE_TAG}
     command: node -v
 
@@ -63,7 +63,7 @@ services:
         FACTORY_VERSION: ${FACTORY_VERSION}
         YARN_VERSION: ${YARN_VERSION}
       tags:
-       - ${REPO_PREFIX-}cypress/base:latest
+      #  - ${REPO_PREFIX-}cypress/base:latest
        - ${REPO_PREFIX-}cypress/base:${BASE_IMAGE_TAG}
     command: node -v
 


### PR DESCRIPTION
- depends on https://github.com/cypress-io/cypress-docker-images/issues/1083
- closes https://github.com/cypress-io/cypress-docker-images/issues/1082
- closes https://github.com/cypress-io/cypress-docker-images/issues/1050
- supersedes https://github.com/cypress-io/cypress-docker-images/pull/1090

## Issue

Current Cypress Docker images which include Node.js `18.x` are using [18.16.1](https://github.com/nodejs/node/blob/main/doc/changelogs/CHANGELOG_V18.md#2023-06-20-version-18161-hydrogen-lts-rafaelgss) which is now almost one year old.
The current latest Node.js 18.x version is [18.20.3](https://github.com/nodejs/node/blob/main/doc/changelogs/CHANGELOG_V18.md#2024-05-21-version-18203-hydrogen-lts-richardlau) released on May 21, 2024.

## Change

Refresh Current Cypress Docker images `cypress/base`, `cypress/browsers` and `cypress/included` using the current latest Node.js `18.x` version [18.20.3](https://github.com/nodejs/node/blob/main/doc/changelogs/CHANGELOG_V18.md#2024-05-21-version-18203-hydrogen-lts-richardlau) combined with the latest default values for OS (Debian 12), Yarn (`1.22.22`), browser and Cypress versions as defined in [factory/.env](https://github.com/cypress-io/cypress-docker-images/blob/master/factory/.env).

- The `latest` tag is not applied, e.g. `cypress/base:latest` as the images created are for older versions.
- No new `cypress/factory` is published. This is not necessary or desired.

## Verification

```bash
cd factory
docker compose build factory
docker compose build included
cd test-project
set -a && . ../.env && set +a
docker compose run test-factory-all-included
```
