### PR TITLE
docs: add mitigation instructions non-root user not node

### DIFF
--- a/README.md
+++ b/README.md
@@ -185,6 +185,26 @@ ENV CYPRESS_SKIP_VERIFY=true
 
 or pass the environment variable as an additional CLI option `--env CYPRESS_SKIP_VERIFY=true` to the [docker run](https://docs.docker.com/reference/cli/docker/container/run/) command.
 
+## Fontconfig error: No writable cache directories
+
+### Problem
+
+If a Cypress Docker image is run with a non-root user other than `node` (`1000`) then Cypress may be unable to write into the Linux `$HOME` directory and may fail. The error message contains the text:
+
+```text
+Fontconfig error: No writable cache directories
+The Test Runner unexpectedly exited via a exit event with signal SIGTRAP
+```
+
+### Workaround
+
+Build a custom Docker image and add the following instructions to the end of the `Dockerfile` to allow the `$HOME` directory for the non-root user `node` to be used and to allow Cypress write access to the necessary cache directories:
+
+```Dockerfile
+ENV HOME=/home/node
+RUN chmod -R 777 $HOME /root/.cache/Cypress
+```
+
 ## Contributing
 
 See [CONTRIBUTING.md](CONTRIBUTING.md)

--- a/examples/included-as-non-root/README.md
+++ b/examples/included-as-non-root/README.md
@@ -34,6 +34,10 @@ docker run --rm -v .:/test -w /test -u node cypress/included
 
 You can expect this command to run successfully.
 
+### Non-root user not node 1000
+
+If you need to run a `cypress/included` image with a non-root user other than `node` (`1000`) and you are experiencing permissions errors, please refer to the [Known Problems](../../README.md#known-problems) section regarding workarounds.
+
 ## GitHub Actions
 
 In general when running Cypress Docker images in GitHub Actions it is recommended to use the GitHub Actions' `container` syntax (see [Running jobs in a container](https://docs.github.com/en/actions/writing-workflows/choosing-where-your-workflow-runs/running-jobs-in-a-container) and [.github/workflows/example-cypress-github-action.yml](../../.github/workflows/example-cypress-github-action.yml)).


### PR DESCRIPTION
- closes #1275

## Issue

If a Cypress Docker image is run with a non-root user other than the configured `node` (`1000`) user, and if no additional measures are taken, multiple subsystems which rely on being able write into the Linux $HOME directory are unable to cache intermediate results. This causes Cypress to fail to run. The error message contains the text:

```text
Fontconfig error: No writable cache directories
The Test Runner unexpectedly exited via a exit event with signal SIGTRAP
```

Cypress Docker images (`cypress/base`, `cypress/browsers`, `cypress/included` & custom images generated from `cypress/factory`) include only a `home` directory for the non-root user `node` (`1000`). This directory is owned by the user `node` and does not allow other users write access.

Executing `npx cypress run` with user `node` or `1000` sets `$HOME` to `/home/node` and creates the following directories in the `$HOME` directory:

```text
.cache/fontconfig
.config/Cypress
.npm/_logs
.pki
```

Executing `npx cypress run` with any other non-root user such as `1001` sets `$HOME` to `/`, which is owned by `root:root` with no write access given to any non-root user. This blocks the above directories from being created, which in turn causes Cypress to fail. The failure shown in the issue reproduction for #1275 relates to the failure to create the directory `.cache/fontconfig`. Other users have reported other error messages, which stem from the same root cause of not be able to write to the directory specified by `$HOME`.

## Mitigation

- Setting the `$HOME` environment variable to point to the existing `/home/node` directory and allowing write access to all users mitigates the issue. The workaround described in [EACCES permission denied binary_state.json](https://github.com/cypress-io/cypress-docker-images/blob/master/README.md#eacces-permission-denied-binary_statejson) for `cypress/base` & `cypress/browsers` which involves allowing write access to all users to `/root/.cache/Cypress` can be combined for all images for simplicity of description.

## Change

Add a new topic to the [README > Known problems](https://github.com/cypress-io/cypress-docker-images/blob/master/README.md#known-problems) section.

Suggest the workaround to add the following instructions to the `Dockerfile` when building a Cypress Docker image to be used with a non-root user other than the built-in `node` (`1000`) user:

```Dockerfile
ENV HOME=/home/node
RUN chmod -R 777 $HOME /root/.cache/Cypress
```

## Verification

Ignore warning:
> This folder is not writable: /opt/app

### cypress/base

Create `examples/basic/Dockerfile.base.workaround_font` with the following contents:

```Dockerfile
FROM cypress/base
COPY . /opt/app
WORKDIR /opt/app
RUN npx cypress install
ENV HOME=/home/node
RUN chmod -R 777 $HOME /root/.cache/Cypress
```

and execute the following:

```shell
cd examples/basic
npm ci
docker build -f Dockerfile.base.workaround_font -t test-base-font .
docker run -it --rm --entrypoint bash --user 1001 test-base-font -c "npx cypress run"
```

### cypress/browsers

Create `examples/basic/Dockerfile.browsers.workaround_font` with the following contents:

```Dockerfile
FROM cypress/browsers
COPY . /opt/app
WORKDIR /opt/app
RUN npx cypress install
ENV HOME=/home/node
RUN chmod -R 777 $HOME /root/.cache/Cypress
```

and execute the following:

```shell
cd examples/basic
npm ci
docker build -f Dockerfile.browsers.workaround_font -t test-browsers-font .
docker run -it --rm --entrypoint bash --user 1001 test-browsers-font -c "npx cypress run"
```

### cypress/factory

Create `examples/basic-mini/Dockerfile.factory.workaround_font` with the following contents:

```Dockerfile
ARG CHROME_VERSION='125.0.6422.141-1'
ARG EDGE_VERSION='125.0.2535.85-1'
ARG FIREFOX_VERSION='126.0.1'

FROM cypress/factory

COPY . /opt/app
WORKDIR /opt/app
RUN npm install cypress --save-dev
RUN npx cypress install
ENV HOME=/home/node
RUN chmod -R 777 $HOME /root/.cache/Cypress
```

and execute the following:

```shell
cd examples/basic-mini
npm ci
docker build -f Dockerfile.factory.workaround_font -t test-factory-font .
docker run -it --rm --entrypoint bash --user 1001 test-factory-font -c "npx cypress run"
```

### cypress/included

Create `examples/included-as-non-root/Dockerfile.included.workaround_font` with the following contents:

```Dockerfile
FROM cypress/included
COPY . /opt/app
WORKDIR /opt/app
ENV HOME=/home/node
RUN chmod -R 777 $HOME
```

and execute the following:

```shell
cd examples/included-as-non-root
npm ci
docker build -f Dockerfile.included.workaround_font -t test-included-font .
docker run -it --rm --entrypoint bash --user 1001 test-browsers-font -c "npx cypress run"
```
