### PR TITLE
chore: update Edge to 134.0.3124.68-1

### DIFF
--- a/factory/.env
+++ b/factory/.env
@@ -27,7 +27,7 @@ CHROME_VERSION='134.0.6998.88-1'
 CYPRESS_VERSION='14.2.0'
 
 # Edge versions: https://packages.microsoft.com/repos/edge/pool/main/m/microsoft-edge-stable/
-EDGE_VERSION='134.0.3124.51-1'
+EDGE_VERSION='134.0.3124.68-1'
 
 # Firefox versions: https://download-installer.cdn.mozilla.net/pub/firefox/releases/
 FIREFOX_VERSION='136.0.1'


### PR DESCRIPTION
## Situation

The following latest images were built with `cypress/factory:5.4.0` that did not have the capability to publish Firefox to `Linux/arm64`:

- `cypress/browsers:node-22.14.0-chrome-134.0.6998.88-1-ff-136.0.1-edge-134.0.3124.51-1`
- `cypress/included:cypress-14.2.0-node-22.14.0-chrome-134.0.6998.88-1-ff-136.0.1-edge-134.0.3124.51-1`

`cypress/factory:5.5.0`, which is capable of publishing Firefox under `Linux/arm64`, is now itself published.

Any new builds can now include Firefox `Linux/arm64` into `cypress/browsers` and `cypress/included`

The Microsoft Edge patch `134.0.3124.68-1` is now available (see [Microsoft Edge Stable Channel release notes](https://learn.microsoft.com/en-us/deployedge/microsoft-edge-relnote-stable-channel)). This can be published as an update in its own right, with the added convenience of triggering a publication of Firefox `136.0.1` to `Linux/arm64` images.

## Change

| Environment variable           | Before            | After             |
| ------------------------------ | ----------------- | ----------------- |
| `FACTORY_VERSION`              | `5.5.0`           | no change         |
| `FACTORY_DEFAULT_NODE_VERSION` | `22.14.0`         | no change         |
| `CHROME_VERSION`               | `134.0.6998.88-1` | no change         |
| `EDGE_VERSION`                 | `134.0.3124.51-1` | `134.0.3124.68-1` |
| `FIREFOX_VERSION`              | `136.0.1`         | no change         |