### PR TITLE
docs: add tag infos to readme files

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,15 +19,15 @@ If no tag is specified, for example `cypress/included`, then the tag `latest` is
 
 Some examples with specific tags including an explanation of the tag meanings are:
 
-- [cypress/base:18.16.0](https://hub.docker.com/layers/cypress/base/18.16.0/images/sha256-d00c441748e2f1b79d4002bddafe6628f9f9f5458a8a3c66697e622600dc5ad5)
-    Node.js `18.16.0`
-- [cypress/browsers:node-18.16.0-chrome-114.0.5735.133-1-ff-114.0.2-edge-114.0.1823.51-1](https://hub.docker.com/layers/cypress/browsers/node-18.16.0-chrome-114.0.5735.133-1-ff-114.0.2-edge-114.0.1823.51-1/images/sha256-e4c1a47c8107c37ca47398d8936743965d871c7285f58b852d5cb2658c400922)
-    Node.js `18.16.0`
-    Chrome `114.0.5735.133-1`
-    Firefox `114.0.2`
-    Edge `114.0.1823.51-1`
-- [cypress/included:12.17.1](https://hub.docker.com/layers/cypress/included/12.17.1/images/sha256-5d541ff206ed28631e720f8fe98dcadf5c62f8e194c028715fb748e564c8c0cc)
-    Cypress `12.17.1`
+- [cypress/base:20.14.0](https://hub.docker.com/layers/cypress/base/20.14.0/images/sha256-ed706ff91fb0642b34422c65d53ee3ad079a03b86c30e7de42a4c15f7d7bb17d)
+    Node.js `20.14.0`
+- [cypress/browsers:node-20.14.0-chrome-125.0.6422.141-1-ff-126.0.1-edge-125.0.2535.85-1](https://hub.docker.com/layers/cypress/browsers/node-20.14.0-chrome-125.0.6422.141-1-ff-126.0.1-edge-125.0.2535.85-1/images/sha256-a8b9c0a4d9b0bb1ca2ebfe1afbf829f248dd73617438a89e65c0e7d842ac7ec6)
+    Node.js `20.14.0`
+    Chrome `125.0.6422.141-1`
+    Firefox `126.0.1`
+    Edge `125.0.2535.85-1`
+- [cypress/included:13.11.0](https://hub.docker.com/layers/cypress/included/13.11.0/images/sha256-20ee9650d920abc422b62c039d2b1a11b415f0ac19a84bc17f4da0c7d2f77a2d)
+    Cypress `13.11.0`
 
 Once an image with a specific version tag (except `latest`) has been published to [Cypress on Docker Hub](https://hub.docker.com/u/cypress) it is frozen. This prevents accidental changes.
 

--- a/base/README.md
+++ b/base/README.md
@@ -4,4 +4,16 @@
 
 > Docker images that include all operating system dependencies necessary to run Cypress, **but NOT Cypress itself** and no pre-installed browsers. See [cypress/included](../included) images if you need Cypress pre-installed in the image. See [cypress/browsers](../browsers) images if you need some browsers pre-installed in the image.
 
-Each tag is named after the Node version or OS it is built on.
+## Tags
+
+[cypress/base](https://hub.docker.com/r/cypress/base/tags) images on [Cypress on Docker Hub](https://hub.docker.com/u/cypress) use image tags in the form:
+
+- `<node version>`
+- `latest`
+
+for example:
+
+- `cypress/base:20.14.0`
+- `cypress/base:latest`
+
+ To avoid unplanned breaking changes, specify a fixed `<node version>` tag, not the `latest` tag.  The `latest` tag is linked to the latest released `cypress/base` image and is updated without notice.

--- a/browsers/README.md
+++ b/browsers/README.md
@@ -3,3 +3,17 @@
 [![Docker Pulls](https://img.shields.io/docker/pulls/cypress/browsers.svg?maxAge=604800)](https://hub.docker.com/r/cypress/browsers/)
 
 > Docker image with all operating system dependencies and some pre-installed browsers, **but NOT Cypress itself**. See [cypress/included](../included) images if you need Cypress pre-installed in the image.
+
+## Tags
+
+[cypress/browsers](https://hub.docker.com/r/cypress/browsers/tags) images on [Cypress on Docker Hub](https://hub.docker.com/u/cypress) use image tags in the form:
+
+- node-`<node version>`-chrome-`<chrome version>`-ff-`<firefox version>`-edge-`<edge version>`
+- `latest`
+
+for example:
+
+- `cypress/browsers:node-20.14.0-chrome-125.0.6422.141-1-ff-126.0.1-edge-125.0.2535.85-1`
+- `cypress/browsers:latest`
+
+ To avoid unplanned breaking changes, specify a fixed `<node version>` & `<browser version>` combination tag, not the `latest` tag.  The `latest` tag is linked to the latest released `cypress/browsers` image and is updated without notice.

--- a/factory/README.md
+++ b/factory/README.md
@@ -9,6 +9,20 @@
 * edge
 * cypress
 
+## Tags
+
+[cypress/factory](https://hub.docker.com/r/cypress/factory/tags) images on [Cypress on Docker Hub](https://hub.docker.com/u/cypress) use image tags in the form:
+
+- `<factory version>`
+- `latest`
+
+for example:
+
+- `cypress/factory:4.0.2`
+- `cypress/factory:latest`
+
+ To avoid unplanned breaking changes, specify a fixed `<factory version>` tag, not the `latest` tag.  The `latest` tag is linked to the latest released `cypress/factory` image and is updated without notice.
+
 ## Benefits
 
 * Freedom to choose which versions to test against.

--- a/included/README.md
+++ b/included/README.md
@@ -4,6 +4,24 @@
 
 > Docker images with all operating system dependencies, Cypress, and some pre-installed browsers.
 
+## Tags
+
+[cypress/included](https://hub.docker.com/r/cypress/included/tags) images on [Cypress on Docker Hub](https://hub.docker.com/u/cypress) use image tags in the form:
+
+- `<cypress version>`-node-`<node version>`-chrome-`<chrome version>`-ff-`<firefox version>`-edge-`<edge version>`-
+- `<cypress version>`<br>This is a short-form convenience tag,  equivalent to the above full tag.
+- `latest`
+
+for example:
+
+- `cypress/included:cypress-13.11.0-node-20.14.0-chrome-125.0.6422.141-1-ff-126.0.1-edge-125.0.2535.85-1`
+- `cypress/included:13.11.0`
+- `cypress/included:latest`
+
+ To avoid unplanned breaking changes, specify a fixed `<cypress version>`, `<node version>` & `<browser version>` combination tag or use the short-form `<cypress version>` tag, not the `latest` tag.  The `latest` tag is linked to the latest released `cypress/included` image and is updated without notice.
+
+## Usage
+
 This image should be enough to run Cypress tests headlessly or in the interactive mode with a single Docker command like this:
 
 ```shell


### PR DESCRIPTION
## Issue

The README files deal inconsistently with information about which tags are used by Cypress Docker images:

- [README](https://github.com/cypress-io/cypress-docker-images/blob/master/README.md)
- [factory/README](https://github.com/cypress-io/cypress-docker-images/blob/master/factory/README.md)
- [base/README](https://github.com/cypress-io/cypress-docker-images/blob/master/base/README.md)
- [browsers/README](https://github.com/cypress-io/cypress-docker-images/blob/master/browsers/README.md)
- [included/README](https://github.com/cypress-io/cypress-docker-images/blob/master/included/README.md)

## Background

Tags are created through [factory/docker-compose.yml](https://github.com/cypress-io/cypress-docker-images/blob/master/factory/docker-compose.yml).

https://github.com/cypress-io/cypress-docker-images/blob/55c80b6bd6a64213f5544da91fc50dd966834075/factory/docker-compose.yml#L15-L16

https://github.com/cypress-io/cypress-docker-images/blob/55c80b6bd6a64213f5544da91fc50dd966834075/factory/docker-compose.yml#L66-L67

https://github.com/cypress-io/cypress-docker-images/blob/55c80b6bd6a64213f5544da91fc50dd966834075/factory/docker-compose.yml#L52-L53

https://github.com/cypress-io/cypress-docker-images/blob/55c80b6bd6a64213f5544da91fc50dd966834075/factory/docker-compose.yml#L34-L36

in combination with

https://github.com/cypress-io/cypress-docker-images/blob/55c80b6bd6a64213f5544da91fc50dd966834075/factory/.env#L40-L46

## Changes

- The example versions used in the [README](https://github.com/cypress-io/cypress-docker-images/blob/master/README.md) are refreshed.

- The information described in the Background section above is extracted and added to the respective README files.
