### PR TITLE
chore: correct ssh version output in circleci

### DIFF
--- a/circle.yml
+++ b/circle.yml
@@ -141,7 +141,7 @@ jobs:
             - run:
                   name: check ssh version # We don't really care what version ssh has as long as the command doesn't error
                   command: |
-                    ACTUAL_VERSION=$(docker compose run --rm test-factory-all-included ssh -V)
+                    ACTUAL_VERSION=$(docker compose run --rm test-factory-all-included ssh -V 2>&1)
                     echo "Version ${ACTUAL_VERSION} confirmed"
                   working_directory: factory/test-project
     check-node-override-version:


### PR DESCRIPTION
## Issue

The ssh version output in job `check-factory-versions`, step `check ssh version` in the [circle.yml](https://github.com/cypress-io/cypress-docker-images/blob/master/circle.yml) workflow is incorrectly formatted. See for instance https://app.circleci.com/pipelines/github/cypress-io/cypress-docker-images/2263/workflows/a3348dc7-4903-4dc9-807a-01b06f24fe90/jobs/69265/parallel-runs/0/steps/0-112

```text
OpenSSH_9.2p1 Debian-2+deb12u3, OpenSSL 3.0.14 4 Jun 2024
Version  confirmed
```

In the command

```shell
ACTUAL_VERSION=$(docker compose run test-factory-all-included ssh -V)
```

the output of `ssh -V` is sent to `stderr` where it is output directly and not fed into the environment variable `ACTUAL_VERSION`.

## Change

In the step `check ssh version` of the job `check-factory-versions` in the workflow [circle.yml](https://github.com/cypress-io/cypress-docker-images/blob/master/circle.yml), redirect `stderr` to `stdout` with `2>&1` in the command:

```shell
ACTUAL_VERSION=$(docker compose run test-factory-all-included ssh -V 2>&1)
```

## Verification

After the change, the `ssh` version output should be similar to:

```text
Version OpenSSH_9.2p1 Debian-2+deb12u3, OpenSSL 3.0.14 4 Jun 2024 confirmed
```

## Reference

Debian [1.5.8. Typical command sequences and shell redirection](https://www.debian.org/doc/manuals/debian-reference/ch01.en.html#_typical_command_sequences_and_shell_redirection)