### PR TITLE
chore: update browsers and bump cypress to 14.2.0 inside the factory

### DIFF
--- a/factory/.env
+++ b/factory/.env
@@ -21,16 +21,16 @@ NODE_VERSION="${FACTORY_DEFAULT_NODE_VERSION}"
 FACTORY_VERSION='5.4.0'
 
 # Chrome versions: https://www.ubuntuupdates.org/package/google_chrome/stable/main/base/google-chrome-stable
-CHROME_VERSION='133.0.6943.126-1'
+CHROME_VERSION='134.0.6998.88-1'
 
 # Cypress versions: https://www.npmjs.com/package/cypress
-CYPRESS_VERSION='14.1.0'
+CYPRESS_VERSION='14.2.0'
 
 # Edge versions: https://packages.microsoft.com/repos/edge/pool/main/m/microsoft-edge-stable/
-EDGE_VERSION='133.0.3065.82-1'
+EDGE_VERSION='134.0.3124.51-1'
 
 # Firefox versions: https://download-installer.cdn.mozilla.net/pub/firefox/releases/
-FIREFOX_VERSION='135.0.1'
+FIREFOX_VERSION='136.0.1'
 
 # Yarn versions: https://www.npmjs.com/package/yarn and
 # https://classic.yarnpkg.com/latest-version


### PR DESCRIPTION
Updates:
Firefox from 135 to 136
Chrome from 133 to 134
Edge from 133 to 134

Cypress from 14.1.0 to 14.2.0