### PR TITLE
docs: re-format contributing

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -24,14 +24,14 @@ Releases to these public repositories are reserved for configurations that cover
 
 ### Building locally
 
-We use docker compose to build the factory locally.
+We use `docker compose` to build the `factory` image locally.
 
 ```bash
 cd factory
 docker compose build factory
 ```
 
-With the factory image built, you can now build the other included images
+With the `factory` image built, you can now build other images
 
 ```bash
 # This builds the 'included' image specified in the docker-compose file.
@@ -41,7 +41,7 @@ docker compose build included
 docker compose build
 ```
 
-Or you can then run tests in the test-project
+Or you can then run tests in the `test-project`
 
 ```bash
 cd test-project
@@ -71,7 +71,7 @@ Once the PR is merged into the `master` branch, the corresponding images will be
 
 ##### Older versions
 
->Note: Assistance from a member of the Cypress org is required for this process
+> Note: Assistance from a member of the Cypress org is required for this process
 
 In general, [factory/.env](./factory/.env) in the `master` branch should contain the latest versions we officially support. If you need to release an older version, do not modify contents in the `master` branch. Instead, carry out the following steps:
 
@@ -84,34 +84,34 @@ In general, [factory/.env](./factory/.env) in the `master` branch should contain
 
 #### Manual
 
->Note: This requires being a member of the Cypress org
+> Note: This requires being a member of the Cypress org
 
-`base-internal` and `browsers-internal` images are not automatically published after changes are merged. They require manual publishing to dockerhub. To manual publish:
+`base-internal` and `browsers-internal` images are not automatically published after changes are merged. They require manual publishing to Docker Hub. To manual publish:
 
 1. Generate the corresponding files within the `base-internal` and/or `browsers-internal` directories that you want to generate the image from.
 2. Log into Docker Desktop using `cypressdockerpublisher` credentials.
-3. Follow the instructions to build the image from within the generated Dockerfile within the appropriate directory in order to build the image locally.
+3. Follow the instructions to build the image from within the generated `Dockerfile` within the appropriate directory in order to build the image locally.
 4. Select 'Push to Hub' on the generate image within Docker Desktop.
-5. Check dockerhub to ensure the new image it published and test that it works.
+5. Check Docker Hub to ensure the new image is published and test that it works.
 
 ![](https://github.com/cypress-io/cypress/assets/1271364/85507060-acc3-48b5-bc16-4160c4620e1e)
 
-#### To forward X11 from inside a docker container to a host running macOS
+#### To forward X11 from inside a Docker container to a host running macOS
 
-If you need to test that the image works with Cypress, you can follow these instructions if on a MacOS machine, which might prove helpful when debugging image dependencies:
+If you need to test that the image works with Cypress, you can follow these instructions if on a macOS machine, which might prove helpful when debugging image dependencies:
 
 1. Install XQuartz: https://www.xquartz.org/
-2. Launch XQuartz.  Under the XQuartz menu, select Settings
+2. Launch XQuartz. Under the XQuartz menu, select Settings
 3. Go to the security tab and ensure "Allow connections from network clients" is checked.
 4. From the XQuarts terminal, run `xhost + ${hostname}` to allow connections to the macOS host
-5. From the XQuarts terminal, Setup a HOSTNAME env var `` export HOSTNAME="host.docker.internal:0" ``
-6. From the XQuarts terminal, run your docker image like such:
+5. From the XQuarts terminal, set up a `HOSTNAME` env var `export HOSTNAME="host.docker.internal:0"`
+6. From the XQuarts terminal, run your Docker image like such:
 
 ```bash
 docker run --rm -it -e DISPLAY="host.docker.internal:0" -v /tmp/.X11-unix:/tmp/.X11-unix --entrypoint bash <YOUR_IMAGE_TAG>
- ```
+```
 
- When executing `npx cypress open` from the docker container, the display should now be visible!
+When executing `npx cypress open` from the Docker container, the display should now be visible!
 
 ## Releasing a new factory version
 
@@ -156,7 +156,7 @@ Whenever upgrading or installing packages with `apt-get`, use the `--no-install-
 
 Per the Docker documentation [Building best practices](https://docs.docker.com/build/building/best-practices/#apt-get), you don't need to add `apt-get clean`, since the Docker images implicitly run that command after every `apt-get` execution.
 
->Official Debian and Ubuntu images automatically run `apt-get clean`, so explicit invocation is not required.
+> Official Debian and Ubuntu images automatically run `apt-get clean`, so explicit invocation is not required.
 
 ## Tool versions
 
@@ -176,7 +176,7 @@ RUN echo  " node version:    $(node -v) \n" \
 
 As of Cypress 10.2.0, `arm64` and `x64` are both supported.
 
-In CI, the images are built and tested in real `arm64` and `x64` architectures. Then, via `binfmt` and `docker buildx`, we build x64 and cross-build arm64 from the same machine, and then publish that image to Docker Hub. The `docker buildx` step runs a second time to push to Amazon ECR:
+In CI, the images are built and tested in real `arm64` and `x64` architectures. Then, via `binfmt` and `docker buildx`, we build `x64` and cross-build `arm64` from the same machine, and then publish that image to Docker Hub. The `docker buildx` step runs a second time to push to Amazon ECR:
 
 <!-- diagram generated w/ https://asciiflow.com/ -->
 
@@ -211,35 +211,37 @@ These steps assume you have Docker Hub and ECR credentials.
 When following these steps, you may get into a state where you have cached copies of images causing wrong behavior. If this happens, delete the offending images, or `docker system prune --all` to be safe.
 
 1. Ensure that the entire `FROM` chain of this image has a `linux/arm64` version, and follow this guide for those `FROM` images if necessary. For example, generating an `arm64` `cypress/browsers:node1.2.3-chrome100` would require an `arm64` `cypress/base:1.2.3` image.
-2. Re-run the `yarn add:<type>:image` command to update the Dockerfile folder with any changes in the build scripts. The correct command is at the top of every `build.sh` file in a comment. Verify that this has replaced the existing image and not caused any unexpected changes, like generating in the wrong directory.
-3. `cd` into the Dockerfile folder.
+2. Re-run the `yarn add:<type>:image` command to update the `Dockerfile` folder with any changes in the build scripts. The correct command is at the top of every `build.sh` file in a comment. Verify that this has replaced the existing image and not caused any unexpected changes, like generating in the wrong directory.
+3. `cd` into the `Dockerfile` folder.
 4. Build the image and tag it with `tmp`:
-    ```shell
-    docker build -t cypress/<image>:tmp --platform linux/arm64 .
-    ```
+   ```shell
+   docker build -t cypress/<image>:tmp --platform linux/arm64 .
+   ```
 5. Manually validate that the image works as expected and is really in `arm64`:
-    ```shell
-    docker run -it cypress/<image>:tmp node -p "process.arch" # expect arm64
-    ```
+   ```shell
+   docker run -it cypress/<image>:tmp node -p "process.arch" # expect arm64
+   ```
 6. Push the `tmp` tag, and record the digest string (`sha256:hexadecimal...`). This is your `arm64` digest string.
-    ```shell
-    docker push cypress/<image>:tmp
-    # example output:
-    # [...]
-    # tmp: digest: sha256:6c38510771b756153b6f4d54c3ef9185006c1659f725e79d4999cd6304720353 size: 3659
-    ```
+   ```shell
+   docker push cypress/<image>:tmp
+   # example output:
+   # [...]
+   # tmp: digest: sha256:6c38510771b756153b6f4d54c3ef9185006c1659f725e79d4999cd6304720353 size: 3659
+   ```
 7. Find the current `amd64` digest string, either by using Docker Hub to browse tags, or `docker image inspect cypress/...`
 8. Create a combined manifest using the existing name:
-    ```shell
-    docker manifest create cypress/<image>:<tag> \
-      cypress/<image>:tmp@sha256:rest-of-arm64-digest \
-      cypress/<image>:<tag>@sha256:rest-of-amd64-digest
 
-    # example:
-    # docker manifest create cypress/included:10.3.0 \
-    #  cypress/included:tmp@sha256:6c38510771b756153b6f4d54c3ef9185006c1659f725e79d4999cd6304720353 \
-    #  cypress/included:10.3.0@sha256:942468cdb722c408607093f60eeb1b4ff098a384f9123bf2ded36f55d4c96352
-    ```
+   ```shell
+   docker manifest create cypress/<image>:<tag> \
+     cypress/<image>:tmp@sha256:rest-of-arm64-digest \
+     cypress/<image>:<tag>@sha256:rest-of-amd64-digest
+
+   # example:
+   # docker manifest create cypress/included:10.3.0 \
+   #  cypress/included:tmp@sha256:6c38510771b756153b6f4d54c3ef9185006c1659f725e79d4999cd6304720353 \
+   #  cypress/included:10.3.0@sha256:942468cdb722c408607093f60eeb1b4ff098a384f9123bf2ded36f55d4c96352
+   ```
+
 9. Run `docker manifest push cypress/<image>:<tag>` to push the completed manifest to Docker Hub.
 10. Validate that the pushed image is correct.
 11. To publish to ECR, use `docker login` to switch accounts and follow the below, slightly modified, steps - you don't need to rebuild the `linux/arm64` version. ECR Digest strings may differ from the Hub Digest strings since they are built separately.


### PR DESCRIPTION
## Issue

The document [CONTRIBUTING.md](https://github.com/cypress-io/cypress-docker-images/blob/master/CONTRIBUTING.md) contains some minor formatting and other text issues:

- Docker terms "Docker Hub" and "Docker" not always written according to their Trademark
- Prettier suggests formatting changes

## Change

- Write "Docker Hub" and "Docker" correctly
- Format literal references
- Format according to Prettier rules
- Correct typos & grammar
