### PR TITLE
feat: enable firefox arm64 build with cypress/factory

### DIFF
--- a/circle.yml
+++ b/circle.yml
@@ -255,8 +255,11 @@ workflows:
                     parameters:
                         test-target: [
                             test-factory-electron,
+                            test-factory-firefox,
                             test-factory-cypress-included-electron,
                             test-factory-cypress-included-electron-non-root-user,
+                            test-factory-cypress-included-firefox,
+                            test-factory-cypress-included-firefox-non-root-user,
                             test-factory-all-included-electron-only
                             ]
                         resourceClass: [arm.medium]
@@ -317,7 +320,8 @@ workflows:
                     alias: browsers-arm
                     parameters:
                         test-target: [
-                            test-browsers-electron
+                            test-browsers-electron,
+                            test-browsers-firefox
                             ]
                         resourceClass: [arm.medium]
                         target: [browsers]
@@ -338,7 +342,8 @@ workflows:
                     alias: included-arm
                     parameters:
                         test-target: [
-                            test-included-electron
+                            test-included-electron,
+                            test-included-firefox
                             ]
                         resourceClass: [arm.medium]
                         target: [included]

--- a/factory/.env
+++ b/factory/.env
@@ -18,7 +18,7 @@ NODE_VERSION="${FACTORY_DEFAULT_NODE_VERSION}"
 
 # Update the FACTORY_VERSION to deploy cypress/factory if you make changes to
 # BASE_IMAGE, FACTORY_DEFAULT_NODE_VERSION, YARN_VERSION, factory.Dockerfile or installScripts
-FACTORY_VERSION='5.4.0'
+FACTORY_VERSION='5.5.0'
 
 # Chrome versions: https://www.ubuntuupdates.org/package/google_chrome/stable/main/base/google-chrome-stable
 CHROME_VERSION='134.0.6998.88-1'

--- a/factory/CHANGELOG.md
+++ b/factory/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Change log
 
+## 5.5.0
+
+- Add factory support for Firefox `arm64` with versions `136.0` and above. Addresses [#1306](https://github.com/cypress-io/cypress-docker-images/issues/1306).
+
 ## 5.4.0
 
 - Add support for HTTP_PROXY when building a `cypress/factory` based image. Addressed in [#1276](https://github.com/cypress-io/cypress-docker-images/pull/1276).

--- a/factory/installScripts/firefox/default.sh
+++ b/factory/installScripts/firefox/default.sh
@@ -1,6 +1,11 @@
 #! /bin/bash
 
 # Firefox does not have a debian package that is kept up to date, so instead we install deps directly and download the tar to unzip.
+#
+# $1: version (example: 136.0)
+# $2: compression (xz or bz2)
+# $3: platform (linux-x86_64 or linux-aarch64)
+
 apt-get update \
   && apt-get install -y \
     libxtst6 \
@@ -8,7 +13,7 @@ apt-get update \
     libdbus-glib-1-2 \
     mplayer \
     xz-utils \
-  && wget --no-verbose -O /tmp/firefox.tar.${2} https://download-installer.cdn.mozilla.net/pub/firefox/releases/${1}/linux-x86_64/en-US/firefox-${1}.tar.${2} \
+  && wget --no-verbose -O /tmp/firefox.tar.${2} https://download-installer.cdn.mozilla.net/pub/firefox/releases/${1}/${3}/en-US/firefox-${1}.tar.${2} \
   && tar -C /opt -xaf /tmp/firefox.tar.${2} \
   && rm /tmp/firefox.tar.${2} \
   && ln -fs /opt/firefox/firefox /usr/bin/firefox \

--- a/factory/installScripts/firefox/install-firefox-version.js
+++ b/factory/installScripts/firefox/install-firefox-version.js
@@ -8,10 +8,28 @@ if (!firefoxVersion) {
   return
 }
 
-if (process.arch !== 'x64') {
-  console.log('Not downloading Firefox since we are not on x64. For arm64 status see https://bugzilla.mozilla.org/show_bug.cgi?id=1678342')
-  return
+const architecture = process.arch
+let platform
+
+switch (architecture) {
+  case 'x64':
+    platform = 'linux-x86_64'
+    break
+  case 'arm64':
+    platform = 'linux-aarch64'
+    if (firefoxVersion >= '136.0') {
+      break
+    }
+    else {
+      console.log(`Firefox ${firefoxVersion} not available for arm64, minimum 136.0 required, skipping download`)
+      return
+    }
+  default:
+    console.log(`Unsupported architecture ${architecture} for Firefox, skipping download`)
+    return
 }
+
+console.log(`Installing Firefox version ${firefoxVersion} for ${architecture}`)
 
 // Change in compression from bz2 to xz in Firefox 135.0
 // See https://www.mozilla.org/en-US/firefox/135.0/releasenotes/
@@ -22,10 +40,8 @@ if (firefoxVersion >= '135.0') {
   compression = `xz`
 }
 
-console.log('Installing Firefox version: ', firefoxVersion)
-
 // Insert logic here if needed to run a different install script based on chrome version.
-const install = spawn(`${__dirname}/default.sh`, [firefoxVersion, compression], {stdio: 'inherit'})
+const install = spawn(`${__dirname}/default.sh`, [firefoxVersion, compression, platform], { stdio: 'inherit' })
 
 install.on('error', function (error) {
   console.log('child process errored with ' + error.toString())


### PR DESCRIPTION
- closes https://github.com/cypress-io/cypress-docker-images/issues/1306

## Situation

- Until now, Cypress Docker images only had access to x86 versions of Firefox. The [examples/firefox-esr](https://github.com/cypress-io/cypress-docker-images/tree/master/examples/firefox-esr) additionally demonstrated how to build Firefox from the ESR (Extended Support Release) channel into a custom Cypress Docker image.
- With the release of [Firefox 136.0](https://www.mozilla.org/en-US/firefox/136.0/releasenotes/), Mozilla announced:
  > On Linux, Firefox is now available on ARM64 (AArch64), with installation options via APT and tarballs. Flatpak support is coming soon.

- [factory/installScripts/firefox](https://github.com/cypress-io/cypress-docker-images/tree/master/factory/installScripts/firefox) skips installation if `x64` is not detected. This prevents any attempt to install Firefox for `arm64`.

## Change

Modify scripts in [factory/installScripts/firefox](https://github.com/cypress-io/cypress-docker-images/tree/master/factory/installScripts/firefox) to allow installing Firefox `arm64` in addition to `amd64`:

CDN is

- `https://download-installer.cdn.mozilla.net/pub/firefox/releases/<version>/linux-x86_64/en-US/` for `amd64`
- `https://download-installer.cdn.mozilla.net/pub/firefox/releases/<version>/linux-aarch64/en-US/` for `arm64` (new)

This change is backwards-compatible with previous versions of Firefox.

Add Firefox arm tests to [factory/test-project/docker-compose.yml](https://github.com/cypress-io/cypress-docker-images/blob/master/factory/test-project/docker-compose.yml). These tests could be made required in GitHub branch protection rules at a later stage.

In [factory/.env](https://github.com/cypress-io/cypress-docker-images/blob/master/factory/.env) make the following updates:

| Environment variable           | Before            | After     |
| ------------------------------ | ----------------- | --------- |
| `FACTORY_VERSION`              | `5.4.0`           | `5.5.0`   |
| `FACTORY_DEFAULT_NODE_VERSION` | `22.14.0`         | no change |
| `CHROME_VERSION`               | `134.0.6998.88-1` | no change |
| `EDGE_VERSION`                 | `134.0.3124.51-1` | no change |
| `FIREFOX_VERSION`              | `136.0.1`         | no change |

## Outcome

- Custom Cypress Docker images built for the `arm64` architecture can contain Firefox `>=136.0`
- When `FIREFOX_VERSION` or `FACTORY_DEFAULT_NODE_VERSION` is bumped in any future PR, any new Debian Linux `arm64` Cypress Docker images `cypress/browsers` and `cypress/included` will include Firefox
