### PR TITLE
docs: add examples/basic-mini project - w/o Cypress version

### DIFF
--- a/examples/basic-mini/README.md
+++ b/examples/basic-mini/README.md
@@ -1,0 +1,7 @@
+# examples/basic-mini
+
+This directory contains a simple example of a Cypress E2E test with one test spec `cypress/e2e/spec.cy.js`. The example is intended for use with a Cypress Docker image `cypress/included` which includes a version of Cypress installed in the image. In order to avoid potential version conflicts between the example and the Docker image there is no Cypress version included in the [package.json](package.json) file.
+
+## Non-Docker demonstration
+
+Unlike the related [basic](../basic/) example, this example is not suited to be run without a Docker image, since it does not include Cypress (see above for explanation).

--- a/examples/basic-mini/cypress.config.js
+++ b/examples/basic-mini/cypress.config.js
@@ -1,0 +1,8 @@
+const { defineConfig } = require('cypress')
+
+module.exports = defineConfig({
+  fixturesFolder: false,
+  e2e: {
+    supportFile: false,
+  },
+})

--- a/examples/basic-mini/cypress/e2e/spec.cy.js
+++ b/examples/basic-mini/cypress/e2e/spec.cy.js
@@ -1,0 +1,6 @@
+describe('test local demo page', () => {
+  it('heading', () => {
+    cy.visit('index.html')
+    cy.contains('h2', 'Test')
+  })
+})

--- a/examples/basic-mini/index.html
+++ b/examples/basic-mini/index.html
@@ -1,0 +1,16 @@
+<!DOCTYPE html>
+<html lang="en">
+
+<head>
+  <meta charset="utf-8">
+  <title>Test for Cypress Docker images</title>
+</head>
+
+<body>
+  <h1>Purpose</h1>
+  <p>This page is used for demonstrating Cypress Docker images.</p>
+  <h2>Test heading</h2>
+  <p>This is a test page</p>
+</body>
+
+</html>

--- a/examples/basic-mini/package-lock.json
+++ b/examples/basic-mini/package-lock.json
@@ -1,0 +1,12 @@
+{
+  "name": "example-basic-mini",
+  "version": "1.0.0",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "example-basic-mini",
+      "version": "1.0.0"
+    }
+  }
+}

--- a/examples/basic-mini/package.json
+++ b/examples/basic-mini/package.json
@@ -1,0 +1,6 @@
+{
+  "name": "example-basic-mini",
+  "version": "1.0.0",
+  "description": "Basic E2E Cypress test example - no Cypress module",
+  "private": true
+}


### PR DESCRIPTION
## Situation

To avoid Cypress-version conflicts when testing with `cypress/included`, a Cypress project is needed which has no Cypress dependency defined in its `package*.json` files.

## Change

Add a the Cypress project `examples/basic-mini` configured without any Cypress version dependency.

## Verification

```shell
cd examples/basic-mini
docker run -it --rm -v .:/e2e -w /e2e cypress/included
docker run -it --rm -v .:/e2e -w /e2e --entrypoint cypress cypress/included info
docker run -it --rm -v .:/e2e -w /e2e --entrypoint cypress cypress/included run --browser chrome
```
