### PR TITLE
test: update github-actions example to ubuntu-24.04 runner

### DIFF
--- a/.github/workflows/example-cypress-github-action.yml
+++ b/.github/workflows/example-cypress-github-action.yml
@@ -13,7 +13,7 @@ on: workflow_dispatch
 
 jobs:
   docker-base:
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-24.04
     container:
       # Examples use latest tag
       # For production use, to avoid the risk of breaking changes,
@@ -32,7 +32,7 @@ jobs:
           working-directory: examples/basic
 
   docker-browsers:
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-24.04
     strategy:
       # Makes sure that each browser test runs, even if any other test fails
       fail-fast: false
@@ -53,7 +53,7 @@ jobs:
           browser: ${{ matrix.browser }}
 
   docker-included:
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-24.04
     strategy:
       fail-fast: false
       matrix:


### PR DESCRIPTION
## Issue

The example workflow [.github/workflows/example-cypress-github-action.yml](https://github.com/cypress-io/cypress-docker-images/blob/master/.github/workflows/example-cypress-github-action.yml) runs jobs in the GitHub-hosted runner [ubuntu-22.04](https://github.com/actions/runner-images/blob/main/images/ubuntu/Ubuntu2204-Readme.md).

Ubuntu `24.04.1` LTS (Noble Numbat) is the latest [Ubuntu release](https://wiki.ubuntu.com/Releases) in the Long Term Support (LTS) category and is available as a GitHub-hosted runner [ubuntu-24.04](https://github.com/actions/runner-images/blob/main/images/ubuntu/Ubuntu2404-Readme.md).

## Change

Update the example workflow [.github/workflows/example-cypress-github-action.yml](https://github.com/cypress-io/cypress-docker-images/blob/master/.github/workflows/example-cypress-github-action.yml) to run jobs in the GitHub-hosted runner [ubuntu-24.04](https://github.com/actions/runner-images/blob/main/images/ubuntu/Ubuntu2404-Readme.md).