### PR TITLE
docs: add binary_state.json permission denied known problem

### DIFF
--- a/README.md
+++ b/README.md
@@ -157,6 +157,38 @@ container:
 
 See [Tag Selection](#tag-selection) above for advice on selecting a non-default image tag.
 
+## EACCES permission denied binary_state.json
+
+### Problem
+
+If a custom Docker image is built from a `cypress/base` or `cypress/browsers` Cypress Docker image, using a `Dockerfile` to install the Cypress binary (for instance with `npx cypress install`), and the custom image is then run as a container with a non-root user, Cypress will fail to run with an error message:
+
+> Error: EACCES: permission denied, open '/root/.cache/Cypress/`<Cypress version>`/binary_state.json'
+
+This is due to an open Cypress issue [#30684](https://github.com/cypress-io/cypress/issues/30684) where Cypress fails to verify the installed Cypress binary if it does not have write access to the Cypress binary directory.
+
+### Workaround
+
+To workaround this issue, either make the Cypress binary directory writable, or skip the Cypress binary verification.
+
+To make the complete Cypress binary directory writable, add the following to the `Dockerfile` after the step to install the Cypress binary:
+
+```Dockerfile
+RUN chmod -R 777 /root/.cache/Cypress
+```
+
+To skip Cypress binary verification using the environment variable `CYPRESS_SKIP_VERIFY`, described in the Cypress documentation [Advanced Installation](https://docs.cypress.io/app/references/advanced-installation#Environment-variables), either add the following to the `Dockerfile`:
+
+```Dockerfile
+ENV CYPRESS_SKIP_VERIFY=true
+```
+
+or pass the environment variable as a CLI option:
+
+```shell
+docker run --env CYPRESS_SKIP_VERIFY=true
+```
+
 ## Contributing
 
 See [CONTRIBUTING.md](CONTRIBUTING.md)

--- a/README.md
+++ b/README.md
@@ -183,11 +183,7 @@ To skip Cypress binary verification using the environment variable `CYPRESS_SKIP
 ENV CYPRESS_SKIP_VERIFY=true
 ```
 
-or pass the environment variable as a CLI option:
-
-```shell
-docker run --env CYPRESS_SKIP_VERIFY=true
-```
+or pass the environment variable as an additional CLI option `--env CYPRESS_SKIP_VERIFY=true` to the [docker run](https://docs.docker.com/reference/cli/docker/container/run/) command.
 
 ## Contributing
 


### PR DESCRIPTION
- partially resolves issue #1272
- possibly also related to issue https://github.com/cypress-io/cypress-docker-images/issues/914

## Issue

If a custom Docker image is built from `cypress/base` or `cypress/browsers` and a Cypress binary is installed (for instance with `npx cypress install`) and the custom image is then run with a non-root user, Cypress will fail to run with an error message:

> Error: EACCES: permission denied, open '/root/.cache/Cypress/`<Cypress version>`/binary_state.json'

This is due to an open Cypress issue https://github.com/cypress-io/cypress/issues/30684 where Cypress fails to verify the installed Cypress binary if it does not have write access to the Cypress binary directory.

## Repro steps

Follow the steps in [cypress/base README > Docker build and run](https://github.com/cypress-io/cypress-docker-images/tree/master/base#docker-build-and-run), running the generated image with `--user node` for the non-root user `node`:

`Dockerfile`:
```dockerfile
FROM cypress/base
COPY . /opt/app
WORKDIR /opt/app
RUN npx cypress install # Install Cypress binary into image
```

```shell
cd examples/basic         # Use a pre-configured simple Cypress E2E project
npm ci                    # Install Cypress
docker build . -f Dockerfile.base -t test-base  # Build a new image
docker run -it --rm --entrypoint bash --user node test-base -c "npx cypress run" # Run Cypress test in container
```

## Change

Add a new topic to the [README > Known problems](https://github.com/cypress-io/cypress-docker-images/blob/master/README.md#known-problems) section, referring to Cypress issue https://github.com/cypress-io/cypress/issues/30684.

Suggest the workarounds:

1. Add the `RUN` command `chmod -R 777 /root/.cache/Cypress` to the `Dockerfile`, similar to the workaround employed in [factory/installScripts/cypress/default.sh](https://github.com/cypress-io/cypress-docker-images/blob/master/factory/installScripts/cypress/default.sh) OR
2. Add the `ENV` environment variable `CYPRESS_SKIP_VERIFY=true` to the `Dockerfile` (see [Advanced Installation > Environment variables](https://docs.cypress.io/app/references/advanced-installation#Environment-variables)) OR
3. Use the environment variable in the `docker run --env CYPRESS_SKIP_VERIFY=true` command

### Dockerfiles

`Dockerfile.base.workaround_1`:
```dockerfile
FROM cypress/base
COPY . /opt/app
WORKDIR /opt/app
RUN npx cypress install # Install Cypress binary into image
RUN chmod -R 777 /root/.cache/Cypress
```

`Dockerfile.base.workaround_2`:
```dockerfile
FROM cypress/base
COPY . /opt/app
WORKDIR /opt/app
RUN npx cypress install # Install Cypress binary into image
ENV CYPRESS_SKIP_VERIFY=true
```

## Verification

Ignore warning:
> This folder is not writable: /opt/app

### Option 1

```shell
cd examples/basic         # Use a pre-configured simple Cypress E2E project
npm ci                    # Install Cypress
docker build -f Dockerfile.base.workaround_1 -t test-base-wa1 .
docker run -it --rm --entrypoint bash --user node test-base-wa1 -c "npx cypress run" # Run Cypress test in container
```

### Option 2

```shell
cd examples/basic         # Use a pre-configured simple Cypress E2E project
npm ci                    # Install Cypress
docker build -f Dockerfile.base.workaround_2 -t test-base-wa2 .
docker run -it --rm --entrypoint bash --user node test-base-wa2 -c "npx cypress run" # Run Cypress test in container
```

### Option 3

```shell
cd examples/basic         # Use a pre-configured simple Cypress E2E project
npm ci                    # Install Cypress
docker build -f Dockerfile.base -t test-base .
docker run -it --rm --entrypoint bash --env CYPRESS_SKIP_VERIFY=true --user node test-base -c "npx cypress run" # Run Cypress test in container
```
