### PR TITLE
docs: add examples readme links to readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,9 +56,9 @@ Don't see the exact combination of Cypress, Node.js and browser versions you nee
 
 ## Examples
 
-- Check out the [README](./included/README.md) document in the [included](./included) directory for examples of how to use `cypress/included` images. (As described above, these images include all operating system dependencies, Cypress, and some browsers installed globally.)
+- Check out the documentation for each type of Cypress Docker image to read about example usage: [cypress/base](./base/README.md), [cypress/browsers](./browsers/README.md) and [cypress/included](./included/README.md) can all be used directly without change. Each of the Docker images can be used to build other images. [cypress/factory](./factory/README.md) is the preferred image to generate custom images.
 
-- See the example workflow [.github/workflows//example-cypress-github-action.yml](./.github/workflows/example-cypress-github-action.yml) for Continuous Integration (CI) using [`cypress-io/github-action`](https://github.com/cypress-io/github-action) together with Cypress Docker images.
+- See the example workflow [.github/workflows//example-cypress-github-action.yml](./.github/workflows/example-cypress-github-action.yml) for Continuous Integration (CI) using [cypress&#8209;io/github&#8209;action](https://github.com/cypress-io/github-action) together with Cypress Docker images.
 
 ## Known problems
 


### PR DESCRIPTION
## Issue

The following individual README documents are not linked into the top level [README](https://github.com/cypress-io/cypress-docker-images/blob/master/README.md) document:

- [base/README](https://github.com/cypress-io/cypress-docker-images/blob/master/base/README.md)
- [browsers/README](https://github.com/cypress-io/cypress-docker-images/blob/master/browsers/README.md)

The top level [README](https://github.com/cypress-io/cypress-docker-images/blob/master/README.md) currently only refers to the:

- [included/README](https://github.com/cypress-io/cypress-docker-images/blob/master/included/README.md)

## Change

- Now that these files have example content added (see PR #1110 and #1113), links to these files are added to the [README > Examples](https://github.com/cypress-io/cypress-docker-images/blob/master/README.md#examples) section.
