### PR TITLE
feat(deps): add zstd to factory image

### DIFF
--- a/factory/.env
+++ b/factory/.env
@@ -14,7 +14,7 @@ NODE_VERSION="${FACTORY_DEFAULT_NODE_VERSION}"
 
 # Update the FACTORY_VERSION to deploy cypress/factory if you make changes to
 # BASE_IMAGE, FACTORY_DEFAULT_NODE_VERSION, YARN_VERSION, factory.Dockerfile or installScripts
-FACTORY_VERSION='4.0.6'
+FACTORY_VERSION='4.1.0'
 
 # Chrome versions: https://www.ubuntuupdates.org/package/google_chrome/stable/main/base/google-chrome-stable
 CHROME_VERSION='127.0.6533.119-1'

--- a/factory/CHANGELOG.md
+++ b/factory/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Change log
 
+## 4.1.0
+
+- Adds [zstd](https://packages.debian.org/stable/utils/zstd) (fast lossless compression algorithm -- CLI tool) to images. Addresses [#584](https://github.com/cypress-io/cypress-docker-images/issues/584)
+
 ## 4.0.6
 
 - Reinstates empty directory structure `/usr/share/man` which was previously removed as part of factory build process. Addresses [#1184](https://github.com/cypress-io/cypress-docker-images/issues/1184)

--- a/factory/factory.Dockerfile
+++ b/factory/factory.Dockerfile
@@ -55,7 +55,9 @@ RUN ls -la /root \
     # Needed to make https calls from the docker container
     openssl \
     ca-certificates \
-    # build only dependancies: removed in onbuild step
+    # Fast lossless compression algorithm - preferred by GitHub @actions/cache
+    zstd \
+    # build only dependencies: removed in onbuild step
     bzip2 \
     gnupg \
     dirmngr \


### PR DESCRIPTION
- Closes https://github.com/cypress-io/cypress-docker-images/issues/584

## Issue

[cypress/factory](https://github.com/cypress-io/cypress-docker-images/tree/master/factory), and other Cypress Docker images, built using the `factory` process, do not include [zstd](https://packages.debian.org/stable/utils/zstd) (fast lossless compression algorithm) from [Debian packages](https://www.debian.org/distrib/packages), however they do include [gzip](https://packages.debian.org/stable/utils/gzip) (compress or expand files), which is classed as "essential" and is already part of the `debian:12-slim` image.

For comparison, GitHub Linux runner images, such as [ubuntu-22.04](https://github.com/actions/runner-images/blob/main/images/ubuntu/Ubuntu2204-Readme.md), include both [gzip](https://packages.ubuntu.com/jammy/utils/gzip) and [zstd](https://packages.ubuntu.com/jammy/utils/zstd).

As described in issue #584, the GitHub JavaScript [actions/cache](https://github.com/actions/cache), action for caching dependencies, which in turn uses [@actions/cache](https://github.com/actions/toolkit/tree/main/packages/cache), prefers `zstd` over `gzip` for performance and cross-OS compatibility (see [Usage > Save Cache](https://github.com/actions/toolkit/tree/main/packages/cache#save-cache)).

[Zstd](https://github.com/facebook/zstd), short for Zstandard, is a fast lossless compression algorithm, targeting real-time compression scenarios at zlib-level compression ratio.

## Change

- Add [zstd](https://packages.debian.org/stable/utils/zstd) from [Debian packages](https://www.debian.org/distrib/packages) to [factory.Dockerfile](https://github.com/cypress-io/cypress-docker-images/blob/master/factory/factory.Dockerfile).
- Update `FACTORY_VERSION` to `4.1.0`

## Impact

- All Cypress Docker images, including `cypress/factory` include `zstd` at their next publication.
- GitHub Actions workflows using [@actions/cache](https://github.com/actions/toolkit/tree/main/packages/cache) will use the same compression mechanism whether they run natively in a runner or inside a Cypress Docker container.
- `cypress/factory` minimal 0.4% image size increase (uncompressed size before 506MB, after 508MB).
