### PR TITLE
chore: update factory to browser latest and bump cypress version to 13.15.1

### DIFF
--- a/factory/.env
+++ b/factory/.env
@@ -21,16 +21,16 @@ NODE_VERSION="${FACTORY_DEFAULT_NODE_VERSION}"
 FACTORY_VERSION='4.3.0'
 
 # Chrome versions: https://www.ubuntuupdates.org/package/google_chrome/stable/main/base/google-chrome-stable
-CHROME_VERSION='129.0.6668.89-1'
+CHROME_VERSION='130.0.6723.69-1'
 
 # Cypress versions: https://www.npmjs.com/package/cypress
-CYPRESS_VERSION='13.15.0'
+CYPRESS_VERSION='13.15.1'
 
 # Edge versions: https://packages.microsoft.com/repos/edge/pool/main/m/microsoft-edge-stable/
-EDGE_VERSION='129.0.2792.65-1'
+EDGE_VERSION='130.0.2849.52-1'
 
 # Firefox versions: https://download-installer.cdn.mozilla.net/pub/firefox/releases/
-FIREFOX_VERSION='131.0.2'
+FIREFOX_VERSION='131.0.3'
 
 # Yarn versions: https://www.npmjs.com/package/yarn and
 # https://classic.yarnpkg.com/latest-version


### PR DESCRIPTION
In the Cypress Docker Factory:
- updates Chrome to `130.0.6723.69-1`
- updates Edge to `130.0.2849.52-1`
- updates Firefox to `131.0.3`
- bumps Cypress to `13.15.1`