### PR TITLE
chore: cypress 13.12.0 release

### DIFF
--- a/factory/.env
+++ b/factory/.env
@@ -16,16 +16,16 @@ NODE_VERSION="${FACTORY_DEFAULT_NODE_VERSION}"
 FACTORY_VERSION='4.0.2'
 
 # Chrome versions: https://www.ubuntuupdates.org/package/google_chrome/stable/main/base/google-chrome-stable
-CHROME_VERSION='125.0.6422.141-1'
+CHROME_VERSION='126.0.6478.114-1'
 
 # Cypress versions: https://www.npmjs.com/package/cypress
-CYPRESS_VERSION='13.11.0'
+CYPRESS_VERSION='13.12.0'
 
 # Edge versions: https://packages.microsoft.com/repos/edge/pool/main/m/microsoft-edge-stable/
-EDGE_VERSION='125.0.2535.85-1'
+EDGE_VERSION='126.0.2592.61-1'
 
 # Firefox versions: https://download-installer.cdn.mozilla.net/pub/firefox/releases/
-FIREFOX_VERSION='126.0.1'
+FIREFOX_VERSION='127.0.1'
 
 # Yarn versions: https://www.npmjs.com/package/yarn and
 # https://classic.yarnpkg.com/latest-version


### PR DESCRIPTION
updates:
chrome to `126.0.6478.114-1`
edge to `126.0.2592.61-1`
firefox to `127.0.1`
cypress to `13.12.0`