### PR TITLE
test: disable ubuntu-24.04-arm usage

### DIFF
--- a/.github/workflows/example-tests.yml
+++ b/.github/workflows/example-tests.yml
@@ -22,12 +22,16 @@ jobs:
           included-as-non-root
           ]
         os: [
-          ubuntu-24.04,     # testing Linux/amd64 platform
-          ubuntu-24.04-arm  # testing Linux/arm64 platform
+          ubuntu-24.04     # testing Linux/amd64 platform
+          #
+          # temporarily disable testing on arm due to reliability issues
+          # see https://github.com/actions/partner-runner-images/issues for updates
+          #
+          # ubuntu-24.04-arm  # testing Linux/arm64 platform
           ]
-        exclude:
-          - os: ubuntu-24.04-arm
-            directory: chrome-for-testing #browser not available for Linux/arm64
+        # exclude:
+        #   - os: ubuntu-24.04-arm
+        #     directory: chrome-for-testing #browser not available for Linux/arm64
     runs-on: ${{ matrix.os }}
     steps:
       - uses: actions/checkout@v4


### PR DESCRIPTION
## Issue

Use of the GitHub Partner runner image [ubuntu-24.04-arm](https://github.com/actions/partner-runner-images/blob/main/images/arm-ubuntu-24-image.md) is unreliable. It may for instance fail simply checking out the repo.

Other users have also reported similar issues including segmentation faults. See https://github.com/actions/partner-runner-images/issues.

## Change

Disable use of [ubuntu-24.04-arm](https://github.com/actions/partner-runner-images/blob/main/images/arm-ubuntu-24-image.md) in [.github/workflows/example-tests.yml](https://github.com/cypress-io/cypress-docker-images/blob/master/.github/workflows/example-tests.yml)

## Related

- https://github.com/actions/partner-runner-images/issues/47