### PR TITLE
chore: add node 20.18.3 images to base-internal

### DIFF
--- a/base-internal/releases/node-20/20.18.3-bullseye/Dockerfile
+++ b/base-internal/releases/node-20/20.18.3-bullseye/Dockerfile
@@ -1,0 +1,94 @@
+# build it with command
+#   docker build -t cypress/base-internal:20.18.3-bullseye --platform linux/amd64 .
+#
+FROM node:20.18.3-bullseye-slim
+
+RUN apt-get update && \
+  apt-get install --no-install-recommends -y \
+  libgtk2.0-0 \
+  libgtk-3-0 \
+  libnotify-dev \
+  libgconf-2-4 \
+  libgbm-dev \
+  libnss3 \
+  libxss1 \
+  libasound2 \
+  libxtst6 \
+  procps \
+  xauth \
+  xvfb \
+  build-essential \
+  # install text editors
+  vim-tiny \
+  nano \
+  # install emoji font
+  fonts-noto-color-emoji \
+  # install Chinese fonts
+  # this list was copied from https://github.com/jim3ma/docker-leanote
+  fonts-arphic-bkai00mp \
+  fonts-arphic-bsmi00lp \
+  fonts-arphic-gbsn00lp \
+  fonts-arphic-gkai00mp \
+  fonts-arphic-ukai \
+  fonts-arphic-uming \
+  ttf-wqy-zenhei \
+  ttf-wqy-microhei \
+  xfonts-wqy \
+  # clean up
+  && rm -rf /var/lib/apt/lists/* \
+  && apt-get clean
+
+USER root
+
+RUN node --version
+
+# Install dependencies
+RUN apt-get update && \
+  apt-get install -y \
+  fonts-liberation \
+  git \
+  libcurl4 \
+  libcurl3-gnutls \
+  libcurl3-nss \
+  libvulkan1 \
+  xdg-utils \
+  wget \
+  # needed for circle orb browsers to install firefox
+  gpg \
+  # needed for circle orb browsers to install chromedriver
+  jq \
+  curl \
+  # chrome dependencies
+  libu2f-udev \
+  # firefox dependencies
+  bzip2 \
+  # add codecs needed for video playback in firefox
+  # https://github.com/cypress-io/cypress-docker-images/issues/150
+  mplayer \
+  \
+  # clean up
+  && rm -rf /var/lib/apt/lists/* \
+  && apt-get clean
+
+# install libappindicator3-1 - not included with Debian 11
+RUN wget --no-verbose /usr/src/libappindicator3-1_0.4.92-7_amd64.deb "http://ftp.us.debian.org/debian/pool/main/liba/libappindicator/libappindicator3-1_0.4.92-7_amd64.deb" && \
+  dpkg -i /usr/src/libappindicator3-1_0.4.92-7_amd64.deb ; \
+  apt-get install -f -y && \
+  rm -f /usr/src/libappindicator3-1_0.4.92-7_amd64.deb
+
+# a few environment variables to make NPM installs easier
+# good colors for most applications
+ENV TERM=xterm
+# avoid million NPM install messages
+ENV npm_config_loglevel=warn
+
+RUN npm --version \
+  && npm install -g yarn@latest --force \
+  && yarn --version \
+  && node -p process.versions \
+  && node -p 'module.paths' \
+  && echo  " node version:    $(node -v) \n" \
+    "npm version:     $(npm -v) \n" \
+    "yarn version:    $(yarn -v) \n" \
+    "debian version:  $(cat /etc/debian_version) \n" \
+    "user:            $(whoami) \n"

--- a/base-internal/releases/node-20/20.18.3-bullseye/README.md
+++ b/base-internal/releases/node-20/20.18.3-bullseye/README.md
@@ -1,0 +1,14 @@
+# cypress/base-internal:20.18.3-bullseye
+
+A Docker image with all dependencies pre-installed.
+
+NOTE: This image is intended for internal use with https://github.com/cypress-io/cypress. It contains a few differences from the factory, such as:
+
+#### Dependency Additions
+
+- xauth (to run xvfb inside system-tests)
+- build-essential to install `make` and other linux build packages
+
+#### Env variables
+
+- Does not contain the `CACHE_FOLDER` and `FACTORY_DEFAULT_NODE_VERSION` env variables to keep unit tests non environment specific

--- a/base-internal/releases/node-20/20.18.3-bullseye/build.sh
+++ b/base-internal/releases/node-20/20.18.3-bullseye/build.sh
@@ -1,0 +1,7 @@
+set e+x
+
+# build image with Cypress dependencies
+LOCAL_NAME=cypress/base-internal:20.18.3-bullseye
+
+echo "Building $LOCAL_NAME"
+docker build -t $LOCAL_NAME .

--- a/base-internal/releases/node-20/20.18.3-yarn-berry/Dockerfile
+++ b/base-internal/releases/node-20/20.18.3-yarn-berry/Dockerfile
@@ -1,0 +1,68 @@
+# build it with command
+#   docker build -t cypress/base-internal:20.18.3-yarn-berry --platform linux/amd64 .
+#
+FROM node:20.18.3-bookworm-slim
+
+RUN apt-get update && \
+  apt-get install --no-install-recommends -y \
+  libgtk2.0-0 \
+  libgtk-3-0 \
+  libnotify-dev \
+  libgconf-2-4 \
+  libgbm-dev \
+  libnss3 \
+  libxss1 \
+  libasound2 \
+  libxtst6 \
+  procps \
+  xauth \
+  xvfb \
+  build-essential \
+  # install text editors
+  vim-tiny \
+  nano \
+  wget \
+  curl \
+  git \
+  # install emoji font
+  fonts-noto-color-emoji \
+  # install Chinese fonts
+  # this list was copied from https://github.com/jim3ma/docker-leanote
+  fonts-arphic-bkai00mp \
+  fonts-arphic-bsmi00lp \
+  fonts-arphic-gbsn00lp \
+  fonts-arphic-gkai00mp \
+  fonts-arphic-ukai \
+  fonts-arphic-uming \
+  ttf-wqy-zenhei \
+  ttf-wqy-microhei \
+  xfonts-wqy \
+  # clean up
+  && rm -rf /var/lib/apt/lists/* \
+  && apt-get clean
+
+  RUN apt-get update && \
+  apt-get install --no-install-recommends -y \
+  ca-certificates
+
+# a few environment variables to make NPM installs easier
+# good colors for most applications
+ENV TERM=xterm
+# avoid million NPM install messages
+ENV npm_config_loglevel=warn
+# allow installing when the main user is root
+ENV npm_config_unsafe_perm=true
+# need to enable corepack to set yarn version
+RUN corepack enable
+# set the yarn version to 4 to get yarn berry, which does not install modules into node_modules
+RUN yarn set version 4.3.1
+
+RUN npm --version \
+  && yarn --version \
+  && node -p process.versions \
+  && node -p 'module.paths' \
+  && echo  " node version:    $(node -v) \n" \
+    "npm version:     $(npm -v) \n" \
+    "yarn version:    $(yarn -v) \n" \
+    "debian version:  $(cat /etc/debian_version) \n" \
+    "user:            $(whoami) \n"

--- a/base-internal/releases/node-20/20.18.3-yarn-berry/README.md
+++ b/base-internal/releases/node-20/20.18.3-yarn-berry/README.md
@@ -1,0 +1,13 @@
+# cypress/base-internal:20.18.3-yarn-berry
+
+A Docker image with all dependencies pre-installed.
+
+NOTE: This image is intended for internal use with https://github.com/cypress-io/cypress. It contains a few differences from the factory, such as:
+
+#### Dependency Additions
+* xauth (to run xvfb inside system-tests)
+* build-essential to install `make` and other linux build packages
+* has yarn 4 to test yarn PnP dependencies with Cypress in order to verify the `@cypress/webpack-batteries-included-preprocessor` works with yarn PnP (without `node_modules`)
+
+#### Env variables
+* Does not contain the `CACHE_FOLDER` and `FACTORY_DEFAULT_NODE_VERSION` env variables to keep unit tests non environment specific

--- a/base-internal/releases/node-20/20.18.3-yarn-berry/build.sh
+++ b/base-internal/releases/node-20/20.18.3-yarn-berry/build.sh
@@ -1,0 +1,7 @@
+set e+x
+
+# build image with Cypress dependencies
+LOCAL_NAME=cypress/base-internal:20.18.3-yarn-berry
+
+echo "Building $LOCAL_NAME"
+docker build -t $LOCAL_NAME .

--- a/base-internal/releases/node-20/20.18.3/Dockerfile
+++ b/base-internal/releases/node-20/20.18.3/Dockerfile
@@ -1,0 +1,56 @@
+# build it with command
+#   docker build -t cypress/base-internal:20.18.3 --platform linux/amd64 .
+#
+FROM node:20.18.3-bookworm-slim
+
+RUN apt-get update && \
+  apt-get install --no-install-recommends -y \
+  libgtk2.0-0 \
+  libgtk-3-0 \
+  libnotify-dev \
+  libgconf-2-4 \
+  libgbm-dev \
+  libnss3 \
+  libxss1 \
+  libasound2 \
+  libxtst6 \
+  procps \
+  xauth \
+  xvfb \
+  build-essential \
+  # install text editors
+  vim-tiny \
+  nano \
+  # install emoji font
+  fonts-noto-color-emoji \
+  # install Chinese fonts
+  # this list was copied from https://github.com/jim3ma/docker-leanote
+  fonts-arphic-bkai00mp \
+  fonts-arphic-bsmi00lp \
+  fonts-arphic-gbsn00lp \
+  fonts-arphic-gkai00mp \
+  fonts-arphic-ukai \
+  fonts-arphic-uming \
+  ttf-wqy-zenhei \
+  ttf-wqy-microhei \
+  xfonts-wqy \
+  # clean up
+  && rm -rf /var/lib/apt/lists/* \
+  && apt-get clean
+
+# a few environment variables to make NPM installs easier
+# good colors for most applications
+ENV TERM=xterm
+# avoid million NPM install messages
+ENV npm_config_loglevel=warn
+
+RUN npm --version \
+  && npm install -g yarn@latest --force \
+  && yarn --version \
+  && node -p process.versions \
+  && node -p 'module.paths' \
+  && echo  " node version:    $(node -v) \n" \
+    "npm version:     $(npm -v) \n" \
+    "yarn version:    $(yarn -v) \n" \
+    "debian version:  $(cat /etc/debian_version) \n" \
+    "user:            $(whoami) \n"

--- a/base-internal/releases/node-20/20.18.3/README.md
+++ b/base-internal/releases/node-20/20.18.3/README.md
@@ -1,0 +1,14 @@
+# cypress/base-internal:20.18.3
+
+A Docker image with all dependencies pre-installed.
+
+NOTE: This image is intended for internal use with https://github.com/cypress-io/cypress. It contains a few differences from the factory, such as:
+
+#### Dependency Additions
+
+- xauth (to run xvfb inside system-tests)
+- build-essential to install `make` and other linux build packages
+
+#### Env variables
+
+- Does not contain the `CACHE_FOLDER` and `FACTORY_DEFAULT_NODE_VERSION` env variables to keep unit tests non environment specific

--- a/base-internal/releases/node-20/20.18.3/build.sh
+++ b/base-internal/releases/node-20/20.18.3/build.sh
@@ -1,0 +1,7 @@
+set e+x
+
+# build image with Cypress dependencies
+LOCAL_NAME=cypress/base-internal:20.18.3
+
+echo "Building $LOCAL_NAME"
+docker build -t $LOCAL_NAME .


### PR DESCRIPTION
Necessary for Electron 34 latest version: https://github.com/cypress-io/cypress/pull/31260