### PR TITLE
build: disable default provenance attestation

### DIFF
--- a/circle.yml
+++ b/circle.yml
@@ -217,6 +217,15 @@ jobs:
                     docker run --privileged --rm tonistiigi/binfmt --install linux/amd64,linux/arm64
                     docker buildx create --name builder --use
 
+                    # Disable default provenance attestation for Buildx
+                    # https://docs.docker.com/build/building/variables/#buildx_no_default_attestations
+                    # https://docs.docker.com/build/release-notes/#0100
+                    # Keeps using docker
+                    # "mediaType": "application/vnd.docker.distribution.manifest.list.v2+json"
+                    # instead of moving to oci, which may cause compatibility issues, for example
+                    # "mediaType": "application/vnd.oci.image.index.v1+json"
+                    export BUILDX_NO_DEFAULT_ATTESTATIONS=1
+
                     docker login -u "$DOCKERHUB_USERNAME" --password "$DOCKERHUB_PASS"
                     docker buildx bake -f ./docker-compose.yml --progress plain --set *.platform=linux/arm64,linux/amd64 --push << parameters.target >>
 


### PR DESCRIPTION
Supports resolution of

- https://github.com/cypress-io/cypress-docker-images/issues/1145
- https://github.com/cypress-io/cypress-docker-images/issues/1095

## Issue

- Docker [Buildx v0.10.0](https://docs.docker.com/build/release-notes/#0100) introduced a breaking change causing multi-architecture manifests to use `oci` instead of `docker` `imageType` formats. The release notes warn about issues with registry and runtime support. This already caused a issue in this repo (see https://github.com/cypress-io/cypress-docker-images/issues/1141). It is unknown whether allowing the manifest `imageType` to change for Cypress Docker images would cause usage issues in users' environments and it would have to be considered as a breaking change for Cypress Docker.

- This repo is currently using [Buildx v0.9.1](https://docs.docker.com/build/release-notes/#091) so this issue needs to be considered and prepared before any update to Buildx `v0.10.x` takes place:


  | Image tag                                                                                                           | Node.js   | Docker Engine                                                          | buildx                                                           | Status  |
  | ------------------------------------------------------------------------------------------------------------------- | --------- | ---------------------------------------------------------------------- | ---------------------------------------------------------------- | ------- |
  | [ubuntu-2204:2022.10.2](https://discuss.circleci.com/t/linux-machine-executor-update-2022-october-q4-update/45753)  | `16.17.1` | [20.10.18](https://docs.docker.com/engine/release-notes/20.10/#201018) | [v0.9.1](https://github.com/docker/buildx/releases/tag/v0.9.1)   | Current |


## Change

In order to keep the current manifest schema as follows:

```json
"schemaVersion": 2,
"mediaType": "application/vnd.docker.distribution.manifest.list.v2+json",
```

instead of moving to

```json
"schemaVersion": 2,
"mediaType": "application/vnd.oci.image.index.v1+json",
```

an environment variable setting [BUILDX_NO_DEFAULT_ATTESTATIONS=1](https://docs.docker.com/build/building/variables/#buildx_no_default_attestations), introduced in [Buildx 0.10.4](https://docs.docker.com/build/release-notes/#0104), is added to the `push` job of the [circle.yml](https://github.com/cypress-io/cypress-docker-images/blob/master/circle.yml) workflow.
