### PR TITLE
chore: update cypress to 13.14.2 and update browsers

### DIFF
--- a/factory/.env
+++ b/factory/.env
@@ -20,16 +20,16 @@ NODE_VERSION="${FACTORY_DEFAULT_NODE_VERSION}"
 FACTORY_VERSION='4.1.1'
 
 # Chrome versions: https://www.ubuntuupdates.org/package/google_chrome/stable/main/base/google-chrome-stable
-CHROME_VERSION='128.0.6613.113-1'
+CHROME_VERSION='128.0.6613.119-1'
 
 # Cypress versions: https://www.npmjs.com/package/cypress
-CYPRESS_VERSION='13.14.1'
+CYPRESS_VERSION='13.14.2'
 
 # Edge versions: https://packages.microsoft.com/repos/edge/pool/main/m/microsoft-edge-stable/
-EDGE_VERSION='128.0.2739.42-1'
+EDGE_VERSION='128.0.2739.63-1'
 
 # Firefox versions: https://download-installer.cdn.mozilla.net/pub/firefox/releases/
-FIREFOX_VERSION='129.0.2'
+FIREFOX_VERSION='130.0'
 
 # Yarn versions: https://www.npmjs.com/package/yarn and
 # https://classic.yarnpkg.com/latest-version


### PR DESCRIPTION
updates cypress to 13.14.2 and updates chrome, edge, and firefox to latest.