### PR TITLE
docs: add firefox arm64 build factory

### DIFF
--- a/factory/.env
+++ b/factory/.env
@@ -21,15 +21,18 @@ NODE_VERSION="${FACTORY_DEFAULT_NODE_VERSION}"
 FACTORY_VERSION='5.5.0'
 
 # Chrome versions: https://www.ubuntuupdates.org/package/google_chrome/stable/main/base/google-chrome-stable
+# Linux/amd64 only
 CHROME_VERSION='134.0.6998.88-1'
 
 # Cypress versions: https://www.npmjs.com/package/cypress
 CYPRESS_VERSION='14.2.0'
 
 # Edge versions: https://packages.microsoft.com/repos/edge/pool/main/m/microsoft-edge-stable/
+# Linux/amd64 only
 EDGE_VERSION='134.0.3124.51-1'
 
 # Firefox versions: https://download-installer.cdn.mozilla.net/pub/firefox/releases/
+# Linux/amd64 for all versions, Linux/arm64 for versions 136.0 and above
 FIREFOX_VERSION='136.0.1'
 
 # Yarn versions: https://www.npmjs.com/package/yarn and

--- a/factory/README.md
+++ b/factory/README.md
@@ -70,6 +70,8 @@ Example: `CHROME_VERSION='131.0.6778.264-1'`
 
 [Chrome versions](https://www.ubuntuupdates.org/package/google_chrome/stable/main/base/google-chrome-stable)
 
+This browser is currently available only for the `Linux/amd64` platform.
+
 ### FIREFOX_VERSION
 
 The version of Firefox to install. If the `ARG` variable is unset or an empty string, Firefox is not installed. The exact version must be used, no wildcards or shorthands are supported.
@@ -78,6 +80,8 @@ Example: `FIREFOX_VERSION='134.0'`
 
 [Firefox versions](https://download-installer.cdn.mozilla.net/pub/firefox/releases/)
 
+This browser is available for the `Linux/amd64` platform in all versions, and for the `Linux/arm64` platform in Firefox `136.0` and above.
+
 ### EDGE_VERSION
 
 The version of Edge to install. If the `ARG` variable is unset or an empty string, Edge is not installed. The exact version must be used, no wildcards or shorthands are supported.
@@ -85,6 +89,8 @@ The version of Edge to install. If the `ARG` variable is unset or an empty strin
 Example: `EDGE_VERSION='131.0.2903.112-1'`
 
 [Edge versions](https://packages.microsoft.com/repos/edge/pool/main/m/microsoft-edge-stable/)
+
+This browser is currently available only for the `Linux/amd64` platform.
 
 ## Usage
 


### PR DESCRIPTION
- follows on from https://github.com/cypress-io/cypress-docker-images/pull/1307

## Situation

- https://github.com/cypress-io/cypress-docker-images/pull/1307 added the ability for `cypress/factory` to generate Docker images including Firefox `arm64`

The above is not yet reflected in the [factory/README](https://github.com/cypress-io/cypress-docker-images/blob/master/factory/README.md) documentation.

## Change

Add information to the following, to cover the added support and availability of Firefox for `Linux/arm64` in release `136.0` and above, and to explicitly list other individual browsers availability in `Linux/arm64` images:

- [factory/README](https://github.com/cypress-io/cypress-docker-images/blob/master/factory/README.md)
- [factory/.env](https://github.com/cypress-io/cypress-docker-images/blob/master/factory/.env)

Note that updates to other README documents are delayed until regular Cypress Docker images `cypress/browsers` and `cypress/included` publication is triggered by any new browser release, a new Node.js LTS release or a new Cypress release. ~~This is likely to happen in the next week or two.~~ Edit: see PR #1315 