### PR TITLE
chore: update circleci to ubuntu-2204:2024.11.1 (latest) machine image

### DIFF
--- a/circle.yml
+++ b/circle.yml
@@ -52,7 +52,7 @@ commands:
 jobs:
     check-factory-versions:
         machine:
-            image: ubuntu-2204:2024.08.1
+            image: ubuntu-2204:2024.11.1
         steps:
             - checkout
             - expand-env-file
@@ -146,7 +146,7 @@ jobs:
                   working_directory: factory/test-project
     check-node-override-version:
         machine:
-            image: ubuntu-2204:2024.08.1
+            image: ubuntu-2204:2024.11.1
         steps:
             - checkout
             - expand-env-file
@@ -172,7 +172,7 @@ jobs:
                   working_directory: factory/test-project
     test-image:
         machine:
-            image: ubuntu-2204:2024.08.1
+            image: ubuntu-2204:2024.11.1
         parameters:
             target:
                 type: string
@@ -202,7 +202,7 @@ jobs:
 
     push:
         machine:
-            image: ubuntu-2204:2024.08.1
+            image: ubuntu-2204:2024.11.1
         parameters:
             target:
                 type: string


### PR DESCRIPTION
## Issue

- PR https://github.com/cypress-io/cypress-docker-images/pull/1214 updated the [circle.yml](https://github.com/cypress-io/cypress-docker-images/blob/master/circle.yml) workflow to use machine image `ubuntu-2204:2024.08.1` from [Circle CI Machine Images > ubuntu-2204](https://circleci.com/developer/machine/image/ubuntu-2204).

- The Docker Engine version [26.1.4](https://docs.docker.com/engine/release-notes/26.1/#2614) was released 5 months ago in June 2024. The latest CircleCI Ubuntu machine image `ubuntu-2204:2024.11.1`, as shown on the [CircleCI machine image overview](https://circleci.com/developer/images?imageType=machine), offers Docker Engine [27.3.1](https://docs.docker.com/engine/release-notes/27/#2731) (released in Sept 2024).

## Change

Update the [circle.yml](https://github.com/cypress-io/cypress-docker-images/blob/master/circle.yml) workflow from [ubuntu-2204:2024.08.1](https://discuss.circleci.com/t/ubuntu-20-04-22-04-24-04-q3-edge-release/51699) to the latest version `ubuntu-2204:2024.11.1`.

Moving to `ubuntu-2204:2024.11.1` updates the components as follows:

| Image tag                                                                                                   | Node.js   | Docker Engine                                                     | buildx                                                           | Status  |
| ----------------------------------------------------------------------------------------------------------- | --------- | ----------------------------------------------------------------- | ---------------------------------------------------------------- | ------- |
| [ubuntu-2204:2024.08.1](https://discuss.circleci.com/t/ubuntu-20-04-22-04-24-04-q3-edge-release/51699)      | `20.16.0` | [26.1.4](https://docs.docker.com/engine/release-notes/26.1/#2614) | [v0.16.1](https://github.com/docker/buildx/releases/tag/v0.16.1) | current  |
| `ubuntu-2204:2024.11.1`      | `22.11.0` | [27.3.1](https://docs.docker.com/engine/release-notes/27/#2731) | [v0.17.1](https://github.com/docker/buildx/releases/tag/v0.17.1) | future  |

This is a major version update for Node.js from `20.x` to `22.x`, the new LTS version. It is a major version update for Docker Engine from `26.x` to `27.x` and a major functional update from Docker Buildx [v0.16.1](https://github.com/docker/buildx/releases/tag/v0.16.1) to [v0.17.1](https://github.com/docker/buildx/releases/tag/v0.17.1). Based on a review of the release notes, there is no impact expected for the Cypress Docker image build process.
