### PR TITLE
chore: support cypress 13.14.0 and update to chrome 128, edge 128, and firefox 129.0.2

### DIFF
--- a/factory/.env
+++ b/factory/.env
@@ -20,16 +20,16 @@ NODE_VERSION="${FACTORY_DEFAULT_NODE_VERSION}"
 FACTORY_VERSION='4.1.1'
 
 # Chrome versions: https://www.ubuntuupdates.org/package/google_chrome/stable/main/base/google-chrome-stable
-CHROME_VERSION='127.0.6533.119-1'
+CHROME_VERSION='128.0.6613.84-1'
 
 # Cypress versions: https://www.npmjs.com/package/cypress
-CYPRESS_VERSION='13.13.3'
+CYPRESS_VERSION='13.14.0'
 
 # Edge versions: https://packages.microsoft.com/repos/edge/pool/main/m/microsoft-edge-stable/
-EDGE_VERSION='127.0.2651.98-1'
+EDGE_VERSION='128.0.2739.42-1'
 
 # Firefox versions: https://download-installer.cdn.mozilla.net/pub/firefox/releases/
-FIREFOX_VERSION='129.0.1'
+FIREFOX_VERSION='129.0.2'
 
 # Yarn versions: https://www.npmjs.com/package/yarn and
 # https://classic.yarnpkg.com/latest-version


### PR DESCRIPTION
Updates the factory to use Cypress 13.14.0, chrome 128, edge 128, and firefox 129.0.2