### PR TITLE
chore: Cypress 13.17.0 release

### DIFF
--- a/factory/.env
+++ b/factory/.env
@@ -21,16 +21,16 @@ NODE_VERSION="${FACTORY_DEFAULT_NODE_VERSION}"
 FACTORY_VERSION='5.1.1'
 
 # Chrome versions: https://www.ubuntuupdates.org/package/google_chrome/stable/main/base/google-chrome-stable
-CHROME_VERSION='131.0.6778.108-1'
+CHROME_VERSION='131.0.6778.139-1'
 
 # Cypress versions: https://www.npmjs.com/package/cypress
-CYPRESS_VERSION='13.16.1'
+CYPRESS_VERSION='13.17.0'
 
 # Edge versions: https://packages.microsoft.com/repos/edge/pool/main/m/microsoft-edge-stable/
-EDGE_VERSION='131.0.2903.70-1'
+EDGE_VERSION='131.0.2903.99-1'
 
 # Firefox versions: https://download-installer.cdn.mozilla.net/pub/firefox/releases/
-FIREFOX_VERSION='133.0'
+FIREFOX_VERSION='133.0.3'
 
 # Yarn versions: https://www.npmjs.com/package/yarn and
 # https://classic.yarnpkg.com/latest-version


### PR DESCRIPTION
updates Cypress to 13.17.0
updates Chrome to 131.0.6778.139-1
updates Edge to 131.0.2903.99-1
updates Firefox to 133.0.3