### PR TITLE
docs: use /app as standard example working directory

### DIFF
--- a/base/README.md
+++ b/base/README.md
@@ -29,10 +29,10 @@ In this example we first run the unchanged image `cypress/base` as a container:
 ```shell
 cd examples/basic         # Use a pre-configured simple Cypress E2E project
 npm ci                    # Install Cypress
-docker run -it --rm -v .:/e2e -w /e2e cypress/base  # Run image as container
+docker run -it --rm -v .:/app -w /app cypress/base  # Run image as container
 ```
 
-At the `bash` prompt `:/e2e#`, we can then enter the following commands:
+At the `bash` prompt `:/app#`, we can then enter the following commands:
 
 ```shell
 npx cypress install       # Install Cypress binary into running Docker container

--- a/browsers/README.md
+++ b/browsers/README.md
@@ -34,10 +34,10 @@ In this example we first run the unchanged image `cypress/browsers` as a contain
 ```shell
 cd examples/basic         # Use a pre-configured simple Cypress E2E project
 npm ci                    # Install Cypress
-docker run -it --rm -v .:/e2e -w /e2e cypress/browsers  # Run image as container
+docker run -it --rm -v .:/app -w /app cypress/browsers  # Run image as container
 ```
 
-At the `bash` prompt `:/e2e#`, we can then enter the following commands:
+At the `bash` prompt `:/app#`, we can then enter the following commands:
 
 ```shell
 npx cypress install       # Install Cypress binary into running Docker container

--- a/examples/chromium/README.md
+++ b/examples/chromium/README.md
@@ -26,10 +26,10 @@ In this example we first run the unchanged image `cypress/base` as a container:
 ```shell
 cd examples/chromium  # Use a pre-configured simple Cypress E2E project
 npm ci                # Install Cypress
-docker run -it --rm -v .:/e2e -w /e2e cypress/base  # Run image as container
+docker run -it --rm -v .:/app -w /app cypress/base  # Run image as container
 ```
 
-At the `bash` prompt `:/e2e#`, we can then enter the following commands:
+At the `bash` prompt `:/app#`, we can then enter the following commands:
 
 ```shell
 apt-get update                      # Update package index

--- a/examples/firefox-esr/README.md
+++ b/examples/firefox-esr/README.md
@@ -28,10 +28,10 @@ In this example we first run the unchanged image `cypress/base` as a container:
 ```shell
 cd examples/firefox-esr  # Use a pre-configured simple Cypress E2E project
 npm ci                # Install Cypress
-docker run -it --rm -v .:/e2e -w /e2e cypress/base  # Run image as container
+docker run -it --rm -v .:/app -w /app cypress/base  # Run image as container
 ```
 
-At the `bash` prompt `:/e2e#`, we can then enter the following commands:
+At the `bash` prompt `:/app#`, we can then enter the following commands:
 
 ```shell
 apt-get update                     # Update package index


### PR DESCRIPTION
## Issue

Some examples are using `/e2e` as a generic working directory in a Docker command line. For example:

```shell
docker run -it --rm -v .:/e2e -w /e2e cypress/base
```

This is a carry-over from legacy Cypress when only End-to-End tests were supported.

It is a misleading naming usage which suggests this is about E2E only. Cypress Docker images can however be used to execute both End-to-End and Component Testing.

## Change

The directory name in the Docker options `-v` and `-w` is arbitrary and changed from `/e2e` to a neutral name `/app`.