### PR TITLE
chore(deps): update cypress to 14.0.0 in examples

### DIFF
--- a/examples/basic/package-lock.json
+++ b/examples/basic/package-lock.json
@@ -8,7 +8,7 @@
       "name": "example-basic",
       "version": "1.0.0",
       "devDependencies": {
-        "cypress": "^13.17.0"
+        "cypress": "^14.0.0"
       }
     },
     "node_modules/@colors/colors": {
@@ -590,9 +590,9 @@
       }
     },
     "node_modules/cypress": {
-      "version": "13.17.0",
-      "resolved": "https://registry.npmjs.org/cypress/-/cypress-13.17.0.tgz",
-      "integrity": "sha512-5xWkaPurwkIljojFidhw8lFScyxhtiFHl/i/3zov+1Z5CmY4t9tjIdvSXfu82Y3w7wt0uR9KkucbhkVvJZLQSA==",
+      "version": "14.0.0",
+      "resolved": "https://registry.npmjs.org/cypress/-/cypress-14.0.0.tgz",
+      "integrity": "sha512-kEGqQr23so5IpKeg/dp6GVi7RlHx1NmW66o2a2Q4wk9gRaAblLZQSiZJuDI8UMC4LlG5OJ7Q6joAiqTrfRNbTw==",
       "dev": true,
       "hasInstallScript": true,
       "license": "MIT",
@@ -645,7 +645,7 @@
         "cypress": "bin/cypress"
       },
       "engines": {
-        "node": "^16.0.0 || ^18.0.0 || >=20.0.0"
+        "node": "^18.0.0 || ^20.0.0 || >=22.0.0"
       }
     },
     "node_modules/dashdash": {

--- a/examples/basic/package.json
+++ b/examples/basic/package.json
@@ -7,6 +7,6 @@
   },
   "private": true,
   "devDependencies": {
-    "cypress": "^13.17.0"
+    "cypress": "^14.0.0"
   }
 }

--- a/examples/chrome-for-testing/package-lock.json
+++ b/examples/chrome-for-testing/package-lock.json
@@ -9,7 +9,7 @@
       "version": "1.0.0",
       "devDependencies": {
         "@puppeteer/browsers": "^2.6.1",
-        "cypress": "^13.17.0"
+        "cypress": "^14.0.0"
       }
     },
     "node_modules/@colors/colors": {
@@ -727,9 +727,9 @@
       }
     },
     "node_modules/cypress": {
-      "version": "13.17.0",
-      "resolved": "https://registry.npmjs.org/cypress/-/cypress-13.17.0.tgz",
-      "integrity": "sha512-5xWkaPurwkIljojFidhw8lFScyxhtiFHl/i/3zov+1Z5CmY4t9tjIdvSXfu82Y3w7wt0uR9KkucbhkVvJZLQSA==",
+      "version": "14.0.0",
+      "resolved": "https://registry.npmjs.org/cypress/-/cypress-14.0.0.tgz",
+      "integrity": "sha512-kEGqQr23so5IpKeg/dp6GVi7RlHx1NmW66o2a2Q4wk9gRaAblLZQSiZJuDI8UMC4LlG5OJ7Q6joAiqTrfRNbTw==",
       "dev": true,
       "hasInstallScript": true,
       "license": "MIT",
@@ -782,7 +782,7 @@
         "cypress": "bin/cypress"
       },
       "engines": {
-        "node": "^16.0.0 || ^18.0.0 || >=20.0.0"
+        "node": "^18.0.0 || ^20.0.0 || >=22.0.0"
       }
     },
     "node_modules/dashdash": {

--- a/examples/chrome-for-testing/package.json
+++ b/examples/chrome-for-testing/package.json
@@ -10,6 +10,6 @@
   "private": true,
   "devDependencies": {
     "@puppeteer/browsers": "^2.6.1",
-    "cypress": "^13.17.0"
+    "cypress": "^14.0.0"
   }
 }

--- a/examples/chromium/package-lock.json
+++ b/examples/chromium/package-lock.json
@@ -8,7 +8,7 @@
       "name": "example-chromium",
       "version": "1.0.0",
       "devDependencies": {
-        "cypress": "^13.17.0"
+        "cypress": "^14.0.0"
       }
     },
     "node_modules/@colors/colors": {
@@ -590,9 +590,9 @@
       }
     },
     "node_modules/cypress": {
-      "version": "13.17.0",
-      "resolved": "https://registry.npmjs.org/cypress/-/cypress-13.17.0.tgz",
-      "integrity": "sha512-5xWkaPurwkIljojFidhw8lFScyxhtiFHl/i/3zov+1Z5CmY4t9tjIdvSXfu82Y3w7wt0uR9KkucbhkVvJZLQSA==",
+      "version": "14.0.0",
+      "resolved": "https://registry.npmjs.org/cypress/-/cypress-14.0.0.tgz",
+      "integrity": "sha512-kEGqQr23so5IpKeg/dp6GVi7RlHx1NmW66o2a2Q4wk9gRaAblLZQSiZJuDI8UMC4LlG5OJ7Q6joAiqTrfRNbTw==",
       "dev": true,
       "hasInstallScript": true,
       "license": "MIT",
@@ -645,7 +645,7 @@
         "cypress": "bin/cypress"
       },
       "engines": {
-        "node": "^16.0.0 || ^18.0.0 || >=20.0.0"
+        "node": "^18.0.0 || ^20.0.0 || >=22.0.0"
       }
     },
     "node_modules/dashdash": {

--- a/examples/chromium/package.json
+++ b/examples/chromium/package.json
@@ -9,6 +9,6 @@
   },
   "private": true,
   "devDependencies": {
-    "cypress": "^13.17.0"
+    "cypress": "^14.0.0"
   }
 }

--- a/examples/firefox-esr/package-lock.json
+++ b/examples/firefox-esr/package-lock.json
@@ -8,7 +8,7 @@
       "name": "example-firefox-esr",
       "version": "1.0.0",
       "devDependencies": {
-        "cypress": "^13.17.0"
+        "cypress": "^14.0.0"
       }
     },
     "node_modules/@colors/colors": {
@@ -590,9 +590,9 @@
       }
     },
     "node_modules/cypress": {
-      "version": "13.17.0",
-      "resolved": "https://registry.npmjs.org/cypress/-/cypress-13.17.0.tgz",
-      "integrity": "sha512-5xWkaPurwkIljojFidhw8lFScyxhtiFHl/i/3zov+1Z5CmY4t9tjIdvSXfu82Y3w7wt0uR9KkucbhkVvJZLQSA==",
+      "version": "14.0.0",
+      "resolved": "https://registry.npmjs.org/cypress/-/cypress-14.0.0.tgz",
+      "integrity": "sha512-kEGqQr23so5IpKeg/dp6GVi7RlHx1NmW66o2a2Q4wk9gRaAblLZQSiZJuDI8UMC4LlG5OJ7Q6joAiqTrfRNbTw==",
       "dev": true,
       "hasInstallScript": true,
       "license": "MIT",
@@ -645,7 +645,7 @@
         "cypress": "bin/cypress"
       },
       "engines": {
-        "node": "^16.0.0 || ^18.0.0 || >=20.0.0"
+        "node": "^18.0.0 || ^20.0.0 || >=22.0.0"
       }
     },
     "node_modules/dashdash": {

--- a/examples/firefox-esr/package.json
+++ b/examples/firefox-esr/package.json
@@ -9,6 +9,6 @@
   },
   "private": true,
   "devDependencies": {
-    "cypress": "^13.17.0"
+    "cypress": "^14.0.0"
   }
 }


### PR DESCRIPTION
## Change

The [examples](https://github.com/cypress-io/cypress-docker-images/tree/master/examples) are updated to [cypress@14.0.0](https://docs.cypress.io/app/references/changelog#14-0-0) (current `latest`).