### PR TITLE
ci: relax hard-coded version check for git

### DIFF
--- a/circle.yml
+++ b/circle.yml
@@ -130,13 +130,12 @@ jobs:
                     echo "Version ${ACTUAL_VERSION} confirmed"
                   working_directory: factory/test-project
             - run:
+                  # The git version is determined by BASE_IMAGE and its online package sources
+                  # We check that git is installed and report its version
+                  # There is no check for a certain version of git
                   name: check git version
                   command: |
                     ACTUAL_VERSION=$(docker compose run test-factory-all-included git --version)
-                    if [  "git version 2.39.2" != "${ACTUAL_VERSION}" ]; then
-                      echo "Version mismatch, git package version: git version 2.39.2 != ${ACTUAL_VERSION}"
-                      exit 1;
-                    fi
                     echo "Version ${ACTUAL_VERSION} confirmed"
                   working_directory: factory/test-project
             - run:


### PR DESCRIPTION
## Issue

CircleCI contains a check for a fixed version of `git`, however this version is not under control of the `factory` build process. This causes unplanned workflow failures when new versions of `git` are released.

This is the hard-coded check:

https://github.com/cypress-io/cypress-docker-images/blob/dc421e766155fb3096646cf04108c61d3afb587e/circle.yml#L132-L141

The version of `git` depends on the `BASE_IMAGE`:

https://github.com/cypress-io/cypress-docker-images/blob/dc421e766155fb3096646cf04108c61d3afb587e/factory/.env#L9

and so far this is a Debian image, it depends also on the currently distributed package version according to [Package git](https://packages.debian.org/search?keywords=git) which is picked up by the build process:

https://github.com/cypress-io/cypress-docker-images/blob/dc421e766155fb3096646cf04108c61d3afb587e/factory/factory.Dockerfile#L33-L34

causing a refresh each time the `cypress/factory` image is rebuilt. This is what breaks the workflow job `check-factory-versions` from time to time.

## Change

Remove the check for a specific version of `git` and report the version of `git` found.

This method is already used in the `ssh` check in the workflow lines of code following the `git` version check.