### PR TITLE
docs: minor re-format readme files

### DIFF
--- a/base/README.md
+++ b/base/README.md
@@ -16,7 +16,7 @@ for example:
 - `cypress/base:20.14.0`
 - `cypress/base:latest`
 
-To avoid unplanned breaking changes, specify a fixed `<node version>` tag, not the `latest` tag.  The `latest` tag is linked to the latest released `cypress/base` image and is updated without notice.
+To avoid unplanned breaking changes, specify a fixed `<node version>` tag, not the `latest` tag. The `latest` tag is linked to the latest released `cypress/base` image and is updated without notice.
 
 ## CMD
 

--- a/browsers/README.md
+++ b/browsers/README.md
@@ -21,7 +21,7 @@ for example:
 - `cypress/browsers:node-20.14.0-chrome-125.0.6422.141-1-ff-126.0.1-edge-125.0.2535.85-1`
 - `cypress/browsers:latest`
 
-To avoid unplanned breaking changes, specify a fixed `<node version>` & `<browser version>` combination tag, not the `latest` tag.  The `latest` tag is linked to the latest released `cypress/browsers` image and is updated without notice.
+To avoid unplanned breaking changes, specify a fixed `<node version>` & `<browser version>` combination tag, not the `latest` tag. The `latest` tag is linked to the latest released `cypress/browsers` image and is updated without notice.
 
 ## CMD
 

--- a/factory/README.md
+++ b/factory/README.md
@@ -2,12 +2,12 @@
 
 [`cypress/factory`](https://hub.docker.com/r/cypress/factory) is a Docker image that can be used with [`ARG`](https://docs.docker.com/reference/dockerfile/#arg) instructions in a custom-built [`Dockerfile`](https://docs.docker.com/reference/dockerfile/) to generate a new Docker image with specific versions of:
 
-* Node.js
-* Yarn v1 Classic
-* Chrome
-* Firefox
-* Edge
-* Cypress
+- Node.js
+- Yarn v1 Classic
+- Chrome
+- Firefox
+- Edge
+- Cypress
 
 ## Tags
 
@@ -21,16 +21,16 @@ for example:
 - `cypress/factory:4.0.2`
 - `cypress/factory:latest`
 
- To avoid unplanned breaking changes, specify a fixed `<factory version>` tag, not the `latest` tag.  The `latest` tag is linked to the latest released `cypress/factory` image and is updated without notice.
+To avoid unplanned breaking changes, specify a fixed `<factory version>` tag, not the `latest` tag. The `latest` tag is linked to the latest released `cypress/factory` image and is updated without notice.
 
 ## Benefits
 
-* Freedom to choose which versions to test against.
-* No need to wait on an official release to test the latest version of a browser.
-* Smaller Docker image sizes especially when not including unused browsers.
-* Easily test multiple browser versions.
-* Reduced maintenance and pull requests in this repo.
-* Ability for Cypress to offer more variations of Docker images at low cost.
+- Freedom to choose which versions to test against.
+- No need to wait on an official release to test the latest version of a browser.
+- Smaller Docker image sizes especially when not including unused browsers.
+- Easily test multiple browser versions.
+- Reduced maintenance and pull requests in this repo.
+- Ability for Cypress to offer more variations of Docker images at low cost.
 
 ## API
 

--- a/included/README.md
+++ b/included/README.md
@@ -14,7 +14,7 @@
 [cypress/included](https://hub.docker.com/r/cypress/included/tags) images on [Cypress on Docker Hub](https://hub.docker.com/u/cypress) use image tags in the form:
 
 - `<cypress version>`-node-`<node version>`-chrome-`<chrome version>`-ff-`<firefox version>`-edge-`<edge version>`-
-- `<cypress version>`<br>This is a short-form convenience tag,  equivalent to the above full tag.
+- `<cypress version>`<br>This is a short-form convenience tag, equivalent to the above full tag.
 - `latest`
 
 for example:
@@ -23,7 +23,7 @@ for example:
 - `cypress/included:13.11.0`
 - `cypress/included:latest`
 
- To avoid unplanned breaking changes, specify a fixed `<cypress version>`, `<node version>` & `<browser version>` combination tag or use the short-form `<cypress version>` tag, not the `latest` tag.  The `latest` tag is linked to the latest released `cypress/included` image and is updated without notice.
+To avoid unplanned breaking changes, specify a fixed `<cypress version>`, `<node version>` & `<browser version>` combination tag or use the short-form `<cypress version>` tag, not the `latest` tag. The `latest` tag is linked to the latest released `cypress/included` image and is updated without notice.
 
 ## ENTRYPOINT
 


### PR DESCRIPTION
## Issue

Prettier recommends whitespace changes for the main README files:

- [base/README.md](https://github.com/cypress-io/cypress-docker-images/blob/master/base/README.md)
- [browsers/README.md](https://github.com/cypress-io/cypress-docker-images/blob/master/browsers/README.md)
- [included/README.md](https://github.com/cypress-io/cypress-docker-images/blob/master/included/README.md)
- [factory/README.md](https://github.com/cypress-io/cypress-docker-images/blob/master/factory/README.md)

## Change

Apply the recommended whitespace changes from Prettier for the above README files.