### PR TITLE
chore: update Firefox 136.0.2 Edge 134.0.3124.68-1

### DIFF
--- a/factory/.env
+++ b/factory/.env
@@ -29,11 +29,11 @@ CYPRESS_VERSION='14.2.0'
 
 # Edge versions: https://packages.microsoft.com/repos/edge/pool/main/m/microsoft-edge-stable/
 # Linux/amd64 only
-EDGE_VERSION='134.0.3124.51-1'
+EDGE_VERSION='134.0.3124.68-1'
 
 # Firefox versions: https://download-installer.cdn.mozilla.net/pub/firefox/releases/
 # Linux/amd64 for all versions, Linux/arm64 for versions 136.0 and above
-FIREFOX_VERSION='136.0.1'
+FIREFOX_VERSION='136.0.2'
 
 # Yarn versions: https://www.npmjs.com/package/yarn and
 # https://classic.yarnpkg.com/latest-version


### PR DESCRIPTION
## Situation

The following latest images were built with `cypress/factory:5.4.0` that did not have the capability to publish Firefox to `Linux/arm64`:

- `cypress/browsers:node-22.14.0-chrome-134.0.6998.88-1-ff-136.0.1-edge-134.0.3124.51-1`
- `cypress/included:cypress-14.2.0-node-22.14.0-chrome-134.0.6998.88-1-ff-136.0.1-edge-134.0.3124.51-1`

`cypress/factory:5.5.0` which is capable of publishing Firefox under `Linux/arm64`, is now itself published.

[Firefox 136.0.2](https://www.mozilla.org/en-US/firefox/136.0.2/releasenotes/) is released and this will now be included into both `Linux/arm64` and `Linux/amd64` images `cypress/browsers` and `cypress/included`.

Microsoft Edge patch `134.0.3124.68-1` is also included in this update (see [Microsoft Edge Stable Channel release notes](https://learn.microsoft.com/en-us/deployedge/microsoft-edge-relnote-stable-channel)) so that all browsers (Chrome, Edge and Firefox) are at their latest versions.

## Change

| Environment variable           | Before            | After             |
| ------------------------------ | ----------------- | ----------------- |
| `FACTORY_VERSION`              | `5.5.0`           | no change         |
| `FACTORY_DEFAULT_NODE_VERSION` | `22.14.0`         | no change         |
| `CHROME_VERSION`               | `134.0.6998.88-1` | no change         |
| `EDGE_VERSION`                 | `134.0.3124.51-1` | `134.0.3124.68-1` |
| `FIREFOX_VERSION`              | `136.0.1`         | `136.0.2`         |