### PR TITLE
feat: add Node.js GPG key for Antoine du Hamel

### DIFF
--- a/factory/.env
+++ b/factory/.env
@@ -18,7 +18,7 @@ NODE_VERSION="${FACTORY_DEFAULT_NODE_VERSION}"
 
 # Update the FACTORY_VERSION to deploy cypress/factory if you make changes to
 # BASE_IMAGE, FACTORY_DEFAULT_NODE_VERSION, YARN_VERSION, factory.Dockerfile or installScripts
-FACTORY_VERSION='4.2.2'
+FACTORY_VERSION='4.3.0'
 
 # Chrome versions: https://www.ubuntuupdates.org/package/google_chrome/stable/main/base/google-chrome-stable
 CHROME_VERSION='129.0.6668.89-1'

--- a/factory/CHANGELOG.md
+++ b/factory/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Change log
 
+## 4.3.0
+
+- Add the [Node.js release key](https://github.com/nodejs/node/blob/main/README.md#release-keys) for Antoine du Hamel duhamelantoine1995@gmail.com `C0D6248439F1D5604AAFFB4021D900FFDB233756`. Addresses [#1234](https://github.com/cypress-io/cypress-docker-images/issues/1234).
+
 ## 4.2.2
 
 - Updated default node version from `20.17.0` to `20.18.0`. Addresses [#1217](https://github.com/cypress-io/cypress-docker-images/issues/1217) for `cypress/base`, `cypress/browsers` and `cypress/included`.

--- a/factory/installScripts/node/default.sh
+++ b/factory/installScripts/node/default.sh
@@ -4,6 +4,7 @@ groupadd --gid 1000 node \
   && useradd --uid 1000 --gid node --shell /bin/bash --create-home node
 
 # The following is borrowed from https://github.com/nodejs/docker-node/blob/main/20/bookworm-slim/Dockerfile
+# Node.js GPG keys are taken from https://github.com/nodejs/node/
 ARCH= && dpkgArch="$(dpkg --print-architecture)" \
     && case "${dpkgArch##*-}" in \
       amd64) ARCH='x64';; \
@@ -31,6 +32,7 @@ ARCH= && dpkgArch="$(dpkg --print-architecture)" \
       C82FA3AE1CBEDC6BE46B9360C43CEC45C17AB93C \
       108F52B48DB57BB0CC439B2997B01419BD92F80A \
       A363A499291CBBC940DD62E41F10027AF002F8B0 \
+      C0D6248439F1D5604AAFFB4021D900FFDB233756 \
     ; do \
       gpg --batch --keyserver hkps://keys.openpgp.org --recv-keys "$key" || \
       gpg --batch --keyserver keyserver.ubuntu.com --recv-keys "$key" ; \


### PR DESCRIPTION
- closes https://github.com/cypress-io/cypress-docker-images/issues/1234

## Issue

The signature of [Node.js v22.10.0 (current)](https://nodejs.org/en/blog/release/v22.10.0) cannot be checked because it was published by Antoine du Hamel (on Oct 16, 2024) and his new signature from [Node.js release key](https://github.com/nodejs/node/blob/main/README.md#release-keys) is missing from `cypress/factory`.

## Change

Add the [Node.js release key](https://github.com/nodejs/node/blob/main/README.md#release-keys) for

> Antoine du Hamel <duhamelantoine1995@gmail.com> `C0D6248439F1D5604AAFFB4021D900FFDB233756`

to [factory/installScripts/node/default.sh](https://github.com/cypress-io/cypress-docker-images/blob/master/factory/installScripts/node/default.sh) and bump the `FACTORY_VERSION` to `4.3.0`

## Verification

```shell
cd factory
docker compose build factory
export NODE_VERSION='22.10.0'
docker compose build base
```

Confirm that both images build without error.