### PR TITLE
chore: update node version of favtory from 20.16.0 to 20.17.0

### DIFF
--- a/factory/.env
+++ b/factory/.env
@@ -7,14 +7,14 @@
 BASE_IMAGE='debian:12.6-slim'
 
 # Node Versions: https://nodejs.org/en/download/releases/
-FACTORY_DEFAULT_NODE_VERSION='20.16.0'
+FACTORY_DEFAULT_NODE_VERSION='20.17.0'
 
 # Node Versions: https://nodejs.org/en/download/releases/
 NODE_VERSION="${FACTORY_DEFAULT_NODE_VERSION}"
 
 # Update the FACTORY_VERSION to deploy cypress/factory if you make changes to
 # BASE_IMAGE, FACTORY_DEFAULT_NODE_VERSION, YARN_VERSION, factory.Dockerfile or installScripts
-FACTORY_VERSION='4.1.0'
+FACTORY_VERSION='4.1.1'
 
 # Chrome versions: https://www.ubuntuupdates.org/package/google_chrome/stable/main/base/google-chrome-stable
 CHROME_VERSION='127.0.6533.119-1'

--- a/factory/CHANGELOG.md
+++ b/factory/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Change log
 
+## 4.1.1
+
+- Updated default node version from `20.16.0` to `20.17.0`. Addressed in [#1201](https://github.com/cypress-io/cypress-docker-images/pull/1201)
+
 ## 4.1.0
 
 - Adds [zstd](https://packages.debian.org/stable/utils/zstd) (fast lossless compression algorithm -- CLI tool) to images. Addresses [#584](https://github.com/cypress-io/cypress-docker-images/issues/584)


### PR DESCRIPTION
updates the default factory node version from `20.16.0` to `20.17.0`