### PR TITLE
chore: create centos-7 image 

### DIFF
--- a/base-internal/releases/centos-7/Dockerfile
+++ b/base-internal/releases/centos-7/Dockerfile
@@ -1,0 +1,31 @@
+# build it with command
+#   docker build -t cypress/centos7-builder . --platform linux/amd64 .
+#
+FROM centos:7
+
+# Update repo URLs to point to vault.centos.org
+RUN     for repo in /etc/yum.repos.d/*.repo; do \
+            sed -i 's|mirrorlist=|#mirrorlist=|g' $repo; \
+            sed -i 's|#baseurl=http://mirror.centos.org|baseurl=http://vault.centos.org|g' $repo; \
+            sed -i 's|http://mirror.centos.org|http://vault.centos.org|g' $repo; \
+        done && yum clean all
+
+# Install centos-release-scl to get the SCL repositories
+RUN     yum -y install centos-release-scl
+
+# Update repo URLs to point to vault.centos.org again
+RUN     for repo in /etc/yum.repos.d/CentOS-SCLo-scl*.repo; do \
+            sed -i 's|mirrorlist=|#mirrorlist=|g' $repo; \
+            sed -i 's|# baseurl=http://mirror.centos.org|baseurl=http://vault.centos.org|g' $repo; \
+            sed -i 's|#baseurl=http://mirror.centos.org|baseurl=http://vault.centos.org|g' $repo; \
+            sed -i 's|http://mirror.centos.org|http://vault.centos.org|g' $repo; \
+        done && yum clean all
+
+# Install dependencies for building the addon and setting devtoolset-8 as the default compiler
+RUN yum -y install curl python3 make atk-devel atk java-atk-wrapper at-spi2-atk gtk3 libXt libdrm mesa-libgbm Xvfb devtoolset-8-gcc devtoolset-8-gcc-c++
+RUN echo >> /etc/profile.d/devtoolset-8.sh 'source scl_source enable devtoolset-8'
+RUN curl -o- https://raw.githubusercontent.com/nvm-sh/nvm/v0.39.5/install.sh | bash
+RUN echo >> /etc/profile.d/nvm.sh 'source ~/.nvm/nvm.sh'
+# Node 16 is the most recent version that supports CentOS 7. We only need it to call the
+# build script for lib/addon, so there should be minimal risk of security issues.
+RUN source ~/.nvm/nvm.sh && nvm install 16.20.2 && npm install -g yarn

--- a/base-internal/releases/centos-7/README.md
+++ b/base-internal/releases/centos-7/README.md
@@ -1,0 +1,5 @@
+# cypress/centos7-builder
+
+A CentOS 7 image used to build binaries against an older version of glibc (`2.17`).
+
+NOTE: This image is intended for internal use with https://github.com/cypress-io/cypress.

--- a/base-internal/releases/centos-7/build.sh
+++ b/base-internal/releases/centos-7/build.sh
@@ -1,0 +1,6 @@
+set e+x
+
+LOCAL_NAME=cypress/centos7-builder
+
+echo "Building $LOCAL_NAME"
+docker build -t $LOCAL_NAME --platform linux/amd64 .


### PR DESCRIPTION
to host in dockerhub to build glibc related binaries. We are building a centos7 image to host in dockerhub mainly due to us needing to rebuild better-sqlite3 against an older version of glibc. Since centos7 is EOLed, we need to point the mirrors in the image to the centos vault. Building and storing this image prevents the need to call out to these mirrors and rebuild the image