### PR TITLE
feat: update to Debian 12.7 (bookworm)

### DIFF
--- a/factory/.env
+++ b/factory/.env
@@ -4,8 +4,9 @@
 ## If you wish to release Docker image(s) with alternate (i.e. non-primary) versions, do not modify this file in the master branch.
 ## Follow the instructions in the CONTRIBUTING document for alternate versions and work instead in a feature branch.
 
+# Use Debian stable release https://www.debian.org/releases/stable/
 # The Debian image cypress/factory is based on
-BASE_IMAGE='debian:12.6-slim'
+BASE_IMAGE='debian:12.7-slim'
 
 # Node Versions: https://nodejs.org/en/download/releases/
 # master branch needs "Active LTS" version
@@ -17,7 +18,7 @@ NODE_VERSION="${FACTORY_DEFAULT_NODE_VERSION}"
 
 # Update the FACTORY_VERSION to deploy cypress/factory if you make changes to
 # BASE_IMAGE, FACTORY_DEFAULT_NODE_VERSION, YARN_VERSION, factory.Dockerfile or installScripts
-FACTORY_VERSION='4.1.1'
+FACTORY_VERSION='4.2.0'
 
 # Chrome versions: https://www.ubuntuupdates.org/package/google_chrome/stable/main/base/google-chrome-stable
 CHROME_VERSION='128.0.6613.119-1'

--- a/factory/CHANGELOG.md
+++ b/factory/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Change log
 
+## 4.2.0
+
+- Updated Debian base to `debian:12.7-slim` using [Debian 12.7](https://www.debian.org/News/2024/20240831), released on Aug 31, 2024. Addresses [#1207](https://github.com/cypress-io/cypress-docker-images/issues/1207)
+
 ## 4.1.1
 
 - Updated default node version from `20.16.0` to `20.17.0`. Addressed in [#1201](https://github.com/cypress-io/cypress-docker-images/pull/1201)


### PR DESCRIPTION
- Closes https://github.com/cypress-io/cypress-docker-images/issues/1207

## Issue

[Debian 12.7](https://www.debian.org/News/2024/20240831) was released on Aug 31, 2024.

Cypress Factory is currently based on [Debian 12.6](https://www.debian.org/News/2024/20240629).

See [Debian Releases](https://www.debian.org/releases/) for an overview.

## Change

Update to `BASE_IMAGE='debian:12.7-slim'`