### PR TITLE
chore(deps): update to Node.js 20.15.1

### DIFF
--- a/factory/.env
+++ b/factory/.env
@@ -7,14 +7,14 @@
 BASE_IMAGE='debian:12.6-slim'
 
 # Node Versions: https://nodejs.org/en/download/releases/
-FACTORY_DEFAULT_NODE_VERSION='20.14.0'
+FACTORY_DEFAULT_NODE_VERSION='20.15.1'
 
 # Node Versions: https://nodejs.org/en/download/releases/
 NODE_VERSION="${FACTORY_DEFAULT_NODE_VERSION}"
 
 # Update the FACTORY_VERSION to deploy cypress/factory if you make changes to
 # BASE_IMAGE, FACTORY_DEFAULT_NODE_VERSION, YARN_VERSION, factory.Dockerfile or installScripts
-FACTORY_VERSION='4.0.3'
+FACTORY_VERSION='4.0.4'
 
 # Chrome versions: https://www.ubuntuupdates.org/package/google_chrome/stable/main/base/google-chrome-stable
 CHROME_VERSION='126.0.6478.114-1'

--- a/factory/CHANGELOG.md
+++ b/factory/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Change log
 
+## 4.0.4
+
+* Updated default node version from `20.14.0` to `20.15.1`. Addresses [#1153](https://github.com/cypress-io/cypress-docker-images/issues/1153)
+
 ## 4.0.3
 
 * Updated Debian base to `debian:12.6-slim` using [Debian 12.6](https://www.debian.org/News/2024/20240629), released June 29th, 2024. Addresses [#1137](https://github.com/cypress-io/cypress-docker-images/issues/1137)


### PR DESCRIPTION
- closes #1153

## Issue

- The Node.js project released a security update [Node.js v20.15.1 LTS](https://nodejs.org/en/blog/release/v20.15.1) on July 8, 2024.

## Change

In [factory/.env](https://github.com/cypress-io/cypress-docker-images/blob/master/factory/.env) update

- `FACTORY_VERSION` to 4.0.4
- `FACTORY_DEFAULT_NODE_VERSION` from `20.14.0` to `20.15.1`