### PR TITLE
test: bump args-defined browser versions

### DIFF
--- a/factory/test-project/argsDefined.Dockerfile
+++ b/factory/test-project/argsDefined.Dockerfile
@@ -1,7 +1,7 @@
-# Args are defined in the dockerfile before the FROM command.
-ARG CHROME_VERSION='107.0.5304.121-1'
-ARG EDGE_VERSION='100.0.1185.29-1'
-ARG FIREFOX_VERSION='107.0'
+# Args are defined in the Dockerfile before the FROM command.
+ARG CHROME_VERSION='126.0.6478.114-1'
+ARG EDGE_VERSION='126.0.2592.61-1'
+ARG FIREFOX_VERSION='128.0'
 
 ARG BASE_TEST_IMAGE
 

--- a/factory/test-project/docker-compose.yml
+++ b/factory/test-project/docker-compose.yml
@@ -3,7 +3,6 @@
 services:
 
   args-defined:
-    user: node
     build:
       dockerfile: argsDefined.Dockerfile
       context: .


### PR DESCRIPTION
## Issue

The `args-defined` test, defined in [factory/test-project/docker-compose.yml](https://github.com/cypress-io/cypress-docker-images/blob/master/factory/test-project/docker-compose.yml), fails because Google Chrome version `107.0.5304.121-1`, released on Nov 24, 2022, is no longer available for download. Google Chrome purges older browser versions.

This test is not executed in CI. It can however be executed manually.

[factory/test-project/argsDefined.Dockerfile](https://github.com/cypress-io/cypress-docker-images/blob/master/factory/test-project/argsDefined.Dockerfile) currently uses

https://github.com/cypress-io/cypress-docker-images/blob/99c6a03600e9d78fdef710cad66cecdee51bb9d6/factory/test-project/argsDefined.Dockerfile#L2-L4

## Change

- Browser versions defined in [factory/test-project/argsDefined.Dockerfile](https://github.com/cypress-io/cypress-docker-images/blob/master/factory/test-project/argsDefined.Dockerfile) are updated to match the versions in [factory/.env](https://github.com/cypress-io/cypress-docker-images/blob/master/factory/.env)

```Dockerfile
ARG CHROME_VERSION='126.0.6478.114-1'
ARG EDGE_VERSION='126.0.2592.61-1'
ARG FIREFOX_VERSION='128.0'
```

- Modify [factory/test-project/docker-compose.yml](https://github.com/cypress-io/cypress-docker-images/blob/master/factory/test-project/docker-compose.yml) `args-defined` test to use default `root` user instead of non-root `node` to avoid permissions issues. Non-root users are tested in other tests.

## Verification

```shell
cd factory
docker compose build factory
cd test-project
set -a && . ../.env && set +a
docker compose run args-defined
```

The image should build and the Cypress tests should be successful.
