### PR TITLE
chore(deps): update Chrome to 127.0.6533.72-1

### DIFF
--- a/factory/.env
+++ b/factory/.env
@@ -17,7 +17,7 @@ NODE_VERSION="${FACTORY_DEFAULT_NODE_VERSION}"
 FACTORY_VERSION='4.0.4'
 
 # Chrome versions: https://www.ubuntuupdates.org/package/google_chrome/stable/main/base/google-chrome-stable
-CHROME_VERSION='126.0.6478.126-1'
+CHROME_VERSION='127.0.6533.72-1'
 
 # Cypress versions: https://www.npmjs.com/package/cypress
 CYPRESS_VERSION='13.13.1'


### PR DESCRIPTION
## Issue

Google released a new major Chrome Desktop version `127` on July 23, 2024:

- [127.0.6533.72-1](https://chromereleases.googleblog.com/2024/07/stable-channel-update-for-desktop_23.html) for Linux 

The Cypress Docker images repo is currently configured for Chrome [126.0.6478.126-1](https://chromereleases.googleblog.com/2024/06/stable-channel-update-for-desktop_24.html), released on June 24, 2024.

https://github.com/cypress-io/cypress-docker-images/blob/ce3385940051f8114b39654da9ddc73051dc1087/factory/.env#L19-L20

## Change

Update [factory/.env](https://github.com/cypress-io/cypress-docker-images/blob/master/factory/.env) to

```text
CHROME_VERSION='127.0.6533.72-1'
```

## References

- https://www.ubuntuupdates.org/package/google_chrome/stable/main/base/google-chrome-stable
- https://chromereleases.googleblog.com/