### PR TITLE
chore: updates cypress to 13.15.0 and updates chrome and edge to latest

### DIFF
--- a/factory/.env
+++ b/factory/.env
@@ -21,13 +21,13 @@ NODE_VERSION="${FACTORY_DEFAULT_NODE_VERSION}"
 FACTORY_VERSION='4.2.0'
 
 # Chrome versions: https://www.ubuntuupdates.org/package/google_chrome/stable/main/base/google-chrome-stable
-CHROME_VERSION='128.0.6613.137-1'
+CHROME_VERSION='129.0.6668.70-1'
 
 # Cypress versions: https://www.npmjs.com/package/cypress
-CYPRESS_VERSION='13.14.2'
+CYPRESS_VERSION='13.15.0'
 
 # Edge versions: https://packages.microsoft.com/repos/edge/pool/main/m/microsoft-edge-stable/
-EDGE_VERSION='128.0.2739.67-1'
+EDGE_VERSION='129.0.2792.52-1'
 
 # Firefox versions: https://download-installer.cdn.mozilla.net/pub/firefox/releases/
 FIREFOX_VERSION='130.0.1'


### PR DESCRIPTION
updates cypress to 13.15.0 and updates chrome and edge to latest