### PR TITLE
ci: correct circle.yml indentation syntax error

### DIFF
--- a/circle.yml
+++ b/circle.yml
@@ -242,7 +242,7 @@ workflows:
                             test-factory-cypress-included-electron,
                             test-factory-cypress-included-electron-non-root-user,
                             test-factory-all-included-electron-only
-                        ]
+                            ]
                         resourceClass: [arm.medium]
                         target: [factory]
             - test-image:
@@ -262,7 +262,7 @@ workflows:
                             test-factory-cypress-included-firefox-non-root-user,
                             test-factory-cypress-included-edge,
                             test-factory-all-included
-                        ]
+                            ]
                         resourceClass: [medium]
                         target: [factory]
             - test-image:
@@ -271,7 +271,7 @@ workflows:
                     parameters:
                         test-target: [
                             test-base
-                        ]
+                            ]
                         resourceClass: [medium]
                         target: [base]
             - test-image:
@@ -280,7 +280,7 @@ workflows:
                     parameters:
                         test-target: [
                             test-base
-                        ]
+                            ]
                         resourceClass: [arm.medium]
                         target: [base]
             - test-image:
@@ -292,7 +292,7 @@ workflows:
                             test-browsers-chrome,
                             test-browsers-firefox,
                             test-browsers-edge
-                        ]
+                            ]
                         resourceClass: [medium]
                         target: [browsers]
 
@@ -302,7 +302,7 @@ workflows:
                     parameters:
                         test-target: [
                             test-browsers-electron
-                        ]
+                            ]
                         resourceClass: [arm.medium]
                         target: [browsers]
             - test-image:
@@ -314,7 +314,7 @@ workflows:
                             test-included-chrome,
                             test-included-firefox,
                             test-included-edge
-                        ]
+                            ]
                         resourceClass: [medium]
                         target: [included]
             - test-image:
@@ -323,7 +323,7 @@ workflows:
                     parameters:
                         test-target: [
                             test-included-electron
-                        ]
+                            ]
                         resourceClass: [arm.medium]
                         target: [included]
             # pushing the factory image must come first because the other images may pull it down to build


### PR DESCRIPTION
## Issue

The CircleCI workflow [circle.yml](https://github.com/cypress-io/cypress-docker-images/blob/master/circle.yml) formatting is invalid according to the [official VS Code CircleCI extension](https://marketplace.visualstudio.com/items?itemName=circleci.circleci).

The closing brackets (`]`) of `test-target` in multiple places are incorrectly indented.

## Change

Fix the indentation issues concerning `test-target` in the `workflows` section of [circle.yml](https://github.com/cypress-io/cypress-docker-images/blob/master/circle.yml).

This is a whitespace change only. It is however significant in the [yaml](https://yaml.org/spec/1.2.2/) syntax, which uses indentation to define scope.