### PR TITLE
build: add default BASE_IMAGE to factory.Dockerfile

### DIFF
--- a/factory/factory.Dockerfile
+++ b/factory/factory.Dockerfile
@@ -1,5 +1,7 @@
-# Set base image arg to allow easy testing of other debian versions.
-ARG BASE_IMAGE
+# BASE_IMAGE is expected to be overridden
+# Regular builds, using docker compose, take the value from
+# the .env file in the same directory as this file
+ARG BASE_IMAGE='debian:12-slim'
 
 FROM ${BASE_IMAGE} AS factory
 


### PR DESCRIPTION
- Closes https://github.com/cypress-io/cypress-docker-images/issues/1186

## Issue

Docker Desktop [4.33.0](https://docs.docker.com/desktop/release-notes/#4330) introduced new BuildKit checking:
> BuildKit now evaluates Dockerfile rules to inform you of potential issues.

The check reveals that [factory/factory.Dockerfile](https://github.com/cypress-io/cypress-docker-images/blob/master/factory/factory.Dockerfile) violates the rule `InvalidDefaultArgInFrom` as explained in https://docs.docker.com/reference/build-checks/invalid-default-arg-in-from/

There is no default value for BASE_IMAGE defined.

https://github.com/cypress-io/cypress-docker-images/blob/359c915d01fcd9e64282ae0904d2ce11db3abe87/factory/factory.Dockerfile#L1-L4

Instead, the build process, using `docker compose build factory`, relies on `BASE_IMAGE='debian:12.6-slim'` set in [factory/.env](https://github.com/cypress-io/cypress-docker-images/blob/master/factory/.env)

https://github.com/cypress-io/cypress-docker-images/blob/359c915d01fcd9e64282ae0904d2ce11db3abe87/factory/.env#L1-L7



## Change

Add the generic default image specifier `BASE_IMAGE='debian:12-slim'` to [factory/factory.Dockerfile](https://github.com/cypress-io/cypress-docker-images/blob/master/factory/factory.Dockerfile)

## Verification

Using Docker Desktop >= `4.33`

```shell
cd factory
docker build --check . -f factory.Dockerfile
```

1. There should be no warning output
2. The image should be based on `debian:12-slim`

```shell
cd factory
docker compose build factory
```

1. There should be no warning output
2. The image should be based on `debian:12.6-slim`


