### PR TITLE
build: add default FACTORY_VERSION to Dockerfile

### DIFF
--- a/factory/Dockerfile
+++ b/factory/Dockerfile
@@ -1,5 +1,7 @@
-
-ARG FACTORY_VERSION
+# FACTORY_VERSION is expected to be overridden
+# Regular builds, using docker compose, take the value from
+# the .env file in the same directory as this file
+ARG FACTORY_VERSION='4.1.0'
 
 # Multi-stage default image. Used to test and create the pre-built docker images.
 FROM cypress/factory:${FACTORY_VERSION} AS default_image


### PR DESCRIPTION
- Closes https://github.com/cypress-io/cypress-docker-images/issues/1197

## Issue

Docker Desktop [4.33.0](https://docs.docker.com/desktop/release-notes/#4330) introduced new BuildKit checking:
> BuildKit now evaluates Dockerfile rules to inform you of potential issues.

The check reveals that [factory/Dockerfile](https://github.com/cypress-io/cypress-docker-images/blob/master/factory/Dockerfile) violates the rule `InvalidDefaultArgInFrom` as explained in https://docs.docker.com/reference/build-checks/invalid-default-arg-in-from/

There is no default value for `FACTORY_VERSION` defined.

https://github.com/cypress-io/cypress-docker-images/blob/359c915d01fcd9e64282ae0904d2ce11db3abe87/factory/Dockerfile#L1-L2

Instead, the build process, using for instance `docker compose build base`, relies on `FACTORY_VERSION='4.1.0'` set in [factory/.env](https://github.com/cypress-io/cypress-docker-images/blob/master/factory/.env)

https://github.com/cypress-io/cypress-docker-images/blob/36d58b9181d45f03f04b969a8ac537f89596b673/factory/.env#L15-L17


## Change

Add a fallback default `FACTORY_VERSION='4.1.0'` to [factory/Dockerfile](https://github.com/cypress-io/cypress-docker-images/blob/master/factory/Dockerfile)

## Verification

Using Docker Desktop >= `4.33`

```shell
cd factory
docker build --check . -f Dockerfile
```

1. There should be no warning output
2. The image should be based on `cypress/factory:4.1.0`

```shell
cd factory
docker compose build factory
docker compose build base
docker compose build
```

1. There should be no warnings output
2. The `factory` image should (currently) be based on `debian:12.6-slim`
3. The `base` image should (currently) be based on `cypress/factory:4.1.0`