### PR TITLE
chore: re-format html sources

### DIFF
--- a/examples/basic-mini/index.html
+++ b/examples/basic-mini/index.html
@@ -1,16 +1,14 @@
-<!DOCTYPE html>
+<!doctype html>
 <html lang="en">
+  <head>
+    <meta charset="utf-8" />
+    <title>Test for Cypress Docker images</title>
+  </head>
 
-<head>
-  <meta charset="utf-8">
-  <title>Test for Cypress Docker images</title>
-</head>
-
-<body>
-  <h1>Purpose</h1>
-  <p>This page is used for demonstrating Cypress Docker images.</p>
-  <h2>Test heading</h2>
-  <p>This is a test page</p>
-</body>
-
+  <body>
+    <h1>Purpose</h1>
+    <p>This page is used for demonstrating Cypress Docker images.</p>
+    <h2>Test heading</h2>
+    <p>This is a test page</p>
+  </body>
 </html>

--- a/examples/basic/index.html
+++ b/examples/basic/index.html
@@ -1,16 +1,14 @@
-<!DOCTYPE html>
+<!doctype html>
 <html lang="en">
+  <head>
+    <meta charset="utf-8" />
+    <title>Test for Cypress Docker images</title>
+  </head>
 
-<head>
-  <meta charset="utf-8">
-  <title>Test for Cypress Docker images</title>
-</head>
-
-<body>
-  <h1>Purpose</h1>
-  <p>This page is used for demonstrating Cypress Docker images.</p>
-  <h2>Test heading</h2>
-  <p>This is a test page</p>
-</body>
-
+  <body>
+    <h1>Purpose</h1>
+    <p>This page is used for demonstrating Cypress Docker images.</p>
+    <h2>Test heading</h2>
+    <p>This is a test page</p>
+  </body>
 </html>

--- a/examples/included-as-non-root/src/index.html
+++ b/examples/included-as-non-root/src/index.html
@@ -1,16 +1,14 @@
-<!DOCTYPE html>
+<!doctype html>
 <html lang="en">
+  <head>
+    <meta charset="utf-8" />
+    <title>Test for Cypress Docker images</title>
+  </head>
 
-<head>
-  <meta charset="utf-8">
-  <title>Test for Cypress Docker images</title>
-</head>
-
-<body>
-  <h1>Purpose</h1>
-  <p>This page is used for demonstrating Cypress Docker images.</p>
-  <h2>Test heading</h2>
-  <p>This is a test page</p>
-</body>
-
+  <body>
+    <h1>Purpose</h1>
+    <p>This page is used for demonstrating Cypress Docker images.</p>
+    <h2>Test heading</h2>
+    <p>This is a test page</p>
+  </body>
 </html>


### PR DESCRIPTION
## Issue

Prettier recommends minor changes for the example html files:

- [examples/basic-mini/index.html](https://github.com/cypress-io/cypress-docker-images/blob/master/examples/basic-mini/index.html)
- [examples/basic/index.html](https://github.com/cypress-io/cypress-docker-images/blob/master/examples/basic/index.html)
- [examples/included-as-non-root/src/index.html](https://github.com/cypress-io/cypress-docker-images/blob/master/examples/included-as-non-root/src/index.html)

## Change

- Apply the recommended changes from Prettier for the above `*.html` files.

These are source changes only. The pages displayed in a web browser are unchanged.