### PR TITLE
chore: update circleci to ubuntu-2204:2023.10.1 machine image

### DIFF
--- a/circle.yml
+++ b/circle.yml
@@ -52,7 +52,7 @@ commands:
 jobs:
     check-factory-versions:
         machine:
-            image: ubuntu-2204:2023.04.2
+            image: ubuntu-2204:2023.10.1
         steps:
             - checkout
             - expand-env-file
@@ -147,7 +147,7 @@ jobs:
                   working_directory: factory/test-project
     check-node-override-version:
         machine:
-            image: ubuntu-2204:2023.04.2
+            image: ubuntu-2204:2023.10.1
         steps:
             - checkout
             - expand-env-file
@@ -173,7 +173,7 @@ jobs:
                   working_directory: factory/test-project
     test-image:
         machine:
-            image: ubuntu-2204:2023.04.2
+            image: ubuntu-2204:2023.10.1
         parameters:
             target:
                 type: string
@@ -203,7 +203,7 @@ jobs:
 
     push:
         machine:
-            image: ubuntu-2204:2023.04.2
+            image: ubuntu-2204:2023.10.1
         parameters:
             target:
                 type: string


### PR DESCRIPTION
- supports resolution of issue https://github.com/cypress-io/cypress-docker-images/issues/1095

## Issue

- Following the successful merge of PR https://github.com/cypress-io/cypress-docker-images/pull/1147, the [circle.yml](https://github.com/cypress-io/cypress-docker-images/blob/master/circle.yml) workflow is now using machine image [ubuntu-2204:2023.04.2](https://discuss.circleci.com/t/linux-machine-executor-2023-q2-update-edge-ga-release/47680) from [Circle CI Machine Images > ubuntu-2204](https://circleci.com/developer/machine/image/ubuntu-2204). This fulfils the requirement to run under a supported version of Node.js (`18.15.0`), however the Docker Engine [20.10.24](https://docs.docker.com/engine/release-notes/20.10/#201024) with Buildx [v0.10.4](https://github.com/docker/buildx/releases/tag/v0.10.4) is a release from April 2023 and lags behind the latest version of Docker Engine which is currently at [27.0.3](https://docs.docker.com/engine/release-notes/27.0/).

## Change

[Docker Buildx Bake](https://docs.docker.com/build/bake/), used in the Cypress Docker image build workflow, is labeled by Docker as "Experimental". The strategy is then to move in incremental steps, upgrading the [Circle CI Machine Images > ubuntu-2204](https://circleci.com/developer/machine/image/ubuntu-2204) one release at a time, to contain the results of any unexpected changes better.

The [circle.yml](https://github.com/cypress-io/cypress-docker-images/blob/master/circle.yml) workflow is updated to [ubuntu-2204:2023.10.1](https://discuss.circleci.com/t/linux-machine-executor-2023-q4-update/49457):

| Image tag                                                                                                           | Node.js   | Docker Engine                                                          | buildx                                                           | Status  |
| ------------------------------------------------------------------------------------------------------------------- | --------- | ---------------------------------------------------------------------- | ---------------------------------------------------------------- | ------- |
| [ubuntu-2204:2023.04.2](https://discuss.circleci.com/t/linux-machine-executor-2023-q2-update-edge-ga-release/47680) | `18.15.0` | [20.10.24](https://docs.docker.com/engine/release-notes/20.10/#201024) | [v0.10.4](https://github.com/docker/buildx/releases/tag/v0.10.4) | Current  |
| [ubuntu-2204:2023.10.1](https://discuss.circleci.com/t/linux-machine-executor-2023-q4-update/49457) | `18.18.0` | [24.0.6](https://docs.docker.com/engine/release-notes/24.0/#2406) | [v0.11.2](https://github.com/docker/buildx/releases/tag/v0.11.2) | Future  |

## References

### CircleCI Machine Images

[Circle CI Machine Images > ubuntu-2204](https://circleci.com/developer/machine/image/ubuntu-2204)

#### ubuntu-2204:2023.04.2

[Linux Machine Executor - 2023 Q2 Update Edge + GA Release](https://discuss.circleci.com/t/linux-machine-executor-2023-q2-update-edge-ga-release/47680)

Node.js `18.15.0`
Docker  `20.10.24`

#### ubuntu-2204:2023.10.1

[Linux Machine Executor - 2023 Q4 Update](https://discuss.circleci.com/t/linux-machine-executor-2023-q4-update/49457)

Node.js `18.18.0`
Docker  `24.0.6`


### Docker release notes

- [Docker Engine 24.0 release notes](https://docs.docker.com/engine/release-notes/24.0/)
