### PR TITLE
fix(deps): update to node.js 22.12.0 LTS

### DIFF
--- a/factory/.env
+++ b/factory/.env
@@ -11,17 +11,17 @@ BASE_IMAGE='debian:12.8-slim'
 # Node Versions: https://nodejs.org/en/download/releases/
 # master branch needs "Active LTS" version
 # use feature branch for "Maintenance LTS" or "Current" versions
-FACTORY_DEFAULT_NODE_VERSION='22.11.0'
+FACTORY_DEFAULT_NODE_VERSION='22.12.0'
 
 # Node Versions: https://nodejs.org/en/download/releases/
 NODE_VERSION="${FACTORY_DEFAULT_NODE_VERSION}"
 
 # Update the FACTORY_VERSION to deploy cypress/factory if you make changes to
 # BASE_IMAGE, FACTORY_DEFAULT_NODE_VERSION, YARN_VERSION, factory.Dockerfile or installScripts
-FACTORY_VERSION='5.1.0'
+FACTORY_VERSION='5.1.1'
 
 # Chrome versions: https://www.ubuntuupdates.org/package/google_chrome/stable/main/base/google-chrome-stable
-CHROME_VERSION='131.0.6778.85-1'
+CHROME_VERSION='131.0.6778.108-1'
 
 # Cypress versions: https://www.npmjs.com/package/cypress
 CYPRESS_VERSION='13.16.0'
@@ -30,7 +30,7 @@ CYPRESS_VERSION='13.16.0'
 EDGE_VERSION='131.0.2903.70-1'
 
 # Firefox versions: https://download-installer.cdn.mozilla.net/pub/firefox/releases/
-FIREFOX_VERSION='132.0.2'
+FIREFOX_VERSION='133.0'
 
 # Yarn versions: https://www.npmjs.com/package/yarn and
 # https://classic.yarnpkg.com/latest-version

--- a/factory/CHANGELOG.md
+++ b/factory/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Change log
 
+## 5.1.1
+
+- Updated default node version from `22.11.0` to `22.12.0`. Addressed in [#1260](https://github.com/cypress-io/cypress-docker-images/pull/1260).
+
 ## 5.1.0
 
 - Updated Debian base to `debian:12.8-slim` using [Debian 12.8](https://www.debian.org/News/2024/20241109), released on Nov 9, 2024. Addresses [#1252](https://github.com/cypress-io/cypress-docker-images/issues/1252).


### PR DESCRIPTION
## Issue

[Node.js Active LTS version 22.12.0](https://nodejs.org/en/blog/release/v22.12.0) was released on Dec 3, 2024. Cypress Docker images [factory/.env](https://github.com/cypress-io/cypress-docker-images/blob/master/factory/.env) is currently set up to use the previous version `FACTORY_DEFAULT_NODE_VERSION='22.11.0'`.

## Change

In [factory/.env](https://github.com/cypress-io/cypress-docker-images/blob/master/factory/.env) make the following updates:

| Environment variable           | Before            | After              |
| ------------------------------ | ----------------- | ------------------ |
| `FACTORY_VERSION`              | `5.1.0`           | `5.1.1`            |
| `FACTORY_DEFAULT_NODE_VERSION` | `22.11.0`         | `22.12.0`          |
| `CHROME_VERSION`               | `131.0.6778.85-1` | `131.0.6778.108-1` |
| `FIREFOX_VERSION`              | `132.0.2`         | `133.0`            |