### PR TITLE
chore(deps): update prettier to 3.3.3

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10,7 +10,7 @@
       "license": "MIT",
       "devDependencies": {
         "markdown-link-check": "3.12.2",
-        "prettier": "2.5.1"
+        "prettier": "3.3.3"
       },
       "engines": {
         "node": ">=12"
@@ -661,15 +661,19 @@
       }
     },
     "node_modules/prettier": {
-      "version": "2.5.1",
-      "resolved": "https://registry.npmjs.org/prettier/-/prettier-2.5.1.tgz",
-      "integrity": "sha512-vBZcPRUR5MZJwoyi3ZoyQlc1rXeEck8KgeC9AwwOn+exuxLxq5toTRDTSaVrXHxelDMHy9zlicw8u66yxoSUFg==",
+      "version": "3.3.3",
+      "resolved": "https://registry.npmjs.org/prettier/-/prettier-3.3.3.tgz",
+      "integrity": "sha512-i2tDNA0O5IrMO757lfrdQZCc2jPNDVntV0m/+4whiDfWaTKfMNgR7Qz0NAeGz/nRqF4m5/6CLzbP4/liHt12Ew==",
       "dev": true,
+      "license": "MIT",
       "bin": {
-        "prettier": "bin-prettier.js"
+        "prettier": "bin/prettier.cjs"
       },
       "engines": {
-        "node": ">=10.13.0"
+        "node": ">=14"
+      },
+      "funding": {
+        "url": "https://github.com/prettier/prettier?sponsor=1"
       }
     },
     "node_modules/progress": {

--- a/package.json
+++ b/package.json
@@ -26,6 +26,6 @@
   "homepage": "https://github.com/cypress-io/cypress-docker-images#readme",
   "devDependencies": {
     "markdown-link-check": "3.12.2",
-    "prettier": "2.5.1"
+    "prettier": "3.3.3"
   }
 }


### PR DESCRIPTION
## Issue

The repo is currently configured for the older `pretter@2.5.1` release. `prettier@3.0.0` was already released about a year ago, and the current version is `prettier@3.3.3`. Prettier release summaries are posted to their [blog](https://prettier.io/blog/).

Prettier is currently not used in CI, however it is available if needed for format checks / reformatting.

## Change

Update prettier from `2.5.1` to [3.3.3](https://github.com/prettier/prettier/releases/tag/3.3.3).
