### PR TITLE
fix(deps): update to Node.js 22.13.1

### DIFF
--- a/factory/.env
+++ b/factory/.env
@@ -11,14 +11,14 @@ BASE_IMAGE='debian:12.9-slim'
 # Node Versions: https://nodejs.org/en/download/releases/
 # master branch needs "Active LTS" version
 # use feature branch for "Maintenance LTS" or "Current" versions
-FACTORY_DEFAULT_NODE_VERSION='22.13.0'
+FACTORY_DEFAULT_NODE_VERSION='22.13.1'
 
 # Node Versions: https://nodejs.org/en/download/releases/
 NODE_VERSION="${FACTORY_DEFAULT_NODE_VERSION}"
 
 # Update the FACTORY_VERSION to deploy cypress/factory if you make changes to
 # BASE_IMAGE, FACTORY_DEFAULT_NODE_VERSION, YARN_VERSION, factory.Dockerfile or installScripts
-FACTORY_VERSION='5.2.0'
+FACTORY_VERSION='5.2.1'
 
 # Chrome versions: https://www.ubuntuupdates.org/package/google_chrome/stable/main/base/google-chrome-stable
 CHROME_VERSION='132.0.6834.83-1'
@@ -27,10 +27,10 @@ CHROME_VERSION='132.0.6834.83-1'
 CYPRESS_VERSION='14.0.0'
 
 # Edge versions: https://packages.microsoft.com/repos/edge/pool/main/m/microsoft-edge-stable/
-EDGE_VERSION='131.0.2903.147-1'
+EDGE_VERSION='132.0.2957.115-1'
 
 # Firefox versions: https://download-installer.cdn.mozilla.net/pub/firefox/releases/
-FIREFOX_VERSION='134.0.1'
+FIREFOX_VERSION='134.0.2'
 
 # Yarn versions: https://www.npmjs.com/package/yarn and
 # https://classic.yarnpkg.com/latest-version

--- a/factory/CHANGELOG.md
+++ b/factory/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Change log
 
+## 5.2.1
+
+- Updated default node version from `22.13.0` to `22.13.1`. Addressed in [#1288](https://github.com/cypress-io/cypress-docker-images/pull/1288).
+
 ## 5.2.0
 
 - Updated Debian base to `debian:12.9-slim` using [Debian 12.9](https://www.debian.org/News/2025/20250111), released on Jan 11, 2025. Addresses [#1282](https://github.com/cypress-io/cypress-docker-images/issues/1282).


### PR DESCRIPTION
## Issue

- The Node.js project released a security update [Node.js v22.13.1 LTS](https://nodejs.org/en/blog/release/v22.13.1) on Jan 21, 2025.

## Change

In [factory/.env](https://github.com/cypress-io/cypress-docker-images/blob/master/factory/.env) make the following updates:

| Environment variable           | Before             | After              |
| ------------------------------ | ------------------ | ------------------ |
| `FACTORY_VERSION`              | `5.2.0`            | `5.2.1`            |
| `FACTORY_DEFAULT_NODE_VERSION` | `22.13.0`          | `22.13.1`          |
| `CHROME_VERSION`               | `132.0.6834.83-1`  | no change          |
| `EDGE_VERSION`                 | `131.0.2903.147-1` | `132.0.2957.115-1` |
| `FIREFOX_VERSION`              | `134.0.1`          | `134.0.2`          |
