### PR TITLE
test: add tests for examples

### DIFF
--- a/.github/workflows/example-tests.yml
+++ b/.github/workflows/example-tests.yml
@@ -1,0 +1,28 @@
+name: Example Tests
+# This workflow tests examples from the examples directory of this repo.
+
+on:
+  push:
+    paths:
+      - examples/**
+  pull_request:
+  workflow_dispatch:
+
+jobs:
+  example:
+    runs-on: ubuntu-24.04
+    strategy:
+      fail-fast: false
+      matrix:
+        directory: [
+          basic-mini,
+          basic,
+          chromium,
+          firefox-esr,
+          included-as-non-root
+          ]
+    steps:
+      - uses: actions/checkout@v4
+      - name: Run test script
+        working-directory: examples/${{ matrix.directory }}
+        run: ./scripts/test.sh

--- a/examples/basic-mini/scripts/test.sh
+++ b/examples/basic-mini/scripts/test.sh
@@ -1,0 +1,8 @@
+#!/bin/bash
+set -e # fail on error
+#
+# Run in examples/basic-mini directory
+# (amd64 only)
+#
+echo Test base-mini with cypress/included in Chrome
+docker run --rm -v .:/app -w /app --entrypoint cypress cypress/included run -b chrome

--- a/examples/basic/scripts/test.sh
+++ b/examples/basic/scripts/test.sh
@@ -1,0 +1,14 @@
+#!/bin/bash
+set -e # fail on error
+#
+# Run in examples/basic directory
+# (amd64 only)
+#
+echo Test basic example
+npm ci                    # Install dependencies
+echo Build and test with cypress/base in Electron
+docker build -f Dockerfile.base -t test-base  . # Build a new image
+docker run --rm --entrypoint bash test-base -c "npx cypress run" # Run Cypress test in container
+echo Build and test with cypress/browsers in Chrome
+docker build -f Dockerfile.browsers -t test-browsers . # Build a new image
+docker run --rm --entrypoint bash test-browsers -c "npx cypress run -b chrome" # Run Cypress test in container using Chrome

--- a/examples/chromium/scripts/test.sh
+++ b/examples/chromium/scripts/test.sh
@@ -1,0 +1,9 @@
+#!/bin/bash
+set -e # fail on error
+#
+# Run in examples/chromium directory
+#
+echo Test Chromium in cypress/base
+npm ci                           # Install dependencies
+docker build -t test-chromium .  # Build a new image
+docker run --rm --entrypoint bash test-chromium -c "npx cypress run --browser chromium" # Run Cypress test using Chromium

--- a/examples/firefox-esr/scripts/test.sh
+++ b/examples/firefox-esr/scripts/test.sh
@@ -1,0 +1,9 @@
+#!/bin/bash
+set -e # fail on error
+#
+# Run in examples/firefox-esr directory
+#
+echo Test Firefox ESR in cypress/base
+npm ci                              # Install dependencies
+docker build -t test-firefox-esr .  # Build a new image
+docker run --rm --entrypoint bash test-firefox-esr -c "npx cypress run --browser firefox" # Run Cypress test using Firefox ESR

--- a/examples/included-as-non-root/scripts/test.sh
+++ b/examples/included-as-non-root/scripts/test.sh
@@ -1,0 +1,7 @@
+#!/bin/bash
+set -e # fail on error
+#
+# Run in examples/included-as-non-root directory
+#
+echo Test cypress/included running under node \(non-root\) user
+docker run --rm -v .:/test -w /test -u node cypress/included

--- a/examples/test-all-examples.sh
+++ b/examples/test-all-examples.sh
@@ -1,0 +1,40 @@
+#!/bin/bash
+set -e # fail on error
+#
+# Test all examples
+# Run in examples directory
+#
+# These examples are compatible with amd64 architecture
+namedExamplesAmd64=(
+    'basic'
+    'basic-mini'
+    'chromium'
+    'firefox-esr'
+    'included-as-non-root'
+    )
+
+# These examples are compatible with arm64 architecture
+namedExamplesArm64=(
+    'chromium'
+    'firefox-esr'
+    )
+
+if [ "$(uname -m)" = "x86_64" ]; then
+    echo Testing all examples
+    for i in ${!namedExamplesAmd64[@]}; do
+    echo
+    echo testing examples/${namedExamplesAmd64[$i]} directory
+    cd ${namedExamplesAmd64[$i]}
+    ./scripts/test.sh
+    cd ..
+    done
+else
+    echo Testing examples for arm64 only
+    for i in ${!namedExamplesArm64[@]}; do
+    echo
+    echo testing examples/${namedExamplesArm64[$i]} directory
+    cd ${namedExamplesArm64[$i]}
+    ./scripts/test.sh
+    cd ..
+    done
+fi


### PR DESCRIPTION
## Issue

There is no automated testing available for the set of examples in the [examples directory](https://github.com/cypress-io/cypress-docker-images/tree/master/examples).

## Change

- Add a test script `scripts/test.sh` for each of the sub-directories of the [examples directory](https://github.com/cypress-io/cypress-docker-images/tree/master/examples)
- Add a `examples/test-all-examples.sh` script to run all the above scripts
- Add a GitHub Actions workflow to run each of the individual test scripts

## Verification

### Local test

On Ubuntu `24.04.1` LTS, Node.js `22.12.0` LTS with Docker Desktop `4.37.1`

```shell
git clone https://github.com/cypress-io/cypress-docker-images
cd cypress-docker-images
cd examples
./test-all-examples.sh
```

### GitHub Actions test

Under https://github.com/cypress-io/cypress-docker-images/actions run workflow
"Example Tests"
