### PR TITLE
feat: update to Debian 12.8 (bookworm)

### DIFF
--- a/factory/.env
+++ b/factory/.env
@@ -6,7 +6,7 @@
 
 # Use Debian stable release https://www.debian.org/releases/stable/
 # The Debian image cypress/factory is based on
-BASE_IMAGE='debian:12.7-slim'
+BASE_IMAGE='debian:12.8-slim'
 
 # Node Versions: https://nodejs.org/en/download/releases/
 # master branch needs "Active LTS" version
@@ -18,7 +18,7 @@ NODE_VERSION="${FACTORY_DEFAULT_NODE_VERSION}"
 
 # Update the FACTORY_VERSION to deploy cypress/factory if you make changes to
 # BASE_IMAGE, FACTORY_DEFAULT_NODE_VERSION, YARN_VERSION, factory.Dockerfile or installScripts
-FACTORY_VERSION='5.0.0'
+FACTORY_VERSION='5.1.0'
 
 # Chrome versions: https://www.ubuntuupdates.org/package/google_chrome/stable/main/base/google-chrome-stable
 CHROME_VERSION='131.0.6778.69-1'

--- a/factory/CHANGELOG.md
+++ b/factory/CHANGELOG.md
@@ -1,8 +1,12 @@
 # Change log
 
+## 5.1.0
+
+- Updated Debian base to `debian:12.8-slim` using [Debian 12.8](https://www.debian.org/News/2024/20241109), released on Nov 9, 2024. Addresses [#1252](https://github.com/cypress-io/cypress-docker-images/issues/1252).
+
 ## 5.0.0
 
-- Updated default node version from `20.18.0` (`Iron` - Maintenance LTS) to `22.11.0` (`Jod` - Active LTS) - see [Blog v22.11.0](https://nodejs.org/en/blog/release/v22.11.0). Addresses [#1239]https://github.com/cypress-io/cypress-docker-images/issues/1239).
+- Updated default node version from `20.18.0` (`Iron` - Maintenance LTS) to `22.11.0` (`Jod` - Active LTS) - see [Blog v22.11.0](https://nodejs.org/en/blog/release/v22.11.0). Addresses [#1239](https://github.com/cypress-io/cypress-docker-images/issues/1239).
 
 ## 4.3.0
 


### PR DESCRIPTION
feat: update to Debian 12.8 (bookworm)

- Closes https://github.com/cypress-io/cypress-docker-images/issues/1252

## Issue

[Debian 12.8](https://www.debian.org/News/2024/20241109) was released on Nov 9, 2024.

Cypress Factory is currently based on [Debian 12.7](https://www.debian.org/News/2024/20240831)

See [Debian Releases](https://www.debian.org/releases/) for an overview.

## Change

Update to `BASE_IMAGE='debian:12.8-slim'`

Also fixed a missing bracket in the previous [CHANGELOG](https://github.com/cypress-io/cypress-docker-images/blob/master/factory/CHANGELOG.md) entry.