### PR TITLE
fix(deps): rebuild factory with latest debian fixes

### DIFF
--- a/factory/.env
+++ b/factory/.env
@@ -18,7 +18,7 @@ NODE_VERSION="${FACTORY_DEFAULT_NODE_VERSION}"
 
 # Update the FACTORY_VERSION to deploy cypress/factory if you make changes to
 # BASE_IMAGE, FACTORY_DEFAULT_NODE_VERSION, YARN_VERSION, factory.Dockerfile or installScripts
-FACTORY_VERSION='4.2.0'
+FACTORY_VERSION='4.2.1'
 
 # Chrome versions: https://www.ubuntuupdates.org/package/google_chrome/stable/main/base/google-chrome-stable
 CHROME_VERSION='129.0.6668.70-1'

--- a/factory/CHANGELOG.md
+++ b/factory/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Change log
 
+## 4.2.1
+
+- Rebuilt factory with latest Debian `12.x` fixes. This removes the [CVE-2024-32002](https://nvd.nist.gov/vuln/detail/CVE-2024-32002), [CVE-2024-45490](https://nvd.nist.gov/vuln/detail/CVE-2024-45490), [CVE-2024-45491](https://nvd.nist.gov/vuln/detail/CVE-2024-45491) and [CVE-2024-45492](https://nvd.nist.gov/vuln/detail/CVE-2024-45492) vulnerabilities being reported in security scans. Addresses [#1217](https://github.com/cypress-io/cypress-docker-images/issues/1217) for `cypress/factory`.
+
 ## 4.2.0
 
 - Updated Debian base to `debian:12.7-slim` using [Debian 12.7](https://www.debian.org/News/2024/20240831), released on Aug 31, 2024. Addresses [#1207](https://github.com/cypress-io/cypress-docker-images/issues/1207)


### PR DESCRIPTION
- relates to https://github.com/cypress-io/cypress-docker-images/issues/1217

## Issue

Concerning

| Image           | Debian | Published    | Version |
| --------------- | ------ | ------------ | ------- |
| cypress/factory | `12.7` | Sep 10, 2024 | `4.2.0` |

```shell
trivy image --ignore-unfixed --pkg-types os --scanners vuln --severity CRITICAL cypress/factory:latest
```

reports critical fixed issues not yet installed

```text
cypress/factory:latest (debian 12.7)

Total: 5 (CRITICAL: 5)

┌───────────┬────────────────┬──────────┬────────┬───────────────────┬────────────────────┬─────────────────────────────────────────────────────────────┐
│  Library  │ Vulnerability  │ Severity │ Status │ Installed Version │   Fixed Version    │                            Title                            │
├───────────┼────────────────┼──────────┼────────┼───────────────────┼────────────────────┼─────────────────────────────────────────────────────────────┤
│ git       │ CVE-2024-32002 │ CRITICAL │ fixed  │ 1:2.39.2-1.1      │ 1:2.39.5-0+deb12u1 │ git: Recursive clones RCE                                   │
│           │                │          │        │                   │                    │ https://avd.aquasec.com/nvd/cve-2024-32002                  │
├───────────┤                │          │        │                   │                    │                                                             │
│ git-man   │                │          │        │                   │                    │                                                             │
│           │                │          │        │                   │                    │                                                             │
├───────────┼────────────────┤          │        ├───────────────────┼────────────────────┼─────────────────────────────────────────────────────────────┤
│ libexpat1 │ CVE-2024-45490 │          │        │ 2.5.0-1           │ 2.5.0-1+deb12u1    │ libexpat: Negative Length Parsing Vulnerability in libexpat │
│           │                │          │        │                   │                    │ https://avd.aquasec.com/nvd/cve-2024-45490                  │
│           ├────────────────┤          │        │                   │                    ├─────────────────────────────────────────────────────────────┤
│           │ CVE-2024-45491 │          │        │                   │                    │ libexpat: Integer Overflow or Wraparound                    │
│           │                │          │        │                   │                    │ https://avd.aquasec.com/nvd/cve-2024-45491                  │
│           ├────────────────┤          │        │                   │                    ├─────────────────────────────────────────────────────────────┤
│           │ CVE-2024-45492 │          │        │                   │                    │ libexpat: integer overflow                                  │
│           │                │          │        │                   │                    │ https://avd.aquasec.com/nvd/cve-2024-45492                  │
└───────────┴────────────────┴──────────┴────────┴───────────────────┴────────────────────┴─────────────────────────────────────────────────────────────┘
```

## Change

Bump [factory/.env](https://github.com/cypress-io/cypress-docker-images/blob/master/factory/.env) environment variable `FACTORY_VERSION` from `4.2.0` to `4.2.1` to rebuild `cypress/factory` and incorporate all Debian `12.x` published fixes from the Debian repository.

## Verify

```shell
cd factory
docker compose build factory
trivy image --ignore-unfixed --pkg-types os --scanners vuln --severity CRITICAL cypress/factory:4.2.1
docker run -it --rm cypress/factory:4.2.1
```

should show

```text
cypress/factory:4.2.1 (debian 12.7)

Total: 0 (CRITICAL: 0)
```

```shell
git --version
apt list git
apt list git-man
apt list libexpat1
```

should show versions according to "After" column:

| Package     | Before                                                      | After                                                                       |
| ----------- | ----------------------------------------------------------- | --------------------------------------------------------------------------- |
| `git`       | `git version 2.39.2`                                        | `git version 2.39.5`                                                        |
| `git`       | `git/stable,now 1:2.39.2-1.1 amd64 [installed]`             | `git/stable-security,now 1:2.39.5-0+deb12u1 amd64 [installed]`              |
| `git-man`   | `git-man/stable,now 1:2.39.2-1.1 all [installed,automatic]` | `git-man/stable-security,now 1:2.39.5-0+deb12u1 all [installed,automatic]`  |
| `libexpat1` | `libexpat1/stable,now 2.5.0-1 amd64 [installed,automatic]`  | `libexpat1/stable-security,now 2.5.0-1+deb12u1 amd64 [installed,automatic]` |
