### PR TITLE
docs: correct contributing test steps

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -50,7 +50,7 @@ cd test-project
 set -a && . ../.env && set +a
 
 # run the test in an image built on top of the factory.
-docker compose run --rm test-factory-all-included
+docker compose run --build --rm test-factory-all-included
 ```
 
 ### Publishing images


### PR DESCRIPTION
## Issue

When running test steps defined in [CONTRIBUTING > Building locally](https://github.com/cypress-io/cypress-docker-images/blob/master/CONTRIBUTING.md#building-locally), the command

```shell
docker compose run --rm test-factory-all-included
```

will use an image `test-project-test-factory-all-included`, if it exists from previous tests, to run new tests. This ignores parameters in [factory/.env](https://github.com/cypress-io/cypress-docker-images/blob/master/factory/.env) and so any changed parameters are not tested in this case, leading to unexpected results.

## Change

In [CONTRIBUTING > Building locally](https://github.com/cypress-io/cypress-docker-images/blob/master/CONTRIBUTING.md#building-locally) add the `--build` option to `docker compose run`, so the command becomes:

```shell
docker compose run --build --rm test-factory-all-included
```

This ensures that a new image `test-project-test-factory-all-included` is built if any parameters from [factory/.env](https://github.com/cypress-io/cypress-docker-images/blob/master/factory/.env) have changed. If no parameters have changed and the Docker cache has been preserved, the image will rebuild from cache.
