### PR TITLE
docs: update Docker apt-get best practice reference

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -123,11 +123,9 @@ Whenever upgrading or installing packages with `apt-get`, use the `--no-install-
 
 ### Omit `apt-get clean`
 
-Per the official Docker documentation, you don't need to add `apt-get clean`, since the Docker images implicitly run that command after every `apt-get` execution.
+Per the Docker documentation [Building best practices](https://docs.docker.com/build/building/best-practices/#apt-get), you don't need to add `apt-get clean`, since the Docker images implicitly run that command after every `apt-get` execution.
 
 >Official Debian and Ubuntu images automatically run `apt-get clean`, so explicit invocation is not required.
-
--[Best practices for writing Dockerfiles](https://docs.docker.com/develop/develop-images/dockerfile_best-practices/#run)
 
 ## Tool versions
 


### PR DESCRIPTION
## Issue

The Docker best practice article referenced in [CONTRIBUTING > Omit apt-get clean](https://github.com/cypress-io/cypress-docker-images/blob/master/CONTRIBUTING.md#omit-apt-get-clean) has moved to https://docs.docker.com/build/building/best-practices/#apt-get

## Change

Update the link `Best practices for writing Dockerfiles` in [CONTRIBUTING > Omit apt-get clean](https://github.com/cypress-io/cypress-docker-images/blob/master/CONTRIBUTING.md#omit-apt-get-clean) to Docker [Manuals > Docker Build > Building images > Best practices > Dockerfile instructions > RUN > apt-get](https://docs.docker.com/build/building/best-practices/#apt-get) and consolidate the reference into one place in this section.
