### PR TITLE
docs: fix CHANGELOG link to Docker Hub cypress/factory

### DIFF
--- a/factory/CHANGELOG.md
+++ b/factory/CHANGELOG.md
@@ -197,4 +197,4 @@
 
 ## 1.0.0
 
-- Initial Release of [cypress/factory](https://hub.docker.com/repository/docker/cypress/factory/general#)
+- Initial Release of [cypress/factory](https://hub.docker.com/r/cypress/factory)


### PR DESCRIPTION
## Issue

Executing `npm run check:markdown` fails in [factory/CHANGELOG.md](https://github.com/cypress-io/cypress-docker-images/blob/master/factory/CHANGELOG.md) with

> [✖] https://hub.docker.com/repository/docker/cypress/factory/general#

## Change

Correct the link in [factory/CHANGELOG.md](https://github.com/cypress-io/cypress-docker-images/blob/master/factory/CHANGELOG.md)

from

`https://hub.docker.com/repository/docker/cypress/factory/general#` (which requires sign in to access)

to

https://hub.docker.com/r/cypress/factory (which requires no sign in)

## Verification

Execute

```shell
npm run check:markdown
```

and confirm no link errors are reported.