### PR TITLE
feat(deps): update to active lts node.js 22.11.0

### DIFF
--- a/factory/.env
+++ b/factory/.env
@@ -11,14 +11,14 @@ BASE_IMAGE='debian:12.7-slim'
 # Node Versions: https://nodejs.org/en/download/releases/
 # master branch needs "Active LTS" version
 # use feature branch for "Maintenance LTS" or "Current" versions
-FACTORY_DEFAULT_NODE_VERSION='20.18.0'
+FACTORY_DEFAULT_NODE_VERSION='22.11.0'
 
 # Node Versions: https://nodejs.org/en/download/releases/
 NODE_VERSION="${FACTORY_DEFAULT_NODE_VERSION}"
 
 # Update the FACTORY_VERSION to deploy cypress/factory if you make changes to
 # BASE_IMAGE, FACTORY_DEFAULT_NODE_VERSION, YARN_VERSION, factory.Dockerfile or installScripts
-FACTORY_VERSION='4.3.0'
+FACTORY_VERSION='5.0.0'
 
 # Chrome versions: https://www.ubuntuupdates.org/package/google_chrome/stable/main/base/google-chrome-stable
 CHROME_VERSION='130.0.6723.69-1'
@@ -27,10 +27,10 @@ CHROME_VERSION='130.0.6723.69-1'
 CYPRESS_VERSION='13.15.1'
 
 # Edge versions: https://packages.microsoft.com/repos/edge/pool/main/m/microsoft-edge-stable/
-EDGE_VERSION='130.0.2849.52-1'
+EDGE_VERSION='130.0.2849.56-1'
 
 # Firefox versions: https://download-installer.cdn.mozilla.net/pub/firefox/releases/
-FIREFOX_VERSION='131.0.3'
+FIREFOX_VERSION='132.0'
 
 # Yarn versions: https://www.npmjs.com/package/yarn and
 # https://classic.yarnpkg.com/latest-version

--- a/factory/CHANGELOG.md
+++ b/factory/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Change log
 
+## 5.0.0
+
+- Updated default node version from `20.18.0` (`Iron` - Maintenance LTS) to `22.11.0` (`Jod` - Active LTS) - see [Blog v22.11.0](https://nodejs.org/en/blog/release/v22.11.0). Addresses [#1239]https://github.com/cypress-io/cypress-docker-images/issues/1239).
+
 ## 4.3.0
 
 - Add the [Node.js release key](https://github.com/nodejs/node/blob/main/README.md#release-keys) for Antoine du Hamel duhamelantoine1995@gmail.com `C0D6248439F1D5604AAFFB4021D900FFDB233756`. Addresses [#1234](https://github.com/cypress-io/cypress-docker-images/issues/1234).


### PR DESCRIPTION
- closes https://github.com/cypress-io/cypress-docker-images/issues/1239

## Issue

Today, Oct 29, 2024 Node.js `22.x` transitioned from Current status into Active Long Term Support (LTS) status with the release of [Node.js 22.11.0](https://nodejs.org/en/blog/release/v22.11.0), codename 'Jod'.

Node.js `20.x` previously transitioned from Active LTS to Maintenance LTS status on Oct 22, 2024 (see [Node.js release schedule](https://github.com/nodejs/release#release-schedule)).

[factory/.env](https://github.com/cypress-io/cypress-docker-images/blob/master/factory/.env) currently calls out `FACTORY_DEFAULT_NODE_VERSION='20.18.0'` referring to what is now a Node.js Maintenance LTS version.

## Change

In [factory/.env](https://github.com/cypress-io/cypress-docker-images/blob/master/factory/.env) bump the following versions:

- `FACTORY_VERSION` from `4.3.0` to `5.0.0`
- `FACTORY_DEFAULT_NODE_VERSION` from `20.18.0` to `22.11.0`

also bump browser versions:

- `EDGE_VERSION` from `130.0.2849.52-1` to `130.0.2849.56-1`
- `FIREFOX_VERSION` from `131.0.2` to `132.0`

## Verification

```shell
cd factory
docker compose build factory
cd test-project
set -a && . ../.env && set +a
docker image rm test-project-test-factory-all-included
docker compose run --rm test-factory-all-included
```

Confirm that Docker images build and that tests run without error, excepting warnings from known issues including:


- https://github.com/cypress-io/cypress/issues/29554
    > error: XDG_RUNTIME_DIR is invalid or not set in the environment.
