### PR TITLE
chore: Cypress 13.15.2 release

### DIFF
--- a/factory/.env
+++ b/factory/.env
@@ -21,16 +21,16 @@ NODE_VERSION="${FACTORY_DEFAULT_NODE_VERSION}"
 FACTORY_VERSION='5.0.0'
 
 # Chrome versions: https://www.ubuntuupdates.org/package/google_chrome/stable/main/base/google-chrome-stable
-CHROME_VERSION='130.0.6723.69-1'
+CHROME_VERSION='130.0.6723.116-1'
 
 # Cypress versions: https://www.npmjs.com/package/cypress
-CYPRESS_VERSION='13.15.1'
+CYPRESS_VERSION='13.15.2'
 
 # Edge versions: https://packages.microsoft.com/repos/edge/pool/main/m/microsoft-edge-stable/
-EDGE_VERSION='130.0.2849.56-1'
+EDGE_VERSION='130.0.2849.68-1'
 
 # Firefox versions: https://download-installer.cdn.mozilla.net/pub/firefox/releases/
-FIREFOX_VERSION='132.0'
+FIREFOX_VERSION='132.0.1'
 
 # Yarn versions: https://www.npmjs.com/package/yarn and
 # https://classic.yarnpkg.com/latest-version


### PR DESCRIPTION
updates Cypress to `13.15.2`
updates Chrome to `130.0.6723.116-1`
updates Edge to `130.0.2849.68-1`
updates Firefox to `132.0.1`