### PR TITLE
test: run examples in Ubuntu arm64 on GitHub

### DIFF
--- a/.github/workflows/example-tests.yml
+++ b/.github/workflows/example-tests.yml
@@ -10,7 +10,6 @@ on:
 
 jobs:
   example:
-    runs-on: ubuntu-24.04
     strategy:
       fail-fast: false
       matrix:
@@ -22,6 +21,14 @@ jobs:
           firefox-esr,
           included-as-non-root
           ]
+        os: [
+          ubuntu-24.04,     # testing Linux/amd64 platform
+          ubuntu-24.04-arm  # testing Linux/arm64 platform
+          ]
+        exclude:
+          - os: ubuntu-24.04-arm
+            directory: chrome-for-testing #browser not available for Linux/arm64
+    runs-on: ${{ matrix.os }}
     steps:
       - uses: actions/checkout@v4
       - name: Run test script

--- a/examples/basic-mini/scripts/test.sh
+++ b/examples/basic-mini/scripts/test.sh
@@ -1,8 +1,25 @@
 #!/bin/bash
 set -e # fail on error
 #
-# Run in examples/basic-mini directory
-# (amd64 only)
+# Run ./scripts/test.sh in examples/basic-mini directory
 #
-echo Test base-mini with cypress/included in Chrome
-docker run --rm -v .:/app -w /app --entrypoint cypress cypress/included run -b chrome
+ARCHITECTURE=$(uname -m)
+echo Running on $ARCHITECTURE
+
+echo Test basic-mini example
+
+case $ARCHITECTURE in
+  x86_64)
+    echo Testing cypress/included in amd64 using Chrome
+      docker run --rm -v .:/app -w /app --entrypoint cypress cypress/included run -b chrome
+    ;;
+  aarch64)
+    echo Testing cypress/included in arm64 using Electron
+    echo No other browsers available
+      docker run --rm -v .:/app -w /app cypress/included
+    ;;
+  *)
+    echo Unsupported architecture
+    exit 1
+    ;;
+esac

--- a/examples/basic/scripts/test.sh
+++ b/examples/basic/scripts/test.sh
@@ -1,14 +1,30 @@
 #!/bin/bash
 set -e # fail on error
 #
-# Run in examples/basic directory
-# (amd64 only)
+# Run ./scripts/test.sh in examples/basic directory
 #
+ARCHITECTURE=$(uname -m)
+echo Running on $ARCHITECTURE
+
 echo Test basic example
-npm ci                    # Install dependencies
+npm ci # Install dependencies
 echo Build and test with cypress/base in Electron
 docker build -f Dockerfile.base -t test-base  . # Build a new image
 docker run --rm --entrypoint bash test-base -c "npx cypress run" # Run Cypress test in container
-echo Build and test with cypress/browsers in Chrome
-docker build -f Dockerfile.browsers -t test-browsers . # Build a new image
-docker run --rm --entrypoint bash test-browsers -c "npx cypress run -b chrome" # Run Cypress test in container using Chrome
+
+case $ARCHITECTURE in
+  x86_64)
+    echo Testing browsers in amd64
+    echo Build and test with cypress/browsers in Chrome
+      docker build -f Dockerfile.browsers -t test-browsers . # Build a new image
+      docker run --rm --entrypoint bash test-browsers -c "npx cypress run -b chrome" # Run Cypress test in container using Chrome
+    ;;
+  aarch64)
+    echo Skipping browser tests for arm64
+    echo No browsers available
+    ;;
+  *)
+    echo Unsupported architecture
+    exit 1
+    ;;
+esac

--- a/examples/chrome-for-testing/scripts/test.sh
+++ b/examples/chrome-for-testing/scripts/test.sh
@@ -3,24 +3,40 @@ set -e # fail on error
 #
 # Test building and running custom Cypress Docker image with different
 # versions of Chrome for Testing
-# Run in directory examples/chrome-for-testing
-# (amd64 only)
 #
-npm ci # Install dependencies
+# Run ./scripts/test.sh in directory examples/chrome-for-testing
 #
-chromeVersion=(
-    'stable'
-    'beta'
-    'dev'
-    'canary'
-    '130'
-    '131.0.6778.204'
-    )
-# Build, show Cypress info and run Cypress test
-for i in ${!chromeVersion[@]}; do
-echo
-echo CHROME_VERSION ${chromeVersion[$i]}
-docker build --build-arg CHROME_VERSION=${chromeVersion[$i]} -t test-chrome-for-testing .
-docker run --rm --entrypoint bash test-chrome-for-testing -c "npx cypress info"
-docker run --rm --entrypoint bash test-chrome-for-testing -c "npx cypress run --browser chrome-for-testing"
-done
+ARCHITECTURE=$(uname -m)
+echo Running on $ARCHITECTURE
+
+case $ARCHITECTURE in
+  x86_64)
+    echo Testing Chrome for Testing in amd64
+    npm ci # Install dependencies
+    #
+    chromeVersion=(
+        'stable'
+        'beta'
+        'dev'
+        'canary'
+        '130'
+        '131.0.6778.204'
+        )
+    # Build, show Cypress info and run Cypress test
+    for i in ${!chromeVersion[@]}; do
+    echo
+    echo CHROME_VERSION ${chromeVersion[$i]}
+    docker build --build-arg CHROME_VERSION=${chromeVersion[$i]} -t test-chrome-for-testing .
+    docker run --rm --entrypoint bash test-chrome-for-testing -c "npx cypress info"
+    docker run --rm --entrypoint bash test-chrome-for-testing -c "npx cypress run --browser chrome-for-testing"
+    done
+    ;;
+  aarch64)
+    echo Skipping Chrome for Testing for arm64
+    echo This browser is not available for Linux/arm64
+    ;;
+  *)
+    echo Unsupported architecture
+    exit 1
+    ;;
+esac

--- a/examples/chromium/scripts/test.sh
+++ b/examples/chromium/scripts/test.sh
@@ -1,9 +1,25 @@
 #!/bin/bash
 set -e # fail on error
 #
-# Run in examples/chromium directory
+# Run ./scripts/test.sh in examples/chromium directory
 #
+ARCHITECTURE=$(uname -m)
+echo Running on $ARCHITECTURE
+
+case $ARCHITECTURE in
+  x86_64)
+    echo Testing Chromium browser in amd64
+    ;;
+  aarch64)
+    echo Testing Chromium browser in arm64
+    ;;
+  *)
+    echo Unsupported architecture
+    exit 1
+    ;;
+esac
+
 echo Test Chromium in cypress/base
-npm ci                           # Install dependencies
-docker build -t test-chromium .  # Build a new image
+npm ci # Install dependencies
+docker build -t test-chromium . # Build a new image
 docker run --rm --entrypoint bash test-chromium -c "npx cypress run --browser chromium" # Run Cypress test using Chromium

--- a/examples/firefox-esr/scripts/test.sh
+++ b/examples/firefox-esr/scripts/test.sh
@@ -1,9 +1,25 @@
 #!/bin/bash
 set -e # fail on error
 #
-# Run in examples/firefox-esr directory
+# Run ./scripts/test.sh in examples/firefox-esr directory
 #
+ARCHITECTURE=$(uname -m)
+echo Running on $ARCHITECTURE
+
+case $ARCHITECTURE in
+  x86_64)
+    echo Testing Firefox ESR browser in amd64
+    ;;
+  aarch64)
+    echo Testing Firefox ESR browser in arm64
+    ;;
+  *)
+    echo Unsupported architecture
+    exit 1
+    ;;
+esac
+
 echo Test Firefox ESR in cypress/base
-npm ci                              # Install dependencies
-docker build -t test-firefox-esr .  # Build a new image
+npm ci # Install dependencies
+docker build -t test-firefox-esr . # Build a new image
 docker run --rm --entrypoint bash test-firefox-esr -c "npx cypress run --browser firefox" # Run Cypress test using Firefox ESR

--- a/examples/included-as-non-root/scripts/test.sh
+++ b/examples/included-as-non-root/scripts/test.sh
@@ -1,7 +1,23 @@
 #!/bin/bash
 set -e # fail on error
 #
-# Run in examples/included-as-non-root directory
+# Run ./scripts/test.sh in examples/included-as-non-root directory
 #
+ARCHITECTURE=$(uname -m)
+echo Running on $ARCHITECTURE
+
+case $ARCHITECTURE in
+  x86_64)
+    echo Testing in amd64
+    ;;
+  aarch64)
+    echo Testing in arm64
+    ;;
+  *)
+    echo Unsupported architecture
+    exit 1
+    ;;
+esac
+
 echo Test cypress/included running under node \(non-root\) user
 docker run --rm -v .:/test -w /test -u node cypress/included

--- a/examples/test-all-examples.sh
+++ b/examples/test-all-examples.sh
@@ -2,7 +2,7 @@
 set -e # fail on error
 #
 # Test all examples
-# Run in examples directory
+# Run ./test-all-examples.sh in examples directory
 #
 # These examples are compatible with amd64 architecture
 namedExamplesAmd64=(
@@ -16,12 +16,16 @@ namedExamplesAmd64=(
 
 # These examples are compatible with arm64 architecture
 namedExamplesArm64=(
+    'basic'
+    'basic-mini'
+#    'chrome-for-testing' # not available for arm64
     'chromium'
     'firefox-esr'
+    'included-as-non-root'
     )
 
 if [ "$(uname -m)" = "x86_64" ]; then
-    echo Testing all examples
+    echo Testing examples for amd64
     for i in ${!namedExamplesAmd64[@]}; do
     echo
     echo testing examples/${namedExamplesAmd64[$i]} directory
@@ -30,7 +34,7 @@ if [ "$(uname -m)" = "x86_64" ]; then
     cd ..
     done
 else
-    echo Testing examples for arm64 only
+    echo Testing examples for arm64
     for i in ${!namedExamplesArm64[@]}; do
     echo
     echo testing examples/${namedExamplesArm64[$i]} directory


### PR DESCRIPTION
- closes https://github.com/cypress-io/cypress-docker-images/issues/1290

## Situation

Examples in the [examples](https://github.com/cypress-io/cypress-docker-images/tree/master/examples) directory are currently tested in GitHub Actions through the workflow [.github/workflows/example-tests.yml](https://github.com/cypress-io/cypress-docker-images/blob/master/.github/workflows/example-tests.yml) tests using the GitHub Actions runner image [ubuntu-24.04](https://github.com/actions/runner-images/blob/main/images/ubuntu/Ubuntu2404-Readme.md), which runs on a `Linux/amd64` platform.

Examples are not tested on a `Linux/arm64` platform.

## Change

- Add the GitHub Actions runner image `ubuntu-24.04-arm` to the workflow [.github/workflows/example-tests.yml](https://github.com/cypress-io/cypress-docker-images/blob/master/.github/workflows/example-tests.yml)
- Update the script [examples/test-all-examples.sh](https://github.com/cypress-io/cypress-docker-images/blob/master/examples/test-all-examples.sh) and related sub-scripts to cover all possible cases of additionally testing examples on a `Linux/amd64` platform.

## Verification

Check that the workflow [.github/workflows/example-tests.yml](https://github.com/cypress-io/cypress-docker-images/blob/master/.github/workflows/example-tests.yml) runs successfully.

### Local verification

1. Ubuntu `24.04.1` LTS, Node `22.13.1` LTS, `amd64`
2. Ubuntu `24.04.1` LTS, Node `22.13.1` LTS, `arm64` (if available)

```shell
git clone https://github.com/cypress-io/cypress-docker-images
cd cypress-docker-images
cd examples
./test-all-examples.sh
```
