### PR TITLE
chore: create a 20.15 buster image that can be used for building better sqlite3

### DIFF
--- a/base-internal/releases/node-20/20.15.0-buster-python3.8-gcc-10.5/Dockerfile
+++ b/base-internal/releases/node-20/20.15.0-buster-python3.8-gcc-10.5/Dockerfile
@@ -1,0 +1,51 @@
+# build it with command
+#   docker build -t cypress/base-internal:20.15.0-buster-python3.8-gcc-10.5 --platform linux/amd64 .
+#
+FROM cypress/base-internal:20.15.0-buster
+
+RUN apt-get update && \
+  apt-get install -y \
+  wget \
+  xz-utils \
+  bzip2 \
+  make \
+  autoconf \
+  gcc-multilib \
+  g++-multilib \
+  # clean up
+  && rm -rf /var/lib/apt/lists/* \
+  && apt-get clean
+
+
+# Install GCC 10.5. Note that there may be ways to optimize this
+# but it is functional and takes a long time to build (over 8 hours)
+# so it is not worth optimizing for now
+RUN wget https://ftp.gnu.org/gnu/gcc/gcc-10.5.0/gcc-10.5.0.tar.gz \
+  && tar xf gcc-10.5.0.tar.gz \
+  && cd gcc-10.5.0 \
+  && wget https://gmplib.org/download/gmp/gmp-6.2.0.tar.xz \
+  && tar xf gmp-6.2.0.tar.xz \
+  && mv gmp-6.2.0 gmp \
+  && wget https://ftp.gnu.org/gnu/mpfr/mpfr-4.1.0.tar.gz \
+  && tar xf mpfr-4.1.0.tar.gz \
+  && mv mpfr-4.1.0 mpfr \
+  && wget ftp://ftp.gnu.org/gnu/mpc/mpc-1.2.1.tar.gz \
+  && tar xf mpc-1.2.1.tar.gz \
+  && mv mpc-1.2.1 mpc \
+  && wget ftp://gcc.gnu.org/pub/gcc/infrastructure/isl-0.18.tar.bz2 \
+  && tar xf isl-0.18.tar.bz2 \
+  && mv isl-0.18 isl \
+  && ./configure --prefix=/usr --enable-languages=c,c++ \
+  && make -j$(nproc) \
+  && make install
+  
+# Clean up
+RUN rm -rf gcc-10.5.0 gcc-10.5.0.tar.gz
+
+# Install Python 3.8
+RUN wget https://www.python.org/ftp/python/3.8.0/Python-3.8.0.tgz
+RUN tar xvf Python-3.8.0.tgz
+RUN cd Python-3.8.0 && ./configure --enable-optimizations --prefix=/usr && make altinstall
+RUN rm /usr/bin/python3 && ln -s /usr/bin/python3.8 /usr/bin/python3
+# Clean up
+RUN rm -rf Python-3.8.0 Python-3.8.0.tgz

--- a/base-internal/releases/node-20/20.15.0-buster-python3.8-gcc-10.5/README.md
+++ b/base-internal/releases/node-20/20.15.0-buster-python3.8-gcc-10.5/README.md
@@ -1,0 +1,15 @@
+# cypress/base-internal:20.15.0-buster-python3.8-gcc-10.5
+
+A Docker image with all dependencies pre-installed.
+
+NOTE: This image is intended for internal use with https://github.com/cypress-io/cypress. It contains a few differences from the factory, such as:
+
+#### Dependency Additions
+
+- xauth (to run xvfb inside system-tests)
+- build-essential to install `make` and other linux build packages
+- python3.8 and gcc-10.5 to be able to build better-sqlite3
+
+#### Env variables
+
+- Does not contain the `CACHE_FOLDER` and `FACTORY_DEFAULT_NODE_VERSION` env variables to keep unit tests non environment specific

--- a/base-internal/releases/node-20/20.15.0-buster-python3.8-gcc-10.5/build.sh
+++ b/base-internal/releases/node-20/20.15.0-buster-python3.8-gcc-10.5/build.sh
@@ -1,0 +1,7 @@
+set e+x
+
+# build image with Cypress dependencies
+LOCAL_NAME=cypress/base-internal:20.15.0-buster-python3.8-gcc-10.5
+
+echo "Building $LOCAL_NAME"
+docker build -t $LOCAL_NAME .


### PR DESCRIPTION
The goal here is to have a buster image that is capable of building better sqlite3. For that we need:

- gcc-10
- g++-10
- python 3.8

We will still use the existing buster image for testing the built binary to ensure that the binary can still work on glibc 2.28.