### PR TITLE
fix: update cypress/factory to Debian 12.6

### DIFF
--- a/factory/.env
+++ b/factory/.env
@@ -4,7 +4,7 @@
 ## Follow the instructions in the CONTRIBUTING document and work instead in a feature branch.
 
 # The Debian image cypress/factory is based on
-BASE_IMAGE='debian:12-slim'
+BASE_IMAGE='debian:12.6-slim'
 
 # Node Versions: https://nodejs.org/en/download/releases/
 FACTORY_DEFAULT_NODE_VERSION='20.14.0'
@@ -14,7 +14,7 @@ NODE_VERSION="${FACTORY_DEFAULT_NODE_VERSION}"
 
 # Update the FACTORY_VERSION to deploy cypress/factory if you make changes to
 # BASE_IMAGE, FACTORY_DEFAULT_NODE_VERSION, YARN_VERSION, factory.Dockerfile or installScripts
-FACTORY_VERSION='4.0.2'
+FACTORY_VERSION='4.0.3'
 
 # Chrome versions: https://www.ubuntuupdates.org/package/google_chrome/stable/main/base/google-chrome-stable
 CHROME_VERSION='126.0.6478.114-1'

--- a/factory/CHANGELOG.md
+++ b/factory/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Change log
 
+## 4.0.3
+
+* Updated Debian base to `debian:12.6-slim` using [Debian 12.6](https://www.debian.org/News/2024/20240629), released June 29th, 2024. Addresses [#1137](https://github.com/cypress-io/cypress-docker-images/issues/1137)
+
 ## 4.0.2
 
 * Updated default node version from `20.13.1` to `20.14.0`. Addressed in [#1097](https://github.com/cypress-io/cypress-docker-images/pull/1097)


### PR DESCRIPTION
- closes https://github.com/cypress-io/cypress-docker-images/issues/1137

## Issue

- Debian `12.6` was released on [June 29th, 2024](https://www.debian.org/News/2024/20240629) and contains vulnerability fixes which are not included in `cypress/factory:4.0.2` (current `latest`).

## Change

Update to `debian:12.6-slim` in `cypress/factory`, specifying exact version of Debian for documentation clarity of version in use.

## Verification

On Ubuntu `22.04.4` LTS, Node.js `v20.15.0` LTS

Execute:

```shell
cd factory
docker compose build factory
docker compose build
```

and confirm that all images are built without errors or warnings.

Continue with

```shell
cd test-project
set -a && . ../.env && set +a
docker compose run test-factory-all-included
```

and confirm that the image builds without errors or warnings and runs successfully.
