### PR TITLE
fix(deps): update to node.js 20.18.0

### DIFF
--- a/factory/.env
+++ b/factory/.env
@@ -11,26 +11,26 @@ BASE_IMAGE='debian:12.7-slim'
 # Node Versions: https://nodejs.org/en/download/releases/
 # master branch needs "Active LTS" version
 # use feature branch for "Maintenance LTS" or "Current" versions
-FACTORY_DEFAULT_NODE_VERSION='20.17.0'
+FACTORY_DEFAULT_NODE_VERSION='20.18.0'
 
 # Node Versions: https://nodejs.org/en/download/releases/
 NODE_VERSION="${FACTORY_DEFAULT_NODE_VERSION}"
 
 # Update the FACTORY_VERSION to deploy cypress/factory if you make changes to
 # BASE_IMAGE, FACTORY_DEFAULT_NODE_VERSION, YARN_VERSION, factory.Dockerfile or installScripts
-FACTORY_VERSION='4.2.1'
+FACTORY_VERSION='4.2.2'
 
 # Chrome versions: https://www.ubuntuupdates.org/package/google_chrome/stable/main/base/google-chrome-stable
-CHROME_VERSION='129.0.6668.70-1'
+CHROME_VERSION='129.0.6668.89-1'
 
 # Cypress versions: https://www.npmjs.com/package/cypress
 CYPRESS_VERSION='13.15.0'
 
 # Edge versions: https://packages.microsoft.com/repos/edge/pool/main/m/microsoft-edge-stable/
-EDGE_VERSION='129.0.2792.52-1'
+EDGE_VERSION='129.0.2792.65-1'
 
 # Firefox versions: https://download-installer.cdn.mozilla.net/pub/firefox/releases/
-FIREFOX_VERSION='130.0.1'
+FIREFOX_VERSION='131.0'
 
 # Yarn versions: https://www.npmjs.com/package/yarn and
 # https://classic.yarnpkg.com/latest-version

--- a/factory/CHANGELOG.md
+++ b/factory/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Change log
 
+## 4.2.2
+
+- Updated default node version from `20.17.0` to `20.18.0`. Addresses [#1217](https://github.com/cypress-io/cypress-docker-images/issues/1217) for `cypress/base`, `cypress/browsers` and `cypress/included`.
+
 ## 4.2.1
 
 - Rebuilt factory with latest Debian `12.x` fixes. This removes the [CVE-2024-32002](https://nvd.nist.gov/vuln/detail/CVE-2024-32002), [CVE-2024-45490](https://nvd.nist.gov/vuln/detail/CVE-2024-45490), [CVE-2024-45491](https://nvd.nist.gov/vuln/detail/CVE-2024-45491) and [CVE-2024-45492](https://nvd.nist.gov/vuln/detail/CVE-2024-45492) vulnerabilities being reported in security scans. Addresses [#1217](https://github.com/cypress-io/cypress-docker-images/issues/1217) for `cypress/factory`.


### PR DESCRIPTION
- closes https://github.com/cypress-io/cypress-docker-images/issues/1217

## Issue

Concerning

| Image            | Debian | Published    | Version                                                               |
| ---------------- | ------ | ------------ | --------------------------------------------------------------------- |
| cypress/base     | `12.6` | Aug 26, 2024 | `20.17.0`                                                             |
| cypress/browsers | `12.7` | Sep 25, 2024 | `node-20.17.0-chrome-129.0.6668.70-1-ff-130.0.1-edge-129.0.2792.52-1` |
| cypress/included | `12.7` | Sep 25, 2024 | `13.15.0`                                                             |


```shell
trivy image --ignore-unfixed --pkg-types os --scanners vuln --severity CRITICAL cypress/base:latest
trivy image --ignore-unfixed --pkg-types os --scanners vuln --severity CRITICAL cypress/browsers:latest
trivy image --ignore-unfixed --pkg-types os --scanners vuln --severity CRITICAL cypress/included:latest
```

reports critical fixed issues not yet installed, for example with `cypress/base:latest`:

```text
cypress/base:latest (debian 12.7)

Total: 5 (CRITICAL: 5)

┌───────────┬────────────────┬──────────┬────────┬───────────────────┬────────────────────┬─────────────────────────────────────────────────────────────┐
│  Library  │ Vulnerability  │ Severity │ Status │ Installed Version │   Fixed Version    │                            Title                            │
├───────────┼────────────────┼──────────┼────────┼───────────────────┼────────────────────┼─────────────────────────────────────────────────────────────┤
│ git       │ CVE-2024-32002 │ CRITICAL │ fixed  │ 1:2.39.2-1.1      │ 1:2.39.5-0+deb12u1 │ git: Recursive clones RCE                                   │
│           │                │          │        │                   │                    │ https://avd.aquasec.com/nvd/cve-2024-32002                  │
├───────────┤                │          │        │                   │                    │                                                             │
│ git-man   │                │          │        │                   │                    │                                                             │
│           │                │          │        │                   │                    │                                                             │
├───────────┼────────────────┤          │        ├───────────────────┼────────────────────┼─────────────────────────────────────────────────────────────┤
│ libexpat1 │ CVE-2024-45490 │          │        │ 2.5.0-1           │ 2.5.0-1+deb12u1    │ libexpat: Negative Length Parsing Vulnerability in libexpat │
│           │                │          │        │                   │                    │ https://avd.aquasec.com/nvd/cve-2024-45490                  │
│           ├────────────────┤          │        │                   │                    ├─────────────────────────────────────────────────────────────┤
│           │ CVE-2024-45491 │          │        │                   │                    │ libexpat: Integer Overflow or Wraparound                    │
│           │                │          │        │                   │                    │ https://avd.aquasec.com/nvd/cve-2024-45491                  │
│           ├────────────────┤          │        │                   │                    ├─────────────────────────────────────────────────────────────┤
│           │ CVE-2024-45492 │          │        │                   │                    │ libexpat: integer overflow                                  │
│           │                │          │        │                   │                    │ https://avd.aquasec.com/nvd/cve-2024-45492                  │
└───────────┴────────────────┴──────────┴────────┴───────────────────┴────────────────────┴─────────────────────────────────────────────────────────────┘
```

## Change

In [factory/.env](https://github.com/cypress-io/cypress-docker-images/blob/master/factory/.env), bump environment variables:

- `FACTORY_VERSION` from `4.2.1` to `4.2.2`
- `FACTORY_DEFAULT_NODE_VERSION` from `20.17.0` to `20.18.0`
    (see https://nodejs.org/en/download/releases/)
- `CHROME_VERSION` from `129.0.6668.70-1` to `129.0.6668.89-1`
    (see https://www.ubuntuupdates.org/package/google_chrome/stable/main/base/google-chrome-stable)
- `EDGE_VERSION` from `129.0.2792.52-1` to `129.0.2792.65-1`
    (see https://packages.microsoft.com/repos/edge/pool/main/m/microsoft-edge-stable/)
- `FIREFOX_VERSION` from `130.0.1` to `131.0`
    (see https://download-installer.cdn.mozilla.net/pub/firefox/releases/)

to rebuild all images including latest Debian `12.x` published fixes from the Debian repository.

## Verify

```shell
cd factory
docker compose build factory
trivy image --ignore-unfixed --pkg-types os --scanners vuln --severity CRITICAL cypress/factory
docker compose build base
trivy image --ignore-unfixed --pkg-types os --scanners vuln --severity CRITICAL cypress/base
docker compose build browsers
trivy image --ignore-unfixed --pkg-types os --scanners vuln --severity CRITICAL cypress/browsers
docker compose build included
trivy image --ignore-unfixed --pkg-types os --scanners vuln --severity CRITICAL cypress/included:latest
```

should show for each image variant that there are no longer any (critical) vulnerabilities:

```text
Total: 0 (CRITICAL: 0)
```
