### PR TITLE
docs: remove outdated blank screen issue

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,18 +58,6 @@ Check out the [README](./included/README.md) document in the [included](./includ
 
 ## Common problems
 
-### Blank screen in Chrome
-
-When running headed tests with X11 forwarding in Cypress v4 you might see a blank Chrome screen. Try disabling memory sharing by setting the following environment variables:
-
-```shell
-export QT_X11_NO_MITSHM=1
-export _X11_NO_MITSHM=1
-export _MITSHM=0
-```
-
-See [issue #270](https://github.com/cypress-io/cypress-docker-images/issues/270)
-
 ## Firefox not found
 
 By default, the containers run with the root user. However, Firefox by design cannot run with root user, leading to failures such as:


### PR DESCRIPTION
## Issue

[README > Common problems > Blank screen in Chrome](https://github.com/cypress-io/cypress-docker-images/blob/master/README.md#blank-screen-in-chrome) contains the following advice:

>When running headed tests with X11 forwarding in Cypress v4 you might see a blank Chrome screen. Try disabling memory sharing by setting the following environment variables:
>
>```shell
>export QT_X11_NO_MITSHM=1
>export _X11_NO_MITSHM=1
>export _MITSHM=0
>```
>
> - See [issue #270](https://github.com/cypress-io/cypress-docker-images/issues/270)

- [issue #270](https://github.com/cypress-io/cypress-docker-images/issues/270) was closed in March 2020.

---

- The variables mentioned have progressed through to
https://github.com/cypress-io/cypress-docker-images/blob/47149ea3d5b58dae09139ae5a523d7ffd129bc91/factory/factory.Dockerfile#L17-L21

  where these are promulgated to all current Cypress Docker images.

## Change

Since a manual workaround is no longer necessary, the section [README > Common problems > Blank screen in Chrome](https://github.com/cypress-io/cypress-docker-images/blob/master/README.md#blank-screen-in-chrome) is removed from the [README](https://github.com/cypress-io/cypress-docker-images/blob/master/README.md) document.
