### PR TITLE
ci: check image exists with Docker Hub API

### DIFF
--- a/circle.yml
+++ b/circle.yml
@@ -24,24 +24,31 @@ commands:
         parameters:
             target:
                 type: string
-                description: docker compose target being tested
+                description: cypress/* repo name (factory, base, browser or included)
         steps:
             - run:
-                  name: Check if image for << parameters.target >> exists or Docker hub does not respond
-                  # using https://github.com/cypress-io/docker-image-not-found
-                  # to check if Docker hub definitely does not have this image
+                  name: Check if image for << parameters.target >> exists on Docker Hub
+                  # using Docker HUB API https://docs.docker.com/docker-hub/api/latest/
+                  # to check if Docker Hub definitely does not have this image
                   command: |
-                      DOCKER_TAG=''
-                      if [ << parameters.target >> == factory ]; then DOCKER_TAG=cypress/factory:${FACTORY_VERSION}; fi
-                      if [ << parameters.target >> == base ]; then DOCKER_TAG=cypress/base:${BASE_IMAGE_TAG}; fi
-                      if [ << parameters.target >> == browsers ]; then DOCKER_TAG=cypress/browsers:${BROWSERS_IMAGE_TAG}; fi
-                      if [ << parameters.target >> == included ]; then DOCKER_TAG=cypress/included:${INCLUDED_IMAGE_TAG}; fi
+                      DOCKER_NAMESPACE='cypress'
+                      DOCKER_REPO=<< parameters.target >>
 
-                      if npx docker-image-not-found --repo $DOCKER_TAG; then
-                        echo Docker hub says image $DOCKER_TAG does not exist
+                      DOCKER_TAG=''
+                      if [ ${DOCKER_REPO} == factory ]; then DOCKER_TAG=${FACTORY_VERSION}; fi
+                      if [ ${DOCKER_REPO} == base ]; then DOCKER_TAG=${BASE_IMAGE_TAG}; fi
+                      if [ ${DOCKER_REPO} == browsers ]; then DOCKER_TAG=${BROWSERS_IMAGE_TAG}; fi
+                      if [ ${DOCKER_REPO} == included ]; then DOCKER_TAG=${INCLUDED_IMAGE_TAG}; fi
+
+                      DOCKER_NAME=${DOCKER_NAMESPACE}/${DOCKER_REPO}:${DOCKER_TAG}
+
+                      if curl -s https://hub.docker.com/v2/namespaces/${DOCKER_NAMESPACE}/repositories/${DOCKER_REPO}/tags/${DOCKER_TAG} \
+                        | grep -iq 'httperror 404'; then
+                        echo Docker Hub says image $DOCKER_NAME does not exist - HTTP status 404 returned
+                        echo $DOCKER_NAME available for publishing
                       else
-                        echo Docker hub has image $DOCKER_TAG or not responding
-                        echo We should stop in this case
+                        echo Docker Hub found image $DOCKER_NAME - or error occurred
+                        echo Stop to avoid republishing
                         circleci-agent step halt
                       fi
 

--- a/circle.yml
+++ b/circle.yml
@@ -48,7 +48,7 @@ commands:
                         echo $DOCKER_NAME available for publishing
                       else
                         echo Docker Hub found image $DOCKER_NAME - or error occurred
-                        echo Stop to avoid republishing
+                        echo Stopping to avoid republishing
                         circleci-agent step halt
                       fi
 


### PR DESCRIPTION
- closes https://github.com/cypress-io/cypress-docker-images/issues/1142
- closes https://github.com/cypress-io/cypress-docker-images/issues/1141
- supports resolution of issue https://github.com/cypress-io/cypress-docker-images/issues/1095
- supports resolution of issue https://github.com/cypress-io/cypress-docker-images/issues/1145

## Issue

When used in the [CircleCI workflow](https://github.com/cypress-io/cypress-docker-images/blob/master/circle.yml) workflow, the npm module [docker-image-not-found](https://www.npmjs.com/package/docker-image-not-found) outputs an error message "unsupported schema version 2" when attempting to check the existence of a Docker image on Docker Hub, if the image has been published with an `oci` type manifest instead of a `docker` type manifest.

## Change

In the [CircleCI workflow](https://github.com/cypress-io/cypress-docker-images/blob/master/circle.yml) workflow, replace the npm module [docker-image-not-found](https://www.npmjs.com/package/docker-image-not-found) using a [Docker HUB API](https://docs.docker.com/docker-hub/api/latest/) call.

For example, the following command returns `0` if Docker Hub reports that the image is not found (HTTP `404`), otherwise it returns `1`. This works for `docker` and `oci` type manifests:

```shell
curl -s https://hub.docker.com/v2/namespaces/cypress/repositories/factory/tags/4.5.6 | grep -iq 'httperror 404'
```

Apart from the different parameter passing, the [Docker HUB API)](https://docs.docker.com/docker-hub/api/latest/) call is a drop-in replacement for [docker-image-not-found](https://www.npmjs.com/package/docker-image-not-found).
