### PR TITLE
docs: add usage sub-heading to readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,11 +33,13 @@ Once an image with a specific version tag (except `latest`) has been published t
 
 When a new version is published, an image copy with the `latest` tag is also published. This means that the Docker image selected using the `latest` tag (or selected by default if no tag is specified) will also change over time. Specify an explicit version, for example [cypress/base:18.16.0](https://hub.docker.com/layers/cypress/base/18.16.0/images/sha256-d00c441748e2f1b79d4002bddafe6628f9f9f5458a8a3c66697e622600dc5ad5), to access instead a frozen version.
 
->📍Cypress Docker images are offered as a convenience measure. The goal is to offer Node.js, Browser and Cypress versions to streamline running tests in CI or other non-public, sandboxed environments.
->
-> Some preparations and optimizations are not included. For example, given the near infinite permutations, images are not monitored for security vulnerabilities. Additionally, once images are published they are considered immutable and cannot be patched. That means (hypothetically) older images could become more vulnerable over time.
->
-> This means they should **not** be used for production deployment and security scans should be performed as-needed by users of these images.
+## Usage
+
+📍Cypress Docker images are offered as a convenience measure. The goal is to offer Node.js, Browser and Cypress versions to streamline running tests in CI or other non-public, sandboxed environments.
+
+Some preparations and optimizations are not included. For example, given the near infinite permutations, images are not monitored for security vulnerabilities. Additionally, once images are published they are considered immutable and cannot be patched. That means (hypothetically) older images could become more vulnerable over time.
+
+This means they should **not** be used for production deployment and security scans should be performed as-needed by users of these images.
 
 ## Docker Hub
 


### PR DESCRIPTION
## Issue

In the README section [Tag Selection](https://github.com/cypress-io/cypress-docker-images/blob/master/README.md#tag-selection) there is a disclaimer-type section with no heading and which does not have anything to do with tag selection. So it is mixed with a section where is does not belong and because there is no separate heading, it can't easily be referred to.

## Change

- The text was originally added by @jaffrepaul through PR #830 which refers to "Image security".

Add the neutral heading "Usage". If the Cypress.io team prefers a different term, please add review feedback and I will change it accordingly.

The paragraphs are raised from quoted text to regular text.
