### PR TITLE
chore(deps): update Firefox to 128

### DIFF
--- a/factory/.env
+++ b/factory/.env
@@ -26,7 +26,7 @@ CYPRESS_VERSION='13.13.0'
 EDGE_VERSION='126.0.2592.61-1'
 
 # Firefox versions: https://download-installer.cdn.mozilla.net/pub/firefox/releases/
-FIREFOX_VERSION='127.0.1'
+FIREFOX_VERSION='128.0'
 
 # Yarn versions: https://www.npmjs.com/package/yarn and
 # https://classic.yarnpkg.com/latest-version


### PR DESCRIPTION
## Issue

Firefox released versions:

- [127.0.2](https://www.mozilla.org/en-US/firefox/127.0.2/releasenotes/) on June 25, 2024
- [128.0](https://www.mozilla.org/en-US/firefox/128.0/releasenotes/) on July 9, 2024.

The repo is currently configured for Firefox [127.0.1](https://www.mozilla.org/en-US/firefox/127.0.1/releasenotes/), released on June 19, 2024.

https://github.com/cypress-io/cypress-docker-images/blob/2f47b54b7e22b1c5097d92ad8cbd70305075d39c/factory/.env#L28-L29

## Change

Update [factory/.env](https://github.com/cypress-io/cypress-docker-images/blob/master/factory/.env) to

```text
FIREFOX_VERSION='128.0'
```
