### PR TITLE
feat: update to Debian 12.9 (bookworm)

### DIFF
--- a/factory/.env
+++ b/factory/.env
@@ -6,7 +6,7 @@
 
 # Use Debian stable release https://www.debian.org/releases/stable/
 # The Debian image cypress/factory is based on
-BASE_IMAGE='debian:12.8-slim'
+BASE_IMAGE='debian:12.9-slim'
 
 # Node Versions: https://nodejs.org/en/download/releases/
 # master branch needs "Active LTS" version
@@ -18,7 +18,7 @@ NODE_VERSION="${FACTORY_DEFAULT_NODE_VERSION}"
 
 # Update the FACTORY_VERSION to deploy cypress/factory if you make changes to
 # BASE_IMAGE, FACTORY_DEFAULT_NODE_VERSION, YARN_VERSION, factory.Dockerfile or installScripts
-FACTORY_VERSION='5.1.2'
+FACTORY_VERSION='5.2.0'
 
 # Chrome versions: https://www.ubuntuupdates.org/package/google_chrome/stable/main/base/google-chrome-stable
 CHROME_VERSION='132.0.6834.83-1'

--- a/factory/CHANGELOG.md
+++ b/factory/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Change log
 
+## 5.2.0
+
+- Updated Debian base to `debian:12.9-slim` using [Debian 12.9](https://www.debian.org/News/2025/20250111), released on Jan 11, 2025. Addresses [#1282](https://github.com/cypress-io/cypress-docker-images/issues/1282).
+
 ## 5.1.2
 
 - Updated default node version from `22.12.0` to `22.13.0`. Addressed in [#1277](https://github.com/cypress-io/cypress-docker-images/pull/1277).


### PR DESCRIPTION
- Closes https://github.com/cypress-io/cypress-docker-images/issues/1282

## Issue

[Debian 12.9](https://www.debian.org/News/2025/20250111) was released on Jan 11, 2025.

Cypress Factory is currently based on [Debian 12.8](https://www.debian.org/News/2024/20241109)

See [Debian Releases](https://www.debian.org/releases/) for an overview.

## Change

Update to `BASE_IMAGE='debian:12.9-slim'`
Update to `FACTORY_VERSION='5.2.0'`