### PR TITLE
build: remove factory /usr/share/man deletion

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -144,9 +144,13 @@ To avoid bloating the Docker layers with extraneous files, after every `RUN` cal
 
 ```bash
 rm -rf /usr/share/doc && \
-  rm -rf /usr/share/man && \
-  rm -rf /var/lib/apt/lists/*
+rm -rf /usr/share/man && \
+rm -rf /var/lib/apt/lists/*
 ```
+
+Note that due to the use of `debian:<suite>-slim` the directories `/usr/share/doc` and `/usr/share/man` already have minimal content.
+
+Deleting `/usr/share/man` has been removed due to side effects of preventing installation of some other Debian packages.
 
 ### Use the `--no-install-recommends` with `apt-get`
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -150,7 +150,7 @@ rm -rf /var/lib/apt/lists/*
 
 Note that due to the use of `debian:<suite>-slim` the directories `/usr/share/doc` and `/usr/share/man` already have minimal content.
 
-Deleting `/usr/share/man` has been removed due to side effects of preventing installation of some other Debian packages.
+Deleting `/usr/share/man` has been removed as a default cleanup command due to side effects of preventing installation of some other Debian packages.
 
 ### Use the `--no-install-recommends` with `apt-get`
 

--- a/factory/.env
+++ b/factory/.env
@@ -14,7 +14,7 @@ NODE_VERSION="${FACTORY_DEFAULT_NODE_VERSION}"
 
 # Update the FACTORY_VERSION to deploy cypress/factory if you make changes to
 # BASE_IMAGE, FACTORY_DEFAULT_NODE_VERSION, YARN_VERSION, factory.Dockerfile or installScripts
-FACTORY_VERSION='4.0.5'
+FACTORY_VERSION='4.0.6'
 
 # Chrome versions: https://www.ubuntuupdates.org/package/google_chrome/stable/main/base/google-chrome-stable
 CHROME_VERSION='127.0.6533.88-1'

--- a/factory/CHANGELOG.md
+++ b/factory/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Change log
 
+## 4.0.6
+
+- Reinstates empty directory structure `/usr/share/man` which was previously removed as part of factory build process. Addresses [#1184](https://github.com/cypress-io/cypress-docker-images/issues/1184)
+
 ## 4.0.5
 
 - Updated default node version from `20.15.1` to `20.16.0`. Addressed in [#1182](https://github.com/cypress-io/cypress-docker-images/pull/1182)

--- a/factory/factory.Dockerfile
+++ b/factory/factory.Dockerfile
@@ -121,7 +121,6 @@ ONBUILD RUN apt-get purge -y --auto-remove \
     gnupg \
     dirmngr\
   && rm -rf /usr/share/doc \
-  && rm -rf /usr/share/man \
   && rm -rf /var/lib/apt/lists/* \
   # Remove cypress install scripts
   && rm -rf /opt/installScripts


### PR DESCRIPTION
- Closes https://github.com/cypress-io/cypress-docker-images/issues/1184

## Issue

The Global Cleanup phase of the `factory` build process defined in [factory/factory.Dockerfile](https://github.com/cypress-io/cypress-docker-images/blob/master/factory/factory.Dockerfile) deletes the Debian system directories:

- `/usr/share/doc`
- `/usr/share/man`

According to https://github.com/cypress-io/cypress-docker-images/issues/1184 the full default empty directory structure of `/usr/share/man` is necessary for installation of the Debian package [default-jre](https://packages.debian.org/bookworm/default-jre).

## Background

The `cypress/factory` image is built on [debian:12-slim](https://hub.docker.com/_/debian) which includes a description:

> Image Variants
> `debian:<suite>-slim`
> These tags are an experiment in providing a slimmer base (removing some extra files that are normally not necessary within containers, such as man pages and documentation), and are definitely subject to change.

### Variant size comparison

| Directory        | `debian:12` | `debian:12-slim` |
| ---------------- | ----------- | ---------------- |
| `/usr/share/doc` | 8.7M        | 1.5M             |
| `/usr/share/man` | 5.3M        | 20K              |

```shell
$ docker run -it --rm debian:12
root@bd2d433bb2e0:/# du -sh /usr/share/doc
8.7M    /usr/share/doc
root@bd2d433bb2e0:/# du -sh /usr/share/man
5.3M    /usr/share/man
$ docker run -it --rm debian:12-slim
root@d5237aa3e3ee:/# du -sh /usr/share/doc
1.5M    /usr/share/doc
root@d5237aa3e3ee:/# du -sh /usr/share/man
20K     /usr/share/man
```

### Conclusion

`debian:12-slim` includes only a skelton directory structure under `/usr/share/man` and it has already removed the 5.3M files that occupy this directory structure under `debian:12`. This means that an additional purge of this directory by the Cypress Docker build process is not necessary for `debian:12-slim`.

## Change

Remove the following instruction from [factory/factory.Dockerfile](https://github.com/cypress-io/cypress-docker-images/blob/master/factory/factory.Dockerfile):

```shell
rm -rf /usr/share/man
```

This leaves the empty `/usr/share/man` directory structure intact:

```text
4.0K    /usr/share/man/man5
4.0K    /usr/share/man/man1
4.0K    /usr/share/man/man8
4.0K    /usr/share/man/man7
20K     /usr/share/man
```

## Verification

```shell
cd factory
docker compose build factory
docker run -it --rm cypress/factory
du -sh /usr/share/man # shows 20K
apt update
apt install default-jre -y # should be successful
```
