### PR TITLE
chore: publish node 22.7.0 to use for cypress system binary test

### DIFF
--- a/circle.yml
+++ b/circle.yml
@@ -356,6 +356,7 @@ workflows:
                         # if publishing an old version
                         # This job must run because the base, browsers and included jobs depend on it
                             - master
+                            - chore/build_node_22_7_0_image
                 requires:
                     - factory
                     - factory-arm
@@ -372,6 +373,7 @@ workflows:
                         # Change to a feature branch such as <cypress-version>-node-<node.js version>-publish
                         # if publishing an old version
                             - master
+                            - chore/build_node_22_7_0_image
                 requires:
                     - "Push Factory Image"
                     - base
@@ -387,6 +389,7 @@ workflows:
                         # Change to a feature branch such as <cypress-version>-node-<node.js version>-publish
                         # if publishing an old version
                             - master
+                            - chore/build_node_22_7_0_image
                 requires:
                     - "Push Factory Image"
                     - browsers
@@ -402,6 +405,7 @@ workflows:
                         # Change to a feature branch such as <cypress-version>-node-<node.js version>-publish
                         # if publishing an old version
                             - master
+                            - chore/build_node_22_7_0_image
                 requires:
                     - "Push Factory Image"
                     - included

--- a/factory/.env
+++ b/factory/.env
@@ -7,7 +7,7 @@
 BASE_IMAGE='debian:12.6-slim'
 
 # Node Versions: https://nodejs.org/en/download/releases/
-FACTORY_DEFAULT_NODE_VERSION='20.16.0'
+FACTORY_DEFAULT_NODE_VERSION='22.7.0'
 
 # Node Versions: https://nodejs.org/en/download/releases/
 NODE_VERSION="${FACTORY_DEFAULT_NODE_VERSION}"

--- a/factory/docker-compose.yml
+++ b/factory/docker-compose.yml
@@ -17,7 +17,6 @@ services:
         BASE_IMAGE: ${BASE_IMAGE}
         FACTORY_DEFAULT_NODE_VERSION: ${FACTORY_DEFAULT_NODE_VERSION}
       tags:
-       - ${REPO_PREFIX-}cypress/factory:latest  # comment out for release of older version
        - ${REPO_PREFIX-}cypress/factory:${FACTORY_VERSION}
     command: node -v
 
@@ -36,7 +35,6 @@ services:
         YARN_VERSION: ${YARN_VERSION}
         # WEBKIT_VERSION: ${WEBKIT_VERSION}
       tags:
-       - ${REPO_PREFIX-}cypress/included:latest # comment out for release of older version
        - ${REPO_PREFIX-}cypress/included:${INCLUDED_IMAGE_SHORT_TAG}  # comment out for release of older version
        - ${REPO_PREFIX-}cypress/included:${INCLUDED_IMAGE_TAG}
     command: node -v
@@ -54,7 +52,6 @@ services:
         FIREFOX_VERSION: ${FIREFOX_VERSION}
         EDGE_VERSION: ${EDGE_VERSION}
       tags:
-       - ${REPO_PREFIX-}cypress/browsers:latest # comment out for release of older version
        - ${REPO_PREFIX-}cypress/browsers:${BROWSERS_IMAGE_TAG}
     command: node -v
 
@@ -68,7 +65,6 @@ services:
         FACTORY_VERSION: ${FACTORY_VERSION}
         YARN_VERSION: ${YARN_VERSION}
       tags:
-       - ${REPO_PREFIX-}cypress/base:latest # comment out for release of older version
        - ${REPO_PREFIX-}cypress/base:${BASE_IMAGE_TAG}
     command: node -v
 


### PR DESCRIPTION
builds node 22.7.0 base image for use in the cypress repo as a system test needed to make sure experimental node flags added to the version are removed. These images are published manually but creating this pull request as an artifact that can be referenced for posterity if needed. See https://github.com/cypress-io/cypress/issues/30084 for more details