### PR TITLE
fix(deps): update to Node.js 22.14.0

### DIFF
--- a/factory/.env
+++ b/factory/.env
@@ -11,14 +11,14 @@ BASE_IMAGE='debian:12.9-slim'
 # Node Versions: https://nodejs.org/en/download/releases/
 # master branch needs "Active LTS" version
 # use feature branch for "Maintenance LTS" or "Current" versions
-FACTORY_DEFAULT_NODE_VERSION='22.13.1'
+FACTORY_DEFAULT_NODE_VERSION='22.14.0'
 
 # Node Versions: https://nodejs.org/en/download/releases/
 NODE_VERSION="${FACTORY_DEFAULT_NODE_VERSION}"
 
 # Update the FACTORY_VERSION to deploy cypress/factory if you make changes to
 # BASE_IMAGE, FACTORY_DEFAULT_NODE_VERSION, YARN_VERSION, factory.Dockerfile or installScripts
-FACTORY_VERSION='5.3.0'
+FACTORY_VERSION='5.3.1'
 
 # Chrome versions: https://www.ubuntuupdates.org/package/google_chrome/stable/main/base/google-chrome-stable
 CHROME_VERSION='133.0.6943.53-1'
@@ -27,7 +27,7 @@ CHROME_VERSION='133.0.6943.53-1'
 CYPRESS_VERSION='14.0.2'
 
 # Edge versions: https://packages.microsoft.com/repos/edge/pool/main/m/microsoft-edge-stable/
-EDGE_VERSION='132.0.2957.140-1'
+EDGE_VERSION='133.0.3065.59-1'
 
 # Firefox versions: https://download-installer.cdn.mozilla.net/pub/firefox/releases/
 FIREFOX_VERSION='135.0'

--- a/factory/CHANGELOG.md
+++ b/factory/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Change log
 
+## 5.3.1
+
+- Updated default node version from `22.13.1` to `22.14.0`. Addressed in [#1299](https://github.com/cypress-io/cypress-docker-images/pull/1299).
+-
 ## 5.3.0
 
 - Additionally support Firefox 135.0 and above with download file extension `xz` instead of `bz2`. (See [Firefox 135.0 release notes](https://www.mozilla.org/en-US/firefox/135.0/releasenotes/) and [Announcing Faster, Lighter Firefox Downloads for Linux with .tar.xz Packaging!](https://blog.nightly.mozilla.org/2024/11/28/announcing-faster-lighter-firefox-downloads-for-linux-with-tar-xz-packaging/)). Addresses [#1294](https://github.com/cypress-io/cypress-docker-images/issues/1294).


### PR DESCRIPTION
## Issue

- The Node.js project released an update [Node.js v22.14.0 LTS](https://nodejs.org/en/blog/release/v22.14.0) on Feb 11, 2025.

## Change

In [factory/.env](https://github.com/cypress-io/cypress-docker-images/blob/master/factory/.env) make the following updates:

| Environment variable           | Before             | After             |
| ------------------------------ | ------------------ | ----------------- |
| `FACTORY_VERSION`              | `5.3.0`            | `5.3.1`           |
| `FACTORY_DEFAULT_NODE_VERSION` | `22.13.1`          | `22.14.0`         |
| `CHROME_VERSION`               | `133.0.6943.53-1`  | no change         |
| `EDGE_VERSION`                 | `132.0.2957.140-1` | `133.0.3065.59-1` |
| `FIREFOX_VERSION`              | `135.0`            | no change         |
