### PR TITLE
chore: update circleci to ubuntu-2204:2024.08.1 (latest) machine image

### DIFF
--- a/circle.yml
+++ b/circle.yml
@@ -69,7 +69,7 @@ jobs:
             - run:
                   name: check node version
                   command: |
-                    ACTUAL_VERSION=$(docker compose run test-factory-all-included node -v)
+                    ACTUAL_VERSION=$(docker compose run --rm test-factory-all-included node -v)
                     if [ v${NODE_VERSION} != "${ACTUAL_VERSION}" ]; then
                       echo "Version mismatch, v${NODE_VERSION} != ${ACTUAL_VERSION}"
                       exit 1;
@@ -79,7 +79,7 @@ jobs:
             - run:
                   name: check yarn version
                   command: |
-                    ACTUAL_VERSION=$(docker compose run test-factory-all-included yarn -v)
+                    ACTUAL_VERSION=$(docker compose run --rm test-factory-all-included yarn -v)
                     if [ ${YARN_VERSION} != "${ACTUAL_VERSION}" ]; then
                       echo "Version mismatch, ${YARN_VERSION} != ${ACTUAL_VERSION}"
                       exit 1;
@@ -89,7 +89,7 @@ jobs:
             - run:
                   name: check chrome version
                   command: |
-                    ACTUAL_VERSION=$(docker compose run test-factory-all-included google-chrome --version | xargs)
+                    ACTUAL_VERSION=$(docker compose run --rm test-factory-all-included google-chrome --version | xargs)
                     TRIMMED_CHROME_VERSION=$(echo ${CHROME_VERSION} | sed -e 's/-.*$//g')
                     if [ "Google Chrome ${TRIMMED_CHROME_VERSION}" != "${ACTUAL_VERSION}" ]; then
                       echo "Version mismatch, Google Chrome ${TRIMMED_CHROME_VERSION} != ${ACTUAL_VERSION}"
@@ -100,7 +100,7 @@ jobs:
             - run:
                   name: check firefox version
                   command: |
-                    ACTUAL_VERSION=$(docker compose run test-factory-all-included firefox --version)
+                    ACTUAL_VERSION=$(docker compose run --rm test-factory-all-included firefox --version)
                     if [ "Mozilla Firefox ${FIREFOX_VERSION}" != "${ACTUAL_VERSION}" ]; then
                       echo "Version mismatch, Mozilla Firefox ${FIREFOX_VERSION} != ${ACTUAL_VERSION}"
                       exit 1;
@@ -110,7 +110,7 @@ jobs:
             - run:
                   name: check edge version
                   command: |
-                    ACTUAL_VERSION=$(docker compose run test-factory-all-included edge --version | xargs)
+                    ACTUAL_VERSION=$(docker compose run --rm test-factory-all-included edge --version | xargs)
                     TRIMMED_EDGE_VERSION=$(echo ${EDGE_VERSION} | sed -e 's/-.*$//g')
                     if [ "Microsoft Edge ${TRIMMED_EDGE_VERSION}" != "${ACTUAL_VERSION}" ]; then
                       echo "Version mismatch, Microsoft Edge ${TRIMMED_EDGE_VERSION} != ${ACTUAL_VERSION}"
@@ -121,7 +121,7 @@ jobs:
             - run:
                   name: check cypress version
                   command: |
-                    ACTUAL_VERSION=$(docker compose run test-factory-all-included cypress -v)
+                    ACTUAL_VERSION=$(docker compose run --rm test-factory-all-included cypress -v)
                     TRIMMED_ACTUAL_VERSION=$(echo ${ACTUAL_VERSION} | sed -e 's/ Cypress binary version:.*$//g')
                     if [  "Cypress package version: ${CYPRESS_VERSION}" != "${TRIMMED_ACTUAL_VERSION}" ]; then
                       echo "Version mismatch, Cypress package version: ${CYPRESS_VERSION} != ${TRIMMED_ACTUAL_VERSION}"
@@ -135,13 +135,13 @@ jobs:
                   # There is no check for a certain version of git
                   name: check git version
                   command: |
-                    ACTUAL_VERSION=$(docker compose run test-factory-all-included git --version)
+                    ACTUAL_VERSION=$(docker compose run --rm test-factory-all-included git --version)
                     echo "Version ${ACTUAL_VERSION} confirmed"
                   working_directory: factory/test-project
             - run:
                   name: check ssh version # We don't really care what version ssh has as long as the command doesn't error
                   command: |
-                    ACTUAL_VERSION=$(docker compose run test-factory-all-included ssh -V)
+                    ACTUAL_VERSION=$(docker compose run --rm test-factory-all-included ssh -V)
                     echo "Version ${ACTUAL_VERSION} confirmed"
                   working_directory: factory/test-project
     check-node-override-version:
@@ -163,7 +163,7 @@ jobs:
             - run:
                   name: check node version
                   command: |
-                    ACTUAL_VERSION=$(docker compose run test-factory-node-override node -v)
+                    ACTUAL_VERSION=$(docker compose run --rm test-factory-node-override node -v)
                     if [ v18.17.1 != "${ACTUAL_VERSION}" ]; then
                       echo "Version mismatch, v18.17.1 != ${ACTUAL_VERSION}"
                       exit 1;
@@ -197,7 +197,7 @@ jobs:
                   name: test
                   command: |
                     docker compose --progress plain build << parameters.test-target >>
-                    docker compose run << parameters.test-target >>
+                    docker compose run --rm << parameters.test-target >>
                   working_directory: factory/test-project
 
     push:

--- a/circle.yml
+++ b/circle.yml
@@ -52,7 +52,7 @@ commands:
 jobs:
     check-factory-versions:
         machine:
-            image: ubuntu-2204:2024.05.1
+            image: ubuntu-2204:2024.08.1
         steps:
             - checkout
             - expand-env-file
@@ -146,7 +146,7 @@ jobs:
                   working_directory: factory/test-project
     check-node-override-version:
         machine:
-            image: ubuntu-2204:2024.05.1
+            image: ubuntu-2204:2024.08.1
         steps:
             - checkout
             - expand-env-file
@@ -172,7 +172,7 @@ jobs:
                   working_directory: factory/test-project
     test-image:
         machine:
-            image: ubuntu-2204:2024.05.1
+            image: ubuntu-2204:2024.08.1
         parameters:
             target:
                 type: string
@@ -202,7 +202,7 @@ jobs:
 
     push:
         machine:
-            image: ubuntu-2204:2024.05.1
+            image: ubuntu-2204:2024.08.1
         parameters:
             target:
                 type: string


### PR DESCRIPTION
## Issue

- PR https://github.com/cypress-io/cypress-docker-images/pull/1163 updated the [circle.yml](https://github.com/cypress-io/cypress-docker-images/blob/master/circle.yml) workflow to use machine image `ubuntu-2204:2024.05.1` from [Circle CI Machine Images > ubuntu-2204](https://circleci.com/developer/machine/image/ubuntu-2204).

- The Docker Engine version [26.0.2](https://docs.docker.com/engine/release-notes/26.0/#2602) was released 5 months ago in April 2024. The latest CircleCI Ubuntu machine image `ubuntu-2204:2024.08.1` offers Docker Engine [26.1.4](https://docs.docker.com/engine/release-notes/26.1/#2614) (released in June 2024) according to the CircleCI posting [Ubuntu 20.04, 22.04, 24.04 - Q3 Edge Release](https://discuss.circleci.com/t/ubuntu-20-04-22-04-24-04-q3-edge-release/51699).

## Change

Update the [circle.yml](https://github.com/cypress-io/cypress-docker-images/blob/master/circle.yml) workflow from [ubuntu-2204:2024.05.1](https://discuss.circleci.com/t/new-ubuntu-24-04-linux-machine-executor-image/51018) to the latest version [ubuntu-2204:2024.08.1](https://discuss.circleci.com/t/ubuntu-20-04-22-04-24-04-q3-edge-release/51699).

Moving to [ubuntu-2204:2024.08.1](https://discuss.circleci.com/t/ubuntu-20-04-22-04-24-04-q3-edge-release/51699) updates the components as follows:

| Image tag                                                                                                   | Node.js   | Docker Engine                                                     | buildx                                                           | Status  |
| ----------------------------------------------------------------------------------------------------------- | --------- | ----------------------------------------------------------------- | ---------------------------------------------------------------- | ------- |
| [ubuntu-2204:2024.05.1](https://discuss.circleci.com/t/new-ubuntu-24-04-linux-machine-executor-image/51018) | `20.12.2` | [26.0.2](https://docs.docker.com/engine/release-notes/26.0/#2602) | [v0.14.0](https://github.com/docker/buildx/releases/tag/v0.14.0) | current |
| [ubuntu-2204:2024.08.1](https://discuss.circleci.com/t/ubuntu-20-04-22-04-24-04-q3-edge-release/51699)      | `20.16.0` | [26.1.4](https://docs.docker.com/engine/release-notes/26.1/#2614) | [v0.16.1](https://github.com/docker/buildx/releases/tag/v0.16.1) | future  |

This is a minor version update for Node.js `20.x`, a minor version update for Docker Engine `26.x` and a major functional update from Docker Buildx [v0.14.x](https://github.com/docker/buildx/releases/tag/v0.14.0) to [v0.16.1](https://github.com/docker/buildx/releases/tag/v0.16.1). Based on a review of the release notes, there is no impact expected for the Cypress Docker image build process.

Some failing checks caused by upgrading to [buildx v0.15.0](https://github.com/docker/buildx/releases/tag/v0.15.0) (which was also included in Docker Desktop [4.33.0](https://docs.docker.com/desktop/release-notes/#4330)) were already mitigated (see explanation in https://github.com/cypress-io/cypress-docker-images/issues/1186#issuecomment-2275303465).

To avoid new warnings, when `docker compose run` is used, the option `--rm` is now added. This prevents the creation of orphaned containers in jobs. These were warnings only and did not prevent job completion.