### PR TITLE
chore: add 20.15.0 internal docker images

### DIFF
--- a/base-internal/releases/node-20/20.15.0/Dockerfile
+++ b/base-internal/releases/node-20/20.15.0/Dockerfile
@@ -1,0 +1,58 @@
+# build it with command
+#   docker build -t cypress/base-internal:20.15.0 --platform linux/amd64 .
+#
+FROM node:20.15.0-bookworm-slim
+
+RUN apt-get update && \
+  apt-get install --no-install-recommends -y \
+  libgtk2.0-0 \
+  libgtk-3-0 \
+  libnotify-dev \
+  libgconf-2-4 \
+  libgbm-dev \
+  libnss3 \
+  libxss1 \
+  libasound2 \
+  libxtst6 \
+  procps \
+  xauth \
+  xvfb \
+  build-essential \
+  # install text editors
+  vim-tiny \
+  nano \
+  # install emoji font
+  fonts-noto-color-emoji \
+  # install Chinese fonts
+  # this list was copied from https://github.com/jim3ma/docker-leanote
+  fonts-arphic-bkai00mp \
+  fonts-arphic-bsmi00lp \
+  fonts-arphic-gbsn00lp \
+  fonts-arphic-gkai00mp \
+  fonts-arphic-ukai \
+  fonts-arphic-uming \
+  ttf-wqy-zenhei \
+  ttf-wqy-microhei \
+  xfonts-wqy \
+  # clean up
+  && rm -rf /var/lib/apt/lists/* \
+  && apt-get clean
+
+# a few environment variables to make NPM installs easier
+# good colors for most applications
+ENV TERM=xterm
+# avoid million NPM install messages
+ENV npm_config_loglevel=warn
+# allow installing when the main user is root
+ENV npm_config_unsafe_perm=true
+
+RUN npm --version \
+  && npm install -g yarn@latest --force \
+  && yarn --version \
+  && node -p process.versions \
+  && node -p 'module.paths' \
+  && echo  " node version:    $(node -v) \n" \
+    "npm version:     $(npm -v) \n" \
+    "yarn version:    $(yarn -v) \n" \
+    "debian version:  $(cat /etc/debian_version) \n" \
+    "user:            $(whoami) \n"

--- a/base-internal/releases/node-20/20.15.0/Dockerfile
+++ b/base-internal/releases/node-20/20.15.0/Dockerfile
@@ -43,8 +43,6 @@ RUN apt-get update && \
 ENV TERM=xterm
 # avoid million NPM install messages
 ENV npm_config_loglevel=warn
-# allow installing when the main user is root
-ENV npm_config_unsafe_perm=true
 
 RUN npm --version \
   && npm install -g yarn@latest --force \

--- a/base-internal/releases/node-20/20.15.0/README.md
+++ b/base-internal/releases/node-20/20.15.0/README.md
@@ -9,14 +9,3 @@ NOTE: This image is intended for internal use with https://github.com/cypress-io
 
 #### Env variables
 * Does not contain the `CACHE_FOLDER` and `FACTORY_DEFAULT_NODE_VERSION` env variables to keep unit tests non environment specific
-
-## Example
-
-Sample Dockerfile
-
-```
-FROM cypress/base-internal:20.15.0
-RUN npm install --save-dev cypress
-RUN $(npm bin)/cypress verify
-RUN $(npm bin)/cypress run
-```

--- a/base-internal/releases/node-20/20.15.0/README.md
+++ b/base-internal/releases/node-20/20.15.0/README.md
@@ -1,0 +1,22 @@
+# cypress/base-internal:20.15.0
+A Docker image with all dependencies pre-installed.
+
+NOTE: This image is intended for internal use with https://github.com/cypress-io/cypress. It contains a few differences from the factory, such as:
+
+#### Dependency Additions
+* xauth (to run xvfb inside system-tests)
+* build-essential to install `make` and other linux build packages
+
+#### Env variables
+* Does not contain the `CACHE_FOLDER` and `FACTORY_DEFAULT_NODE_VERSION` env variables to keep unit tests non environment specific
+
+## Example
+
+Sample Dockerfile
+
+```
+FROM cypress/base-internal:20.15.0
+RUN npm install --save-dev cypress
+RUN $(npm bin)/cypress verify
+RUN $(npm bin)/cypress run
+```

--- a/base-internal/releases/node-20/20.15.0/build.sh
+++ b/base-internal/releases/node-20/20.15.0/build.sh
@@ -1,0 +1,7 @@
+set e+x
+
+# build image with Cypress dependencies
+LOCAL_NAME=cypress/base-internal:20.15.0
+
+echo "Building $LOCAL_NAME"
+docker build -t $LOCAL_NAME .

--- a/browsers-internal/releases/node-20/node20.15.0-chrome126-ff127/Dockerfile
+++ b/browsers-internal/releases/node-20/node20.15.0-chrome126-ff127/Dockerfile
@@ -1,0 +1,77 @@
+# build this image with command
+#   docker build -t cypress/browsers-internal:node20.15.0-chrome126-ff127 --platform linux/amd64 .
+#
+FROM cypress/base-internal:20.15.0
+
+USER root
+
+RUN node --version
+
+COPY ./global-profile.sh /tmp/global-profile.sh
+RUN cat /tmp/global-profile.sh >> /etc/bash.bashrc && rm /tmp/global-profile.sh
+
+# Install dependencies
+RUN apt-get update && \
+  apt-get install -y \
+  fonts-liberation \
+  git \
+  libcurl4 \
+  libcurl3-gnutls \
+  libcurl3-nss \
+  xdg-utils \
+  wget \
+  curl \
+  # chrome dependencies
+  libu2f-udev \
+  # firefox dependencies
+  bzip2 \
+  # add codecs needed for video playback in firefox
+  # https://github.com/cypress-io/cypress-docker-images/issues/150
+  mplayer \
+  \
+  # clean up
+  && rm -rf /var/lib/apt/lists/* \
+  && apt-get clean
+
+# install libappindicator3-1 - not included with Debian 11
+RUN wget --no-verbose /usr/src/libappindicator3-1_0.4.92-7_amd64.deb "http://ftp.us.debian.org/debian/pool/main/liba/libappindicator/libappindicator3-1_0.4.92-7_amd64.deb" && \
+  dpkg -i /usr/src/libappindicator3-1_0.4.92-7_amd64.deb ; \
+  apt-get install -f -y && \
+  rm -f /usr/src/libappindicator3-1_0.4.92-7_amd64.deb
+
+# install Chrome browser
+RUN node -p "process.arch === 'arm64' ? 'Not downloading Chrome since we are on arm64: https://crbug.com/677140' : process.exit(1)" || \
+  (wget --no-verbose -O /usr/src/google-chrome-stable_current_amd64.deb "http://dl.google.com/linux/chrome/deb/pool/main/g/google-chrome-stable/google-chrome-stable_126.0.6478.126-1_amd64.deb" && \
+  dpkg -i /usr/src/google-chrome-stable_current_amd64.deb ; \
+  apt-get install -f -y && \
+  rm -f /usr/src/google-chrome-stable_current_amd64.deb)
+
+# "fake" dbus address to prevent errors
+# https://github.com/SeleniumHQ/docker-selenium/issues/87
+ENV DBUS_SESSION_BUS_ADDRESS=/dev/null
+
+# install Firefox browser
+RUN node -p "process.arch === 'arm64' ? 'Not downloading Firefox since we are on arm64: https://bugzilla.mozilla.org/show_bug.cgi?id=1678342' : process.exit(1)" || \
+  (wget --no-verbose -O /tmp/firefox.tar.bz2 https://download-installer.cdn.mozilla.net/pub/firefox/releases/127.0.2/linux-x86_64/en-US/firefox-127.0.2.tar.bz2 && \
+  tar -C /opt -xjf /tmp/firefox.tar.bz2 && \
+  rm /tmp/firefox.tar.bz2 && \
+  ln -fs /opt/firefox/firefox /usr/bin/firefox)
+
+# versions of local tools
+RUN echo  " node version:    $(node -v) \n" \
+  "npm version:     $(npm -v) \n" \
+  "yarn version:    $(yarn -v) \n" \
+  "debian version:  $(cat /etc/debian_version) \n" \
+  "Chrome version:  $(google-chrome --version) \n" \
+  "Firefox version: $(firefox --version) \n" \
+  "Edge version:    n/a \n" \ 
+  "git version:     $(git --version) \n" \
+  "whoami:          $(whoami) \n"
+
+# a few environment variables to make NPM installs easier
+# good colors for most applications
+ENV TERM=xterm
+# avoid million NPM install messages
+ENV npm_config_loglevel=warn
+# allow installing when the main user is root
+ENV npm_config_unsafe_perm=true

--- a/browsers-internal/releases/node-20/node20.15.0-chrome126-ff127/Dockerfile
+++ b/browsers-internal/releases/node-20/node20.15.0-chrome126-ff127/Dockerfile
@@ -73,5 +73,3 @@ RUN echo  " node version:    $(node -v) \n" \
 ENV TERM=xterm
 # avoid million NPM install messages
 ENV npm_config_loglevel=warn
-# allow installing when the main user is root
-ENV npm_config_unsafe_perm=true

--- a/browsers-internal/releases/node-20/node20.15.0-chrome126-ff127/README.md
+++ b/browsers-internal/releases/node-20/node20.15.0-chrome126-ff127/README.md
@@ -1,0 +1,18 @@
+# cypress/browsers-internal:node20.15.0-chrome126-ff127
+
+A complete image with all operating system dependencies for Cypress, and Chrome 126.0.6478.126-1, Firefox 127.0.2 browsers.
+
+NOTE: This image is intended for internal use with https://github.com/cypress-io/cypress. It contains a few differences from the factory, such as:
+
+#### Dependency Additions
+* curl
+* build-essentials (to contain `make` and a few other dependencies)
+
+#### Env variables
+* Does not contain the `CACHE_FOLDER` and `FACTORY_DEFAULT_NODE_VERSION` env variables to keep unit tests non environment specific
+
+[Dockerfile](Dockerfile)
+
+**Note:** this image uses the `root` user. You might want to switch to non-root user like `node` when running this container for security
+
+**Note:** Currently, the linux/arm64 build of this image does not contain any browsers except Electron. See https://github.com/cypress-io/cypress-docker-images/issues/695 for more information.

--- a/browsers-internal/releases/node-20/node20.15.0-chrome126-ff127/build.sh
+++ b/browsers-internal/releases/node-20/node20.15.0-chrome126-ff127/build.sh
@@ -1,0 +1,5 @@
+set e+x
+
+LOCAL_NAME=cypress/browsers-internal:node20.15.0-chrome126-ff127
+echo "Building $LOCAL_NAME"
+docker build -t $LOCAL_NAME .

--- a/browsers-internal/releases/node-20/node20.15.0-chrome126-ff127/global-profile.sh
+++ b/browsers-internal/releases/node-20/node20.15.0-chrome126-ff127/global-profile.sh
@@ -1,0 +1,11 @@
+if [[ "$(uname -a)" = *"arm"* || "$(uname -a)" = *"aarch64"* ]]; then
+    printf "\e[31m" # red
+    echo "Warning: You are using the beta Arm build of a cypress/browsers or cypress/included image."
+    echo
+    echo "On Arm, non-Electron browsers are not available, because browser vendors are not yet building for Linux arm64."
+    echo "You must use the built-in Electron browser (--browser electron) to run Cypress or find and install unofficial Arm binary builds."
+    echo
+    echo "More details and links to upstream issues for Chrome, Firefox, and Edge can be found at Cypress's issue tracker:"
+    echo "  https://github.com/cypress-io/cypress-docker-images/issues/695"
+    printf "\e[0m" # reset
+fi


### PR DESCRIPTION
adds the 20.15.0 docker image and browsers images to be used within cypress CI to test the kitchensink. see https://github.com/cypress-io/cypress/pull/29771

images are already published