### PR TITLE
docs: prevent orphaned containers testing locally

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -50,7 +50,7 @@ cd test-project
 set -a && . ../.env && set +a
 
 # run the test in an image built on top of the factory.
-docker compose run test-factory-all-included
+docker compose run --rm test-factory-all-included
 ```
 
 ### Publishing images


### PR DESCRIPTION
## Issue

When following the instructions in [CONTRIBUTING > Building locally](https://github.com/cypress-io/cypress-docker-images/blob/master/CONTRIBUTING.md#building-locally), shown condensed below, using [Docker Desktop 4.33.0](https://docs.docker.com/desktop/release-notes/#4330) and above, repeating the `docker compose run` command leads to a warning "Found orphan containers"

**Instructions**

```shell
cd factory
docker compose build factory
docker compose build included
cd test-project
set -a && . ../.env && set +a
docker compose run test-factory-all-included
```

**Warning**

> WARN[0000] Found orphan containers ([test-project-test-factory-all-included-run-fbb451183daf]) for this project. If you removed or renamed this service in your compose file, you can run this command with the --remove-orphans flag to clean it up.

## Change

In [CONTRIBUTING > Building locally](https://github.com/cypress-io/cypress-docker-images/blob/master/CONTRIBUTING.md#building-locally) change the instruction to the following, using the [option](https://docs.docker.com/reference/cli/docker/compose/run/#options) `--rm` (Automatically remove the container when it exits), to avoid leaving an orphaned container behind:

```shell
docker compose run --rm test-factory-all-included
```
