### PR TITLE
docs: add entrypoint info to included README

### DIFF
--- a/included/README.md
+++ b/included/README.md
@@ -25,6 +25,10 @@ for example:
 
  To avoid unplanned breaking changes, specify a fixed `<cypress version>`, `<node version>` & `<browser version>` combination tag or use the short-form `<cypress version>` tag, not the `latest` tag.  The `latest` tag is linked to the latest released `cypress/included` image and is updated without notice.
 
+## ENTRYPOINT
+
+When running a container from a `cypress/included` image, `cypress run` is executed, as defined by the [ENTRYPOINT](https://docs.docker.com/reference/dockerfile/#entrypoint) parameter of the image.
+
 ## Usage
 
 This image should be enough to run Cypress tests headlessly or in the interactive mode with a single Docker command like this:


### PR DESCRIPTION
## Issue

The [included/README.md](https://github.com/cypress-io/cypress-docker-images/blob/master/included/README.md) does not have the Docker image `ENTRYPOINT` described in the same way as `CMD` in [base/README.md](https://github.com/cypress-io/cypress-docker-images/blob/master/base/README.md#cmd) and in [browsers/README.md](https://github.com/cypress-io/cypress-docker-images/blob/master/browsers/README.md#cmd)

## Change

Add a sub-heading `ENTRYPOINT` to [included/README.md](https://github.com/cypress-io/cypress-docker-images/blob/master/included/README.md).
