### PR TITLE
docs: factory version bump description

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -59,7 +59,15 @@ docker compose run test-factory-all-included
 
 ##### New versions
 
-To publish a new image for `factory`, `base`, `browsers`, and `included`, open a PR with the desired version(s) updated in the [factory/.env](./factory/.env) file. Once the PR is merged into the `master` branch, the corresponding images will be pushed to Docker Hub via an automated script run in CI. Please check that the CI jobs pass after merge.
+To publish a new image for `factory`, `base`, `browsers`, or `included`, open a PR with the desired version(s) updated in the [factory/.env](./factory/.env) file. If you change any of the following environment variables in [factory/.env](./factory/.env), then you should also bump the `FACTORY_VERSION` in the same file and make a note of the change in the factory [CHANGELOG](./factory/CHANGELOG.md):
+
+- `BASE_IMAGE`
+- `FACTORY_DEFAULT_NODE_VERSION`
+- `YARN_VERSION`
+
+You should not change the `FACTORY_VERSION` or make an entry into the factory [CHANGELOG](./factory/CHANGELOG.md) if you are only changing browser versions or the Cypress version.
+
+Once the PR is merged into the `master` branch, the corresponding images will be pushed to [Docker Hub](https://hub.docker.com/u/cypress) and to the [Amazon ECR (Elastic Container Registry) Public Gallery](https://gallery.ecr.aws/cypress-io) via an automated script run through [CircleCI](circle.yml). Please check that the CI jobs pass after merge. Any CI failure can cause the release process to be interrupted.
 
 ##### Older versions
 

--- a/factory/.env
+++ b/factory/.env
@@ -3,7 +3,7 @@
 ## If you wish to release an older Docker image, do not modify this file in the master branch.
 ## Follow the instructions in the CONTRIBUTING document and work instead in a feature branch.
 
-# The debian image the factory is based on
+# The Debian image cypress/factory is based on
 BASE_IMAGE='debian:12-slim'
 
 # Node Versions: https://nodejs.org/en/download/releases/
@@ -12,7 +12,8 @@ FACTORY_DEFAULT_NODE_VERSION='20.14.0'
 # Node Versions: https://nodejs.org/en/download/releases/
 NODE_VERSION="${FACTORY_DEFAULT_NODE_VERSION}"
 
-# Update this to deploy the docker factory if you make changes to factory.Dockerfile or install scripts
+# Update the FACTORY_VERSION to deploy cypress/factory if you make changes to
+# BASE_IMAGE, FACTORY_DEFAULT_NODE_VERSION, YARN_VERSION, factory.Dockerfile or installScripts
 FACTORY_VERSION='4.0.2'
 
 # Chrome versions: https://www.ubuntuupdates.org/package/google_chrome/stable/main/base/google-chrome-stable
@@ -36,7 +37,7 @@ YARN_VERSION='1.22.22'
 # WEBKIT_VERSION='1.29.0'
 
 
-# Tags used for the docker images generated from the factory. Keep in mind the docker images will only release if these versions change.
+# Tags used for the Docker images generated from cypress/factory. Keep in mind the Docker images will only release if these versions change.
 BASE_IMAGE_TAG="${NODE_VERSION}"
 
 BROWSERS_IMAGE_TAG="node-${NODE_VERSION}-chrome-${CHROME_VERSION}-ff-${FIREFOX_VERSION}-edge-${EDGE_VERSION}"


### PR DESCRIPTION
## Issue

[CONTRIBUTING > Releasing a new factory version](https://github.com/cypress-io/cypress-docker-images/blob/master/CONTRIBUTING.md#releasing-a-new-factory-version) specifies releasing a new `cypress/factory` version after changes to [factory.Dockerfile](./factory/factory.Dockerfile) or [installScripts](./factory/installScripts/). It does not mention changes to the [factory/.env](https://github.com/cypress-io/cypress-docker-images/blob/master/factory/.env) file.

In practice, changes to the following parameters in the [factory/.env](https://github.com/cypress-io/cypress-docker-images/blob/master/factory/.env) file have prompted bumping the `FACTORY_VERSION` and recording it in the [factory/CHANGELOG](https://github.com/cypress-io/cypress-docker-images/blob/master/factory/CHANGELOG.md):

- `BASE_IMAGE`
- `FACTORY_DEFAULT_NODE_VERSION`
- `YARN_VERSION`

Changes to the following parameters have not caused `FACTORY_VERSION` to be bumped:

- `CHROME_VERSION`
- `CYPRESS_VERSION`
- `EDGE_VERSION`
- `FIREFOX_VERSION`

This unwritten rule should be documented.

## Discussion

### BASE_IMAGE

Changes to `BASE_IMAGE` must be accompanied by a bump to `FACTORY_VERSION` in [factory/.env](https://github.com/cypress-io/cypress-docker-images/blob/master/factory/.env). This environment variable is used in [factory/docker-compose.yml](https://github.com/cypress-io/cypress-docker-images/blob/master/factory/docker-compose.yml) and if it were not updated, then Docker images such as `cypress/base`, `cypress/browsers` and `cypress/included` would build on the old `BASE_IMAGE` value.

### FACTORY_DEFAULT_NODE_VERSION

The environment variable `CYPRESS_FACTORY_DEFAULT_NODE_VERSION` is loaded into the `cypress/factory` image, so in order to release this change, and keep released images consistent with the [factory/.env](https://github.com/cypress-io/cypress-docker-images/blob/master/factory/.env) contents, `FACTORY_VERSION` must be bumped.

### YARN_VERSION

The `cypress/factory` image does not contain Yarn. If `YARN_VERSION` is changed in [factory/.env](https://github.com/cypress-io/cypress-docker-images/blob/master/factory/.env) it does not cause any new releases of `cypress/base`, `cypress/browsers` or `cypress/included` to take place, since releases are only triggered when there is a change of tag. The Yarn version is not included in any tag, so there is no tag change.

Nevertheless, `YARN_VERSION` is a significant parameter. Bumping `FACTORY_VERSION` and logging the change in the [factory/CHANGELOG](https://github.com/cypress-io/cypress-docker-images/blob/master/factory/CHANGELOG.md) is worthwhile simply from a documentation standpoint.

### Browser versions

Browsers are not built into `cypress/factory` and changes should not be logged into [factory/CHANGELOG](https://github.com/cypress-io/cypress-docker-images/blob/master/factory/CHANGELOG.md) or cause a change of `FACTORY_VERSION`.

- `CHROME_VERSION`
- `EDGE_VERSION`
- `FIREFOX_VERSION`

### CYPRESS_VERSION

The parameter `CYPRESS_VERSION` in [factory/.env](https://github.com/cypress-io/cypress-docker-images/blob/master/factory/.env) only affects the `cypress/included` image, not `cypress/factory`, `cypress/base` or `cypress/browsers`, so changes should not be logged into [factory/CHANGELOG](https://github.com/cypress-io/cypress-docker-images/blob/master/factory/CHANGELOG.md) or cause a change of `FACTORY_VERSION`.

## Change

Add information that the `FACTORY_VERSION` should be changed for the following parameters, and for no others:

- `BASE_IMAGE`
- `FACTORY_DEFAULT_NODE_VERSION`
- `YARN_VERSION`
