### PR TITLE
ci: remove unused node orb from circle.yml

### DIFF
--- a/circle.yml
+++ b/circle.yml
@@ -7,9 +7,6 @@
 
 version: 2.1
 
-orbs:
-    node: circleci/node@5.0.0
-
 commands:
     expand-env-file:
         description: Sets up bash env to load envs from the env file


### PR DESCRIPTION
## Issue

The CircleCI workflow [circle.yml](https://github.com/cypress-io/cypress-docker-images/blob/master/circle.yml) selects the `circleci/node@5.0.0` Orb which is however otherwise unused in the workflow:

```yml
orbs:
    node: circleci/node@5.0.0
```

## Change

Remove the unused CircleCI Orb from the CircleCI workflow [circle.yml](https://github.com/cypress-io/cypress-docker-images/blob/master/circle.yml).
