### PR TITLE
chore: update circleci to ubuntu-2204:2024.01.1 machine image

### DIFF
--- a/circle.yml
+++ b/circle.yml
@@ -52,7 +52,7 @@ commands:
 jobs:
     check-factory-versions:
         machine:
-            image: ubuntu-2204:2023.10.1
+            image: ubuntu-2204:2024.01.1
         steps:
             - checkout
             - expand-env-file
@@ -147,7 +147,7 @@ jobs:
                   working_directory: factory/test-project
     check-node-override-version:
         machine:
-            image: ubuntu-2204:2023.10.1
+            image: ubuntu-2204:2024.01.1
         steps:
             - checkout
             - expand-env-file
@@ -173,7 +173,7 @@ jobs:
                   working_directory: factory/test-project
     test-image:
         machine:
-            image: ubuntu-2204:2023.10.1
+            image: ubuntu-2204:2024.01.1
         parameters:
             target:
                 type: string
@@ -203,7 +203,7 @@ jobs:
 
     push:
         machine:
-            image: ubuntu-2204:2023.10.1
+            image: ubuntu-2204:2024.01.1
         parameters:
             target:
                 type: string


### PR DESCRIPTION
- supports resolution of issue https://github.com/cypress-io/cypress-docker-images/issues/1095

## Issue

- Following the successful merge of PR https://github.com/cypress-io/cypress-docker-images/pull/1155, the [circle.yml](https://github.com/cypress-io/cypress-docker-images/blob/master/circle.yml) workflow is now using machine image [ubuntu-2204:2023.10.1](https://discuss.circleci.com/t/linux-machine-executor-2023-q4-update/49457) from [Circle CI Machine Images > ubuntu-2204](https://circleci.com/developer/machine/image/ubuntu-2204). The Docker Engine [24.0.6](https://docs.docker.com/engine/release-notes/24.0/#2406) is however a release from September 2023 and lags behind the latest version of Docker Engine which is currently at [27.0.3](https://docs.docker.com/engine/release-notes/27.0/).

## Change

Update the [circle.yml](https://github.com/cypress-io/cypress-docker-images/blob/master/circle.yml) workflow from [ubuntu-2204:2023.10.1](https://discuss.circleci.com/t/linux-machine-executor-2023-q4-update/49457) to the next higher version [ubuntu-2204:2024.01.1](https://discuss.circleci.com/t/linux-machine-executor-2024-q1-update/50198).

Updating to [ubuntu-2204:2024.01.1](https://discuss.circleci.com/t/linux-machine-executor-2024-q1-update/50198) updates the components as follows:

| Image tag                                                                                                           | Node.js   | Docker Engine                                                          | buildx                                                           | Status  |
| ------------------------------------------------------------------------------------------------------------------- | --------- | ---------------------------------------------------------------------- | ---------------------------------------------------------------- | ------- |
| [ubuntu-2204:2023.10.1](https://discuss.circleci.com/t/linux-machine-executor-2023-q4-update/49457) | `18.18.0` | [24.0.6](https://docs.docker.com/engine/release-notes/24.0/#2406) | [v0.11.2](https://github.com/docker/buildx/releases/tag/v0.11.2) | current  |
| [ubuntu-2204:2024.01.1](https://discuss.circleci.com/t/linux-machine-executor-2024-q1-update/50198) | `20.10.0` | [24.0.7](https://docs.docker.com/engine/release-notes/24.0/#2407) |  [v0.12.1](https://github.com/docker/buildx/releases/tag/v0.12.1)| future  |

This is a major version update from Node.js `18.x` to `20.x` and a major functional update from Docker Buildx [v0.11.x](https://github.com/docker/buildx/releases/tag/v0.11.0) to [v0.12.x](https://github.com/docker/buildx/releases/tag/v0.12.0).

Although the version of Docker Engine is hardly affected by this PR, it is an important step in the incremental update process towards the latest version of Docker Engine (currently `27.x`).