### PR TITLE
chore: update factory to use cypress 14.0.1 and latest browsers

### DIFF
--- a/factory/.env
+++ b/factory/.env
@@ -21,13 +21,13 @@ NODE_VERSION="${FACTORY_DEFAULT_NODE_VERSION}"
 FACTORY_VERSION='5.2.1'
 
 # Chrome versions: https://www.ubuntuupdates.org/package/google_chrome/stable/main/base/google-chrome-stable
-CHROME_VERSION='132.0.6834.83-1'
+CHROME_VERSION='132.0.6834.159-1'
 
 # Cypress versions: https://www.npmjs.com/package/cypress
-CYPRESS_VERSION='14.0.0'
+CYPRESS_VERSION='14.0.1'
 
 # Edge versions: https://packages.microsoft.com/repos/edge/pool/main/m/microsoft-edge-stable/
-EDGE_VERSION='132.0.2957.115-1'
+EDGE_VERSION='132.0.2957.127-1'
 
 # Firefox versions: https://download-installer.cdn.mozilla.net/pub/firefox/releases/
 FIREFOX_VERSION='134.0.2'


### PR DESCRIPTION
updates the factory to use cypress `14.0.1` and chrome/edge to latest