### PR TITLE
fix(deps): browsers and included rebuild on factory:4.2.1

### DIFF
--- a/factory/.env
+++ b/factory/.env
@@ -27,7 +27,7 @@ CHROME_VERSION='129.0.6668.70-1'
 CYPRESS_VERSION='13.15.0'
 
 # Edge versions: https://packages.microsoft.com/repos/edge/pool/main/m/microsoft-edge-stable/
-EDGE_VERSION='129.0.2792.52-1'
+EDGE_VERSION='129.0.2792.65-1'
 
 # Firefox versions: https://download-installer.cdn.mozilla.net/pub/firefox/releases/
 FIREFOX_VERSION='130.0.1'


### PR DESCRIPTION
- relates to https://github.com/cypress-io/cypress-docker-images/issues/1217

## Issue

Concerning

| Image            | Debian | Published    | Version                                                               |
| ---------------- | ------ | ------------ | --------------------------------------------------------------------- |
| cypress/browsers | `12.7` | Sep 25, 2024 | `node-20.17.0-chrome-129.0.6668.70-1-ff-130.0.1-edge-129.0.2792.52-1` |
| cypress/included | `12.7` | Sep 25, 2024 | `13.15.0`                                                             |


```shell
trivy image --ignore-unfixed --pkg-types os --scanners vuln --severity CRITICAL cypress/browsers:latest
trivy image --ignore-unfixed --pkg-types os --scanners vuln --severity CRITICAL cypress/included:latest
```

reports critical fixed issues not yet installed

```text
cypress/browsers:latest (debian 12.7)

Total: 5 (CRITICAL: 5)

┌───────────┬────────────────┬──────────┬────────┬───────────────────┬────────────────────┬─────────────────────────────────────────────────────────────┐
│  Library  │ Vulnerability  │ Severity │ Status │ Installed Version │   Fixed Version    │                            Title                            │
├───────────┼────────────────┼──────────┼────────┼───────────────────┼────────────────────┼─────────────────────────────────────────────────────────────┤
│ git       │ CVE-2024-32002 │ CRITICAL │ fixed  │ 1:2.39.2-1.1      │ 1:2.39.5-0+deb12u1 │ git: Recursive clones RCE                                   │
│           │                │          │        │                   │                    │ https://avd.aquasec.com/nvd/cve-2024-32002                  │
├───────────┤                │          │        │                   │                    │                                                             │
│ git-man   │                │          │        │                   │                    │                                                             │
│           │                │          │        │                   │                    │                                                             │
├───────────┼────────────────┤          │        ├───────────────────┼────────────────────┼─────────────────────────────────────────────────────────────┤
│ libexpat1 │ CVE-2024-45490 │          │        │ 2.5.0-1           │ 2.5.0-1+deb12u1    │ libexpat: Negative Length Parsing Vulnerability in libexpat │
│           │                │          │        │                   │                    │ https://avd.aquasec.com/nvd/cve-2024-45490                  │
│           ├────────────────┤          │        │                   │                    ├─────────────────────────────────────────────────────────────┤
│           │ CVE-2024-45491 │          │        │                   │                    │ libexpat: Integer Overflow or Wraparound                    │
│           │                │          │        │                   │                    │ https://avd.aquasec.com/nvd/cve-2024-45491                  │
│           ├────────────────┤          │        │                   │                    ├─────────────────────────────────────────────────────────────┤
│           │ CVE-2024-45492 │          │        │                   │                    │ libexpat: integer overflow                                  │
│           │                │          │        │                   │                    │ https://avd.aquasec.com/nvd/cve-2024-45492                  │
└───────────┴────────────────┴──────────┴────────┴───────────────────┴────────────────────┴─────────────────────────────────────────────────────────────┘
```

```text
cypress/included:latest (debian 12.7)

Total: 5 (CRITICAL: 5)

...
(as above for cypress/browsers:latest)
```

## Change

In [factory/.env](https://github.com/cypress-io/cypress-docker-images/blob/master/factory/.env), bump environment variable

- `EDGE_VERSION` from `129.0.2792.52-1` to `129.0.2792.65-1`
    (see https://packages.microsoft.com/repos/edge/pool/main/m/microsoft-edge-stable/)

to rebuild `cypress/browsers` and `cypress/included` based on `cypress/factory:4.2.1`, which includes Debian `12.x` published fixes from the Debian repository.

## Verify

```shell
cd factory
docker pull cypress/factory:4.2.1
docker compose build browsers
trivy image --ignore-unfixed --pkg-types os --scanners vuln --severity CRITICAL cypress/browsers
docker compose build included
trivy image --ignore-unfixed --pkg-types os --scanners vuln --severity CRITICAL cypress/included:latest
```

should show

```text
cypress/browsers (debian 12.7)

Total: 0 (CRITICAL: 0)

cypress/included (debian 12.7)

Total: 0 (CRITICAL: 0)
```
