### PR TITLE
chore: remove factory/test-project from prettier checks

### DIFF
--- a/.prettierignore
+++ b/.prettierignore
@@ -3,3 +3,4 @@
 /base
 /browsers
 /included
+/factory/test-project


### PR DESCRIPTION
## Issue

Prettier suggests reformatting the Cypress [factory/test-project](https://github.com/cypress-io/cypress-docker-images/tree/master/factory/test-project). This project is however set up using pre-defined Cypress scaffolding steps (see [README.MD](https://github.com/cypress-io/cypress-docker-images/blob/master/factory/test-project/README.MD)) and most files have been through an ESLint formatting check performed in the [cypress-io/cypress-example-kitchensink](https://github.com/cypress-io/cypress-example-kitchensink). Prettier and ESLint do not agree in their preferred formatting.

## Change

Add `/factory/test-project` to [.prettierignore](https://github.com/cypress-io/cypress-docker-images/blob/master/.prettierignore) to disable Prettier checking of imported test project files.