### PR TITLE
chore: update circleci to ubuntu-2204:2023.04.2 machine image

### DIFF
--- a/circle.yml
+++ b/circle.yml
@@ -52,7 +52,7 @@ commands:
 jobs:
     check-factory-versions:
         machine:
-            image: ubuntu-2204:2022.10.2
+            image: ubuntu-2204:2023.04.2
         steps:
             - checkout
             - expand-env-file
@@ -147,7 +147,7 @@ jobs:
                   working_directory: factory/test-project
     check-node-override-version:
         machine:
-            image: ubuntu-2204:2022.10.2
+            image: ubuntu-2204:2023.04.2
         steps:
             - checkout
             - expand-env-file
@@ -173,7 +173,7 @@ jobs:
                   working_directory: factory/test-project
     test-image:
         machine:
-            image: ubuntu-2204:2022.10.2
+            image: ubuntu-2204:2023.04.2
         parameters:
             target:
                 type: string
@@ -203,7 +203,7 @@ jobs:
 
     push:
         machine:
-            image: ubuntu-2204:2022.10.2
+            image: ubuntu-2204:2023.04.2
         parameters:
             target:
                 type: string


### PR DESCRIPTION
- closes #1145

## Issue

The [circle.yml](https://github.com/cypress-io/cypress-docker-images/blob/master/circle.yml) workflow is currently using machine image `ubuntu-2204:2022.10.2` from [Circle CI Machine Images > ubuntu-2204](https://circleci.com/developer/machine/image/ubuntu-2204) which includes Node.js `16.17.1`.
This Node.js version entered [End-of-life](https://nodejs.org/en/blog/announcements/nodejs16-eol/) on Sep 11, 2023 and so it is now unsupported.

## Change

The [circle.yml](https://github.com/cypress-io/cypress-docker-images/blob/master/circle.yml) workflow is updated to [ubuntu-2204:2023.04.2](https://discuss.circleci.com/t/linux-machine-executor-2023-q2-update-edge-ga-release/47680):

| Image tag                                                                                                           | Node.js   | Docker Engine                                                          | buildx                                                           | Status  |
| ------------------------------------------------------------------------------------------------------------------- | --------- | ---------------------------------------------------------------------- | ---------------------------------------------------------------- | ------- |
| [ubuntu-2204:2022.10.2](https://discuss.circleci.com/t/linux-machine-executor-update-2022-october-q4-update/45753)  | `16.17.1` | [20.10.18](https://docs.docker.com/engine/release-notes/20.10/#201018) | [v0.9.1](https://github.com/docker/buildx/releases/tag/v0.9.1)   | Current |
| [ubuntu-2204:2023.04.2](https://discuss.circleci.com/t/linux-machine-executor-2023-q2-update-edge-ga-release/47680) | `18.15.0` | [20.10.24](https://docs.docker.com/engine/release-notes/20.10/#201024) | [v0.10.4](https://github.com/docker/buildx/releases/tag/v0.10.4) | Future  |

- Node.js `18.x` is currently in [release status](https://github.com/nodejs/release#release-schedule) "Maintenance" and continues to be supported until Apr 30, 2025.
- [ubuntu-2204:2023.04.2](https://discuss.circleci.com/t/linux-machine-executor-2023-q2-update-edge-ga-release/47680) is the latest non-deprecated machine image which still keeps the [Docker Engine](https://docs.docker.com/engine/) at `20.10.x`. 
- The release notes of [buildx v0.10.0](https://github.com/docker/buildx/releases/tag/v0.10.0) cryptically mention changes to the manifest. This is related to https://github.com/cypress-io/cypress-docker-images/issues/1093.

## References

### CircleCI Machine Images

[Circle CI Machine Images > ubuntu-2204](https://circleci.com/developer/machine/image/ubuntu-2204)

#### ubuntu-2204:2022.10.2

[Linux Machine Executor Update - 2022 October Q4 Update](https://discuss.circleci.com/t/linux-machine-executor-update-2022-october-q4-update/45753) uses

Node.js `16.17.1`
Docker  `20.10.18`

#### ubuntu-2204:2023.04.2

[Linux Machine Executor - 2023 Q2 Update Edge + GA Release](https://discuss.circleci.com/t/linux-machine-executor-2023-q2-update-edge-ga-release/47680)

Node.js `18.15.0`
Docker  `20.10.24`

### Docker release notes

- [Docker Engine 20.10 release notes](https://docs.docker.com/engine/release-notes/20.10/)
