### PR TITLE
feat: support firefox 135 and above with xz compression

### DIFF
--- a/factory/.env
+++ b/factory/.env
@@ -18,7 +18,7 @@ NODE_VERSION="${FACTORY_DEFAULT_NODE_VERSION}"
 
 # Update the FACTORY_VERSION to deploy cypress/factory if you make changes to
 # BASE_IMAGE, FACTORY_DEFAULT_NODE_VERSION, YARN_VERSION, factory.Dockerfile or installScripts
-FACTORY_VERSION='5.2.1'
+FACTORY_VERSION='5.3.0'
 
 # Chrome versions: https://www.ubuntuupdates.org/package/google_chrome/stable/main/base/google-chrome-stable
 CHROME_VERSION='132.0.6834.159-1'

--- a/factory/CHANGELOG.md
+++ b/factory/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Change log
 
+## 5.3.0
+
+- Additionally support Firefox 135.0 and above with download file extension `xz` instead of `bz2`. (See [Firefox 135.0 release notes](https://www.mozilla.org/en-US/firefox/135.0/releasenotes/) and [Announcing Faster, Lighter Firefox Downloads for Linux with .tar.xz Packaging!](https://blog.nightly.mozilla.org/2024/11/28/announcing-faster-lighter-firefox-downloads-for-linux-with-tar-xz-packaging/)). Addresses [#1294](https://github.com/cypress-io/cypress-docker-images/issues/1294).
+
 ## 5.2.1
 
 - Updated default node version from `22.13.0` to `22.13.1`. Addressed in [#1288](https://github.com/cypress-io/cypress-docker-images/pull/1288).

--- a/factory/installScripts/firefox/default.sh
+++ b/factory/installScripts/firefox/default.sh
@@ -7,7 +7,8 @@ apt-get update \
     libgtk-3-0 \
     libdbus-glib-1-2 \
     mplayer \
-  && wget --no-verbose -O /tmp/firefox.tar.bz2 https://download-installer.cdn.mozilla.net/pub/firefox/releases/${1}/linux-x86_64/en-US/firefox-${1}.tar.bz2 \
-  && tar -C /opt -xjf /tmp/firefox.tar.bz2 \
-  && rm /tmp/firefox.tar.bz2 \
+    xz-utils \
+  && wget --no-verbose -O /tmp/firefox.tar.${2} https://download-installer.cdn.mozilla.net/pub/firefox/releases/${1}/linux-x86_64/en-US/firefox-${1}.tar.${2} \
+  && tar -C /opt -xaf /tmp/firefox.tar.${2} \
+  && rm /tmp/firefox.tar.${2} \
   && ln -fs /opt/firefox/firefox /usr/bin/firefox \

--- a/factory/installScripts/firefox/install-firefox-version.js
+++ b/factory/installScripts/firefox/install-firefox-version.js
@@ -13,10 +13,19 @@ if (process.arch !== 'x64') {
   return
 }
 
+// Change in compression from bz2 to xz in Firefox 135.0
+// See https://www.mozilla.org/en-US/firefox/135.0/releasenotes/
+
+let compression = `bz2`
+
+if (firefoxVersion >= '135.0') {
+  compression = `xz`
+}
+
 console.log('Installing Firefox version: ', firefoxVersion)
 
 // Insert logic here if needed to run a different install script based on chrome version.
-const install = spawn(`${__dirname}/default.sh`, [firefoxVersion], {stdio: 'inherit'})
+const install = spawn(`${__dirname}/default.sh`, [firefoxVersion, compression], {stdio: 'inherit'})
 
 install.on('error', function (error) {
   console.log('child process errored with ' + error.toString())


### PR DESCRIPTION
- closes https://github.com/cypress-io/cypress-docker-images/issues/1294

## Issue

[Firefox 135.0](https://www.mozilla.org/en-US/firefox/135.0/releasenotes/) announced that "Linux binaries are [now provided in XZ format](https://blog.nightly.mozilla.org/2024/11/28/announcing-faster-lighter-firefox-downloads-for-linux-with-tar-xz-packaging/), replacing the previous BZ2 format, offering faster unpacking and smaller file sizes."

The change is not compatible with the current [factory/installScripts/firefox/default.sh](https://github.com/cypress-io/cypress-docker-images/blob/master/factory/installScripts/firefox/default.sh) which assumes a `bz2` extension for the Firefox download file. Attempting to configure Firefox `135.0` therefore fails.

## Change

For Firefox `134` and below use `bz2` with `tar -xjf`
For Firefox `135` and above use `xz` with `tar -xJf`

## Verification

```shell
cd factory
docker compose build factory
export FIREFOX_VERSION='134.0'
docker compose build firefox
export FIREFOX_VERSION='135.0'
docker compose build firefox
```
