### PR TITLE
docs: correct dead README Tags link

### DIFF
--- a/README.md
+++ b/README.md
@@ -155,7 +155,7 @@ container:
   options: --user 1001
 ```
 
-See [Tag Selection](#tag-selection) above for advice on selecting a non-default image tag.
+See [Tags](#tags) section above for advice on selecting a non-default image tag.
 
 ## EACCES permission denied binary_state.json
 


### PR DESCRIPTION
## Issue

The link `Tag Selection` in the [README > Firefox not found](https://github.com/cypress-io/cypress-docker-images/blob/master/README.md#firefox-not-found) section has become stale.

The target bookmark was changed to [#tags](https://github.com/cypress-io/cypress-docker-images/blob/master/README.md#tags) as part of an update to that section.

## Change

Correct the [README > Firefox not found](https://github.com/cypress-io/cypress-docker-images/blob/master/README.md#firefox-not-found) link to the[Tags](https://github.com/cypress-io/cypress-docker-images/blob/master/README.md#tags) section on the same page.

## Verification

```shell
npm ci
npx markdown-link-check README.md
```

Ensure that no link errors are reported.