### PR TITLE
chore: update to Cypress 14.0.3

### DIFF
--- a/factory/.env
+++ b/factory/.env
@@ -24,7 +24,7 @@ FACTORY_VERSION='5.3.1'
 CHROME_VERSION='133.0.6943.53-1'
 
 # Cypress versions: https://www.npmjs.com/package/cypress
-CYPRESS_VERSION='14.0.2'
+CYPRESS_VERSION='14.0.3'
 
 # Edge versions: https://packages.microsoft.com/repos/edge/pool/main/m/microsoft-edge-stable/
 EDGE_VERSION='133.0.3065.59-1'


### PR DESCRIPTION
updates Cypress to `14.0.3`