### PR TITLE
ci: remove workflow version from circle.yml

### DIFF
--- a/circle.yml
+++ b/circle.yml
@@ -228,7 +228,6 @@ jobs:
                 working_directory: factory
 
 workflows:
-    version: 2
     test:
         jobs:
             - check-factory-versions


### PR DESCRIPTION
## Issue

The [official VS Code CircleCI extension](https://marketplace.visualstudio.com/items?itemName=circleci) reports that the workflow version in the CircleCI workflow [circle.yml](https://github.com/cypress-io/cypress-docker-images/blob/master/circle.yml) is deprecated.

```yml
workflows:
  version: 2
```

See also https://discuss.circleci.com/t/circleci-2-1-config-overview/26057:

> Make sure to take the version key out of your workflows section or bad things will happen. The only version key in 2.1 is the top-level key.

## Change

Remove `version` from CircleCI [circle.yml](https://github.com/cypress-io/cypress-docker-images/blob/master/circle.yml), `workflows` section.