### PR TITLE
chore: update test-project cypress/support/e2e.js to cypress 14.0.0

### DIFF
--- a/factory/test-project/cypress/support/e2e.js
+++ b/factory/test-project/cypress/support/e2e.js
@@ -15,6 +15,3 @@
 
 // Import commands.js using ES2015 syntax:
 import './commands'
-
-// Alternatively you can use CommonJS syntax:
-// require('./commands')


### PR DESCRIPTION
## Issue

- The scaffolded contents of [factory/test-project/cypress/support/e2e.js](https://github.com/cypress-io/cypress-docker-images/blob/master/factory/test-project/cypress/support/e2e.js) in the [factory/test-project](https://github.com/cypress-io/cypress-docker-images/tree/master/factory/test-project) are no longer exactly aligned with Cypress >= `13.17.0` due to PR https://github.com/cypress-io/cypress/pull/30738.

- Cypress has removed the comment text from the default scaffolded file `support/e2e.js`:

    > // Alternatively you can use CommonJS syntax:
    > // require('./commands')

## Change

- Recreate [factory/test-project/cypress](https://github.com/cypress-io/cypress-docker-images/tree/master/factory/test-project/cypress) using Cypress `14.0.0`.

    This is a housekeeping chore with only a change in comment text. It should have no effect on running tests.