### PR TITLE
docs: add user parameter info to main readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -70,6 +70,14 @@ Don't see the exact combination of Cypress, Node.js and browser versions you nee
 
 - See the example workflow [.github/workflows//example-cypress-github-action.yml](./.github/workflows/example-cypress-github-action.yml) for Continuous Integration (CI) using [cypress&#8209;io/github&#8209;action](https://github.com/cypress-io/github-action) together with Cypress Docker images.
 
+## User
+
+By default, Docker containers run as `root` user. [cypress/base](./base/README.md), [cypress/browsers](./browsers/README.md) and [cypress/included](./included/README.md) images provide the additional non-root user `node`.
+
+If you run a Cypress Docker image locally as container with a non-root user, refer to the [Docker documentation](https://docs.docker.com/), such as [Docker Desktop FAQs](https://docs.docker.com/desktop/), for information on file-sharing between your host system and Docker. File-sharing details differ depending on the host operating system running Docker.
+
+If you specify a Cypress Docker image in a [GitHub Actions job](https://docs.github.com/en/actions/using-jobs/running-jobs-in-a-container) `container` workflow section, add `options: --user 1001` to the workflow to avoid permissions issues.
+
 ## Known problems
 
 ## Firefox not found


### PR DESCRIPTION
## Issue

Currently only the [included/README](https://github.com/cypress-io/cypress-docker-images/blob/master/included/README.md) refers to the `user` parameter to run a Cypress Docker image as container.

Older Docker images fail to run in GitHub Actions if `options: --user 1001` is not applied. Since it is not mandatory to use the Cypress JavaScript GitHub Action, there is a gap in the documentation when a GitHub Actions workflow is used **without** the Cypress JavaScript GitHub Action.

## Change

Add information about the `user` parameter information to the main [README](https://github.com/cypress-io/cypress-docker-images/blob/master/README.md) document. Mention the non-root `node` user added to `base`, `browsers` and `included` images.

Include links to Docker documentation.

Add the instruction `options: --user 1001` for general GitHub Actions usage.
