### PR TITLE
test: set up included-non-root example screenshot

### DIFF
--- a/examples/included-as-non-root/README.md
+++ b/examples/included-as-non-root/README.md
@@ -33,3 +33,20 @@ docker run --rm -v .:/test -w /test -u node cypress/included
 ```
 
 You can expect this command to run successfully.
+
+## GitHub Actions
+
+In general when running Cypress Docker images in GitHub Actions it is recommended to use the GitHub Actions' `container` syntax (see [Running jobs in a container](https://docs.github.com/en/actions/writing-workflows/choosing-where-your-workflow-runs/running-jobs-in-a-container) and [.github/workflows/example-cypress-github-action.yml](../../.github/workflows/example-cypress-github-action.yml)).
+
+If however Docker is run directly in a GitHub Actions workflow, such as:
+
+```yaml
+- run: docker run --rm -v .:/test -w /test -u node cypress/included
+  working-directory: examples/included-as-non-root
+```
+
+then the `docker` command will be run from GitHub's `runner` user `1001` and the Cypress Docker image `node` user `1000` will have no write access to the `/test` directory. Cypress will warn that the project root directory is read-only and that screenshots and videos cannot be captured.
+
+To enable screenshot and video captures, redirect the folders to a writable folder, such as `/tmp`. See [cypress.config.js](./cypress.config.js) for an example.
+
+Pending resolution of Cypress issue https://github.com/cypress-io/cypress/issues/30810, Cypress will however still produce a warning.

--- a/examples/included-as-non-root/cypress.config.js
+++ b/examples/included-as-non-root/cypress.config.js
@@ -1,8 +1,11 @@
-const { defineConfig } = require('cypress')
+const { defineConfig } = require('cypress');
 
 module.exports = defineConfig({
+  downloadsFolder: '/tmp/cypress/downloads',
+  screenshotsFolder: '/tmp/cypress/screenshots',
+  videosFolder: '/tmp/cypress/videos',
   fixturesFolder: false,
   e2e: {
     supportFile: false,
   },
-})
+});

--- a/examples/included-as-non-root/cypress/e2e/spec.cy.js
+++ b/examples/included-as-non-root/cypress/e2e/spec.cy.js
@@ -2,5 +2,6 @@ describe('test local demo page', () => {
   it('heading', () => {
     cy.visit('index.html')
     cy.contains('h2', 'Test')
+    cy.screenshot()
   })
 })


### PR DESCRIPTION
## Issue

[examples/included-as-non-root](https://github.com/cypress-io/cypress-docker-images/blob/master/examples/included-as-non-root) cannot capture screenshots when running with a non-root user in GitHub Actions.

In [actions/workflows/example-tests.yml](https://github.com/cypress-io/cypress-docker-images/actions/workflows/example-tests.yml) running the job `example (included-as-non-root)` in GitHub Actions, Cypress outputs the warning:

```text
This folder is not writable: /test

Writing to this directory is required by Cypress in order to store screenshots and videos.

Enable write permissions to this directory to ensure screenshots and videos are stored.

If you don't require screenshots or videos to be stored you can safely ignore this warning.
```

See logs in https://github.com/cypress-io/cypress-docker-images/actions/runs/12585519287/job/35077469532

The workflow effectively runs the following:

https://github.com/cypress-io/cypress-docker-images/blob/31d5a601eab81c1f9b9163932e3a2c7d07580e48/examples/included-as-non-root/scripts/test.sh#L1-L7

GitHub Runners under `ubuntu-24.04` run commands with the Linux user:

```shell
uid=1001(runner) gid=118(docker) groups=118(docker),4(adm),100(users),999(systemd-journal)
```

The volume mount `-v .:/test` source is owned by the `runner` user and the Cypress `node` user has only `r-x` access, not write access to the directory `/test`.

*Note that this is different from running Docker images as an explicit container in GitHub Actions (see [Running jobs in a container](https://docs.github.com/en/actions/writing-workflows/choosing-where-your-workflow-runs/running-jobs-in-a-container) where the Docker (default) user is `root` unless replaced through [jobs.<job_id>.container.options](https://docs.github.com/en/actions/writing-workflows/workflow-syntax-for-github-actions#jobsjob_idcontaineroptions)).*

## Change

1. In the Cypress configuration [examples/included-as-non-root/cypress.config.js](https://github.com/cypress-io/cypress-docker-images/blob/master/examples/included-as-non-root/cypress.config.js) configure the [volatile folders](https://docs.cypress.io/app/references/configuration#Folders--Files) outside the Cypress project in the `/tmp` directory which is writable by all users.

    | Folder              | Default Location      | New Location               |
    | ------------------- | --------------------- | -------------------------- |
    | `downloadsFolder`   | `cypress/downloads`   | `/tmp/cypress/downloads`   |
    | `screenshotsFolder` | `cypress/screenshots` | `/tmp/cypress/screenshots` |
    | `videosFolder`      | `cypress/videos`      | `/tmp/cypress/videos`      |

2. Add `cy.screenshot()` to [examples/included-as-non-root/cypress/e2e/spec.cy.js](https://github.com/cypress-io/cypress-docker-images/blob/master/examples/included-as-non-root/cypress/e2e/spec.cy.js) to test that a screenshot can be captured.

## Verification

### Local test Ubuntu

Ubuntu `24.04.1` LTS, Node.js `22.12.0 LTS`, Docker Desktop `4.37.1`

```shell
git clone https://github.com/cypress-io/cypress-docker-images
cd cypress-docker-images
cd examples/included-as-non-root
docker run --rm -v .:/test:ro -w /test -u node cypress/included
```


- Ignore the warning "This folder is not writable: /test" (see issue https://github.com/cypress-io/cypress/issues/30810)
- Confirm that screenshot `/tmp/cypress/screenshots/spec.cy.js/test local demo page -- heading.png` is logged as being written.

### Local test Windows 11

Windows 11 24H2, Node.js `22.12.0 LTS`, Docker Desktop `4.37.1` in a `cmd` terminal window

Commands and test as above for Ubuntu.