### PR TITLE
build: use uppercase FROM / AS combination in Dockerfile

### DIFF
--- a/factory/Dockerfile
+++ b/factory/Dockerfile
@@ -2,9 +2,9 @@
 ARG FACTORY_VERSION
 
 # Multi-stage default image. Used to test and create the pre-built docker images.
-FROM cypress/factory:${FACTORY_VERSION} as default_image
+FROM cypress/factory:${FACTORY_VERSION} AS default_image
 
 # Multi-stage included image. We set the entry point only for the included image.
-FROM cypress/factory:${FACTORY_VERSION} as included_image
+FROM cypress/factory:${FACTORY_VERSION} AS included_image
 
 ENTRYPOINT ["cypress", "run"]

--- a/factory/factory.Dockerfile
+++ b/factory/factory.Dockerfile
@@ -1,7 +1,7 @@
 # Set base image arg to allow easy testing of other debian versions.
 ARG BASE_IMAGE
 
-FROM ${BASE_IMAGE} as factory
+FROM ${BASE_IMAGE} AS factory
 
 # "fake" dbus address to prevent errors
 # https://github.com/SeleniumHQ/docker-selenium/issues/87


### PR DESCRIPTION
- closes https://github.com/cypress-io/cypress-docker-images/issues/1139

## Issue

When running `docker compose build factory` under Docker Desktop for Linux, a warning is output:

> => [factory internal] load build definition from factory.Dockerfile
> => => transferring dockerfile: 4.84kB
> => WARN: FromAsCasing: 'as' and 'FROM' keywords' casing do not match (line 4) 

## Change

Modify the following to use upper case "AS" to match the case of "FROM"

- [factory/Dockerfile](https://github.com/cypress-io/cypress-docker-images/blob/master/factory/Dockerfile)
- [factory/factory.Dockerfile](https://github.com/cypress-io/cypress-docker-images/blob/master/factory/factory.Dockerfile)

## Verify

Ubuntu  22.04.4 LTS
Node.js v20.15.0
Docker version  27.0.3
Docker Desktop 4.31.0 (153195)

Execute the following and check that there is no `WARN: FromAsCasing` message output in the logs:

```shell
cd factory
docker compose build factory
```
