### PR TITLE
chore: cypress 14.0.2 release and bump browser versions

### DIFF
--- a/factory/.env
+++ b/factory/.env
@@ -21,16 +21,16 @@ NODE_VERSION="${FACTORY_DEFAULT_NODE_VERSION}"
 FACTORY_VERSION='5.3.0'
 
 # Chrome versions: https://www.ubuntuupdates.org/package/google_chrome/stable/main/base/google-chrome-stable
-CHROME_VERSION='132.0.6834.159-1'
+CHROME_VERSION='133.0.6943.53-1'
 
 # Cypress versions: https://www.npmjs.com/package/cypress
-CYPRESS_VERSION='14.0.1'
+CYPRESS_VERSION='14.0.2'
 
 # Edge versions: https://packages.microsoft.com/repos/edge/pool/main/m/microsoft-edge-stable/
-EDGE_VERSION='132.0.2957.127-1'
+EDGE_VERSION='132.0.2957.140-1'
 
 # Firefox versions: https://download-installer.cdn.mozilla.net/pub/firefox/releases/
-FIREFOX_VERSION='134.0.2'
+FIREFOX_VERSION='135.0'
 
 # Yarn versions: https://www.npmjs.com/package/yarn and
 # https://classic.yarnpkg.com/latest-version


### PR DESCRIPTION
Updates Cypress to `14.0.2` and updates the browsers to latest stable versions