### PR TITLE
chore: Cypress 13.16.0 release

### DIFF
--- a/factory/.env
+++ b/factory/.env
@@ -21,16 +21,16 @@ NODE_VERSION="${FACTORY_DEFAULT_NODE_VERSION}"
 FACTORY_VERSION='5.0.0'
 
 # Chrome versions: https://www.ubuntuupdates.org/package/google_chrome/stable/main/base/google-chrome-stable
-CHROME_VERSION='130.0.6723.116-1'
+CHROME_VERSION='131.0.6778.69-1'
 
 # Cypress versions: https://www.npmjs.com/package/cypress
-CYPRESS_VERSION='13.15.2'
+CYPRESS_VERSION='13.16.0'
 
 # Edge versions: https://packages.microsoft.com/repos/edge/pool/main/m/microsoft-edge-stable/
-EDGE_VERSION='130.0.2849.68-1'
+EDGE_VERSION='131.0.2903.51-1'
 
 # Firefox versions: https://download-installer.cdn.mozilla.net/pub/firefox/releases/
-FIREFOX_VERSION='132.0.1'
+FIREFOX_VERSION='132.0.2'
 
 # Yarn versions: https://www.npmjs.com/package/yarn and
 # https://classic.yarnpkg.com/latest-version
@@ -39,7 +39,6 @@ YARN_VERSION='1.22.22'
 # Webkit versions: https://www.npmjs.com/package/playwright-webkit
 # TODO: Globally installed webkit currently isn't found, see issue https://github.com/cypress-io/cypress/issues/25344
 # WEBKIT_VERSION='1.29.0'
-
 
 # Tags used for the Docker images generated from cypress/factory. Keep in mind the Docker images will only release if these versions change.
 BASE_IMAGE_TAG="${NODE_VERSION}"


### PR DESCRIPTION
updates Cypress to `13.16.0`
updates Chrome to `131.0.6778.69-1`
updates Edge to `131.0.2903.51-1`
updates Firefox to `132.0.2`