### PR TITLE
update factory for cypress 13.13.1

### DIFF
--- a/factory/.env
+++ b/factory/.env
@@ -17,13 +17,13 @@ NODE_VERSION="${FACTORY_DEFAULT_NODE_VERSION}"
 FACTORY_VERSION='4.0.4'
 
 # Chrome versions: https://www.ubuntuupdates.org/package/google_chrome/stable/main/base/google-chrome-stable
-CHROME_VERSION='126.0.6478.114-1'
+CHROME_VERSION='126.0.6478.126-1'
 
 # Cypress versions: https://www.npmjs.com/package/cypress
-CYPRESS_VERSION='13.13.0'
+CYPRESS_VERSION='13.13.1'
 
 # Edge versions: https://packages.microsoft.com/repos/edge/pool/main/m/microsoft-edge-stable/
-EDGE_VERSION='126.0.2592.61-1'
+EDGE_VERSION='126.0.2592.102-1'
 
 # Firefox versions: https://download-installer.cdn.mozilla.net/pub/firefox/releases/
 FIREFOX_VERSION='128.0'


### PR DESCRIPTION
Updates the factory to cypress 13.13.1 and updates browsers to latest available