### PR TITLE
chore: update cypress to 13.13.3 and update browsers in docker factory

### DIFF
--- a/factory/.env
+++ b/factory/.env
@@ -17,16 +17,16 @@ NODE_VERSION="${FACTORY_DEFAULT_NODE_VERSION}"
 FACTORY_VERSION='4.0.6'
 
 # Chrome versions: https://www.ubuntuupdates.org/package/google_chrome/stable/main/base/google-chrome-stable
-CHROME_VERSION='127.0.6533.88-1'
+CHROME_VERSION='127.0.6533.119-1'
 
 # Cypress versions: https://www.npmjs.com/package/cypress
-CYPRESS_VERSION='13.13.2'
+CYPRESS_VERSION='13.13.3'
 
 # Edge versions: https://packages.microsoft.com/repos/edge/pool/main/m/microsoft-edge-stable/
-EDGE_VERSION='127.0.2651.74-1'
+EDGE_VERSION='127.0.2651.98-1'
 
 # Firefox versions: https://download-installer.cdn.mozilla.net/pub/firefox/releases/
-FIREFOX_VERSION='128.0.3'
+FIREFOX_VERSION='129.0.1'
 
 # Yarn versions: https://www.npmjs.com/package/yarn and
 # https://classic.yarnpkg.com/latest-version


### PR DESCRIPTION
update cypress to 13.13.3 and bumps browsers in factory