### PR TITLE
chore: add cypress 13.13.2 to docker factory and bump shipped browsers

### DIFF
--- a/factory/.env
+++ b/factory/.env
@@ -7,26 +7,26 @@
 BASE_IMAGE='debian:12.6-slim'
 
 # Node Versions: https://nodejs.org/en/download/releases/
-FACTORY_DEFAULT_NODE_VERSION='20.15.1'
+FACTORY_DEFAULT_NODE_VERSION='20.16.0'
 
 # Node Versions: https://nodejs.org/en/download/releases/
 NODE_VERSION="${FACTORY_DEFAULT_NODE_VERSION}"
 
 # Update the FACTORY_VERSION to deploy cypress/factory if you make changes to
 # BASE_IMAGE, FACTORY_DEFAULT_NODE_VERSION, YARN_VERSION, factory.Dockerfile or installScripts
-FACTORY_VERSION='4.0.4'
+FACTORY_VERSION='4.0.5'
 
 # Chrome versions: https://www.ubuntuupdates.org/package/google_chrome/stable/main/base/google-chrome-stable
-CHROME_VERSION='127.0.6533.72-1'
+CHROME_VERSION='127.0.6533.88-1'
 
 # Cypress versions: https://www.npmjs.com/package/cypress
-CYPRESS_VERSION='13.13.1'
+CYPRESS_VERSION='13.13.2'
 
 # Edge versions: https://packages.microsoft.com/repos/edge/pool/main/m/microsoft-edge-stable/
-EDGE_VERSION='126.0.2592.102-1'
+EDGE_VERSION='127.0.2651.74-1'
 
 # Firefox versions: https://download-installer.cdn.mozilla.net/pub/firefox/releases/
-FIREFOX_VERSION='128.0'
+FIREFOX_VERSION='128.0.3'
 
 # Yarn versions: https://www.npmjs.com/package/yarn and
 # https://classic.yarnpkg.com/latest-version

--- a/factory/CHANGELOG.md
+++ b/factory/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Change log
 
+## 4.0.5
+
+- Updated default node version from `20.15.1` to `20.16.0`. Addressed in [#1182](https://github.com/cypress-io/cypress-docker-images/pull/1182)
+
 ## 4.0.4
 
 - Updated default node version from `20.14.0` to `20.15.1`. Addresses [#1153](https://github.com/cypress-io/cypress-docker-images/issues/1153)


### PR DESCRIPTION
- updates nodes in the docker factory to `20.16.0`
- bumps chrome to version `127.0.6533.88-1`
- bumps edge to  version `127.0.2651.74-1`
- bumps firefox to version `128.0.3`
- installs Cypress version `13.13.2`