### PR TITLE
build: add version information to logs

### DIFF
--- a/circle.yml
+++ b/circle.yml
@@ -214,9 +214,14 @@ jobs:
             - halt-if-docker-image-exists:
                  target: << parameters.target >>
             - run:
-                name: building Docker image for target << parameters.target >>
+                name: Building Docker image for target << parameters.target >>
                 no_output_timeout: 20m # installing cypress on arm can take some time.
                 command: |
+                    echo Build environment is ...
+                    echo Node.js $(node --version)
+                    echo $(docker --version)
+                    echo $(docker buildx version)
+
                     ## see https://docs.docker.com/desktop/multi-arch/
                     docker run --privileged --rm tonistiigi/binfmt --install linux/amd64,linux/arm64
                     docker buildx create --name builder --use


### PR DESCRIPTION
## Issue

The [circle.yml](https://github.com/cypress-io/cypress-docker-images/blob/master/circle.yml) `push` job outputs no information about the versions of Node.js, Docker and Buildx used to build and push Cypress Docker images.

Documentation provided on the [CircleCI](https://circleci.com/developer) website regarding the content of the Ubuntu machine images is incomplete. Starting with [Docker Engine 23.0](https://docs.docker.com/engine/release-notes/23.0/) Buildx is distributed in a separate package `docker-buildx-plugin`. Since the CircleCI documentation does not list the configured version of Buildx, it is only possible to determine it by inspection of the machine image.

## Change

Add logging information for the versions of Node.js, Docker and Buildx used in the `push` job to the [circle.yml](https://github.com/cypress-io/cypress-docker-images/blob/master/circle.yml) workflow.

Providing this information enables better lookup of the correct release note and other documentation when attempting to resolve possible build issues or when modifying the build process.