### PR TITLE
docs: change contributor's description from old to alternate versions

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -57,7 +57,9 @@ docker compose run test-factory-all-included
 
 #### Automatic
 
-##### New versions
+##### Primary versions
+
+The [factory/.env](./factory/.env) in the `master` branch should be maintained with the latest stable and supported versions. An exception is the `FACTORY_DEFAULT_NODE_VERSION` which should be set to the [Node.js Active LTS](https://nodejs.org/en/about/previous-releases) version, not the "Current" version.
 
 To publish a new image for `factory`, `base`, `browsers`, or `included`, open a PR with the desired version(s) updated in the [factory/.env](./factory/.env) file. If you change any of the following environment variables in [factory/.env](./factory/.env), then you should also bump the `FACTORY_VERSION` in the same file and make a note of the change in the factory [CHANGELOG](./factory/CHANGELOG.md):
 
@@ -69,15 +71,15 @@ You should not change the `FACTORY_VERSION` or make an entry into the factory [C
 
 Once the PR is merged into the `master` branch, the corresponding images will be pushed to [Docker Hub](https://hub.docker.com/u/cypress) and to the [Amazon ECR (Elastic Container Registry) Public Gallery](https://gallery.ecr.aws/cypress-io) via an automated script run through [CircleCI](circle.yml). Please check that the CI jobs pass after merge. Any CI failure can cause the release process to be interrupted.
 
-##### Older versions
+##### Alternate versions
 
 > Note: Assistance from a member of the Cypress org is required for this process
 
-In general, [factory/.env](./factory/.env) in the `master` branch should contain the latest versions we officially support. If you need to release an older version, do not modify contents in the `master` branch. Instead, carry out the following steps:
+If you need to release alternate versions that do not qualify to be primary versions, do not modify the contents of the [factory/.env](./factory/.env) file in the `master` branch. An example would be to publish images including updated [Node.js releases](https://nodejs.org/en/about/previous-releases) in the category "Maintenance LTS" or "Current". Instead, carry out the following steps:
 
 1. Create a feature branch in the form `<cypress-version>-node-<node.js version>-publish`, for example `13.11.0-node-18.20.3-publish`, branched from the `master` branch. If you are not a member of the Cypress org, make a request via a new issue to create a feature branch.
 2. Modify [factory/.env](./factory/.env) with the desired versions. Do not modify the `FACTORY_VERSION`. No new `cypress/factory` image should be published with this process.
-3. Modify [factory/docker-compose.yml](./factory/docker-compose.yml) to comment out the creation of `latest` tags. Comment out the `cypress/included` `INCLUDED_IMAGE_SHORT_TAG` to also prevent this tag from being created. This step is essential to avoid related tags of existing released images being moved back to point to older images.
+3. Modify [factory/docker-compose.yml](./factory/docker-compose.yml) to comment out the creation of `latest` tags. Comment out the `cypress/included` `INCLUDED_IMAGE_SHORT_TAG` to also prevent this tag from being created. This step is essential to avoid the related tags of any existing released images being moved to point to non-primary images.
 4. Modify [circle.yml](circle.yml) to push releases from the feature branch.
 5. Open a PR which targets the feature branch.
 6. After PR merge, check Docker Hub and the associated new image(s).

--- a/factory/.env
+++ b/factory/.env
@@ -1,12 +1,15 @@
-## This env file represents the latest versions Cypress supports.
+## This env file represents the primary versions Cypress supports.
+## These are the latest stable versions and Node.js Active LTS.
 ##
-## If you wish to release an older Docker image, do not modify this file in the master branch.
-## Follow the instructions in the CONTRIBUTING document and work instead in a feature branch.
+## If you wish to release Docker image(s) with alternate (i.e. non-primary) versions, do not modify this file in the master branch.
+## Follow the instructions in the CONTRIBUTING document for alternate versions and work instead in a feature branch.
 
 # The Debian image cypress/factory is based on
 BASE_IMAGE='debian:12.6-slim'
 
 # Node Versions: https://nodejs.org/en/download/releases/
+# master branch needs "Active LTS" version
+# use feature branch for "Maintenance LTS" or "Current" versions
 FACTORY_DEFAULT_NODE_VERSION='20.17.0'
 
 # Node Versions: https://nodejs.org/en/download/releases/

--- a/factory/docker-compose.yml
+++ b/factory/docker-compose.yml
@@ -1,9 +1,9 @@
 # REPO_PREFIX is used in CI to deploy to other docker registries than dockerhub.
 
-## If you wish to release an older Docker image, do not modify this file in the master branch.
-## Follow the instructions in the CONTRIBUTING document and work instead in a feature branch.
+## If you wish to release Docker image(s) with alternate (i.e. non-primary) versions, do not modify this file in the master branch.
+## Follow the instructions in the CONTRIBUTING document for alternate versions and work instead in a feature branch.
 ## Comment out the tags entries for latest tags below so that no latest tag is created.
-## Comment out the INCLUDED_IMAGE_SHORT_TAG so that this tag is not reassigned to an older version.
+## Comment out the INCLUDED_IMAGE_SHORT_TAG so that this tag is not reassigned to a non-primary version.
 
 services:
 
@@ -17,7 +17,7 @@ services:
         BASE_IMAGE: ${BASE_IMAGE}
         FACTORY_DEFAULT_NODE_VERSION: ${FACTORY_DEFAULT_NODE_VERSION}
       tags:
-       - ${REPO_PREFIX-}cypress/factory:latest  # comment out for release of older version
+       - ${REPO_PREFIX-}cypress/factory:latest  # comment out for release of alternate version
        - ${REPO_PREFIX-}cypress/factory:${FACTORY_VERSION}
     command: node -v
 
@@ -36,8 +36,8 @@ services:
         YARN_VERSION: ${YARN_VERSION}
         # WEBKIT_VERSION: ${WEBKIT_VERSION}
       tags:
-       - ${REPO_PREFIX-}cypress/included:latest # comment out for release of older version
-       - ${REPO_PREFIX-}cypress/included:${INCLUDED_IMAGE_SHORT_TAG}  # comment out for release of older version
+       - ${REPO_PREFIX-}cypress/included:latest # comment out for release of alternate version
+       - ${REPO_PREFIX-}cypress/included:${INCLUDED_IMAGE_SHORT_TAG}  # comment out for release of alternate version
        - ${REPO_PREFIX-}cypress/included:${INCLUDED_IMAGE_TAG}
     command: node -v
 
@@ -54,7 +54,7 @@ services:
         FIREFOX_VERSION: ${FIREFOX_VERSION}
         EDGE_VERSION: ${EDGE_VERSION}
       tags:
-       - ${REPO_PREFIX-}cypress/browsers:latest # comment out for release of older version
+       - ${REPO_PREFIX-}cypress/browsers:latest # comment out for release of alternate version
        - ${REPO_PREFIX-}cypress/browsers:${BROWSERS_IMAGE_TAG}
     command: node -v
 
@@ -68,7 +68,7 @@ services:
         FACTORY_VERSION: ${FACTORY_VERSION}
         YARN_VERSION: ${YARN_VERSION}
       tags:
-       - ${REPO_PREFIX-}cypress/base:latest # comment out for release of older version
+       - ${REPO_PREFIX-}cypress/base:latest # comment out for release of alternate version
        - ${REPO_PREFIX-}cypress/base:${BASE_IMAGE_TAG}
     command: node -v
 


### PR DESCRIPTION
## Issue

The contributor documentation refers to publishing "older versions". This is not a good description as it does not cover publishing Cypress Docker images with current Node.js versions later than the active LTS version.

## Change

The distinction is now made between "Primary versions" and "Alternate versions" since the alternate versions could be older or newer than the primary versions.
