### PR TITLE
ci: fix compose --progress plain build cli syntax

### DIFF
--- a/circle.yml
+++ b/circle.yml
@@ -59,12 +59,12 @@ jobs:
             - run:
                   name: building docker image
                   command: |
-                      docker compose build --progress plain factory
+                      docker compose --progress plain build factory
                   working_directory: factory
             - run:
                   name: build test image
                   command: |
-                    docker compose build --progress plain test-factory-all-included
+                    docker compose --progress plain build test-factory-all-included
                   working_directory: factory/test-project
             - run:
                   name: check node version
@@ -154,12 +154,12 @@ jobs:
             - run:
                   name: building docker image
                   command: |
-                      docker compose build --progress plain factory
+                      docker compose --progress plain build factory
                   working_directory: factory
             - run:
                   name: build test image
                   command: |
-                    docker compose build --progress plain test-factory-node-override
+                    docker compose --progress plain build test-factory-node-override
                   working_directory: factory/test-project
             - run:
                   name: check node version
@@ -191,13 +191,13 @@ jobs:
             - run:
                   name: building docker image
                   command: |
-                      if [ << parameters.target >> != factory ]; then docker compose build --progress plain factory; fi
-                      docker compose build --progress plain << parameters.target >>
+                      if [ << parameters.target >> != factory ]; then docker compose --progress plain build factory; fi
+                      docker compose --progress plain build << parameters.target >>
                   working_directory: factory
             - run:
                   name: test
                   command: |
-                    docker compose build --progress plain << parameters.test-target >>
+                    docker compose --progress plain build << parameters.test-target >>
                     docker compose run << parameters.test-target >>
                   working_directory: factory/test-project
 


### PR DESCRIPTION
## Issue

Multiple job logs from the [circle.yml](https://github.com/cypress-io/cypress-docker-images/blob/master/circle.yml) workflow show the warning:

> --progress is a global compose flag, better use `docker compose --progress xx build ...#0 building with "default" instance using docker driver

in response to a Docker CLI command such as:

> docker compose build --progress plain test-factory-cypress-included-electron

## Change

Move the `--progress` compose flag in each of the relevant instances in [circle.yml](https://github.com/cypress-io/cypress-docker-images/blob/master/circle.yml) as suggested by the warning. For example, change to:

> docker compose --progress plain build test-factory-cypress-included-electron