### PR TITLE
chore: update circleci to ubuntu-2204:2024.05.1 (latest) machine image

### DIFF
--- a/circle.yml
+++ b/circle.yml
@@ -52,7 +52,7 @@ commands:
 jobs:
     check-factory-versions:
         machine:
-            image: ubuntu-2204:2024.01.1
+            image: ubuntu-2204:2024.05.1
         steps:
             - checkout
             - expand-env-file
@@ -147,7 +147,7 @@ jobs:
                   working_directory: factory/test-project
     check-node-override-version:
         machine:
-            image: ubuntu-2204:2024.01.1
+            image: ubuntu-2204:2024.05.1
         steps:
             - checkout
             - expand-env-file
@@ -173,7 +173,7 @@ jobs:
                   working_directory: factory/test-project
     test-image:
         machine:
-            image: ubuntu-2204:2024.01.1
+            image: ubuntu-2204:2024.05.1
         parameters:
             target:
                 type: string
@@ -203,7 +203,7 @@ jobs:
 
     push:
         machine:
-            image: ubuntu-2204:2024.01.1
+            image: ubuntu-2204:2024.05.1
         parameters:
             target:
                 type: string


### PR DESCRIPTION
- closes https://github.com/cypress-io/cypress-docker-images/issues/1095

## Issue

- Following the successful merge of PR https://github.com/cypress-io/cypress-docker-images/pull/1160, the [circle.yml](https://github.com/cypress-io/cypress-docker-images/blob/master/circle.yml) workflow is now using machine image [ubuntu-2204:2024.01.1](https://discuss.circleci.com/t/linux-machine-executor-2024-q1-update/50198) from [Circle CI Machine Images > ubuntu-2204](https://circleci.com/developer/machine/image/ubuntu-2204). The Docker Engine version [24.0.7](https://docs.docker.com/engine/release-notes/24.0/#2407) was however already released 9 months ago in October 2023. The latest CircleCI Ubuntu machine image offers Docker Engine [26.0.2](https://docs.docker.com/engine/release-notes/26.0/#2602).

## Change

Update the [circle.yml](https://github.com/cypress-io/cypress-docker-images/blob/master/circle.yml) workflow from [ubuntu-2204:2024.01.1](https://discuss.circleci.com/t/linux-machine-executor-2024-q1-update/50198) to the latest version [ubuntu-2204:2024.05.1](https://discuss.circleci.com/t/new-ubuntu-24-04-linux-machine-executor-image/51018).

Moving to [ubuntu-2204:2024.05.1](https://discuss.circleci.com/t/new-ubuntu-24-04-linux-machine-executor-image/51018) updates the components as follows:

| Image tag                                                                                                           | Node.js   | Docker Engine                                                          | buildx                                                           | Status  |
| ------------------------------------------------------------------------------------------------------------------- | --------- | ---------------------------------------------------------------------- | ---------------------------------------------------------------- | ------- |
| [ubuntu-2204:2024.01.1](https://discuss.circleci.com/t/linux-machine-executor-2024-q1-update/50198) | `20.10.0` | [24.0.7](https://docs.docker.com/engine/release-notes/24.0/#2407) |  [v0.12.1](https://github.com/docker/buildx/releases/tag/v0.12.1)| current  |
| [ubuntu-2204:2024.05.1](https://discuss.circleci.com/t/new-ubuntu-24-04-linux-machine-executor-image/51018) | `20.12.2` | [26.0.2](https://docs.docker.com/engine/release-notes/26.0/#2602) |  [v0.14.0](https://github.com/docker/buildx/releases/tag/v0.14.0)| current  |

This is a minor version update for Node.js `20.x` and a major functional update from Docker Buildx [v0.12.x](https://github.com/docker/buildx/releases/tag/v0.12.0), through [v0.13.x](https://github.com/docker/buildx/releases/tag/v0.13.0) to [v0.14.x](https://github.com/docker/buildx/releases/tag/v0.14.0). Based on a review of the release notes, there is no impact expected for the Cypress Docker image build process.