### PR TITLE
build: migrate to oci manifest

### DIFF
--- a/circle.yml
+++ b/circle.yml
@@ -225,15 +225,6 @@ jobs:
                     docker run --privileged --rm tonistiigi/binfmt --install linux/amd64,linux/arm64
                     docker buildx create --name builder --use
 
-                    # Disable default provenance attestation for Buildx
-                    # https://docs.docker.com/build/building/variables/#buildx_no_default_attestations
-                    # https://docs.docker.com/build/release-notes/#0100
-                    # Keeps using docker
-                    # "mediaType": "application/vnd.docker.distribution.manifest.list.v2+json"
-                    # instead of moving to oci, which may cause compatibility issues, for example
-                    # "mediaType": "application/vnd.oci.image.index.v1+json"
-                    export BUILDX_NO_DEFAULT_ATTESTATIONS=1
-
                     docker login -u "$DOCKERHUB_USERNAME" --password "$DOCKERHUB_PASS"
                     docker buildx bake -f ./docker-compose.yml --progress plain --set *.platform=linux/arm64,linux/amd64 --push << parameters.target >>
 

--- a/factory/.env
+++ b/factory/.env
@@ -18,7 +18,7 @@ NODE_VERSION="${FACTORY_DEFAULT_NODE_VERSION}"
 
 # Update the FACTORY_VERSION to deploy cypress/factory if you make changes to
 # BASE_IMAGE, FACTORY_DEFAULT_NODE_VERSION, YARN_VERSION, factory.Dockerfile or installScripts
-FACTORY_VERSION='5.5.0'
+FACTORY_VERSION='5.6.0'
 
 # Chrome versions: https://www.ubuntuupdates.org/package/google_chrome/stable/main/base/google-chrome-stable
 # Linux/amd64 only

--- a/factory/CHANGELOG.md
+++ b/factory/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Change log
 
+## 5.6.0
+
+- Change image manifest to [Provenance attestations](https://docs.docker.com/build/metadata/attestations/slsa-provenance/) for compatibility with [Open Container Initiative](https://github.com/opencontainers) [OCI image spec](https://github.com/opencontainers/image-spec/blob/main/spec.md). Addresses [#1316](https://github.com/cypress-io/cypress-docker-images/issues/1316).
+
 ## 5.5.0
 
 - Add factory support for Firefox `arm64` with versions `136.0` and above. Addresses [#1306](https://github.com/cypress-io/cypress-docker-images/issues/1306).


### PR DESCRIPTION
- closes https://github.com/cypress-io/cypress-docker-images/issues/1316

## Situation

https://github.com/cypress-io/cypress-docker-images/blob/8ebc9b0cbce51656902955b1b70892c52fee4418/circle.yml#L228-L235

pins the publication process to using the historical manifest format:

```json
"schemaVersion": 2,
"mediaType": "application/vnd.docker.distribution.manifest.list.v2+json",
```

- Refer to #1316 for further background information

## Change

Move from the historical manifest format to use the default OCI manifest.

- Remove [BUILDX_NO_DEFAULT_ATTESTATIONS=1](https://docs.docker.com/build/building/variables/#buildx_no_default_attestations) from the [circle.yml](https://github.com/cypress-io/cypress-docker-images/blob/master/circle.yml) workflow to allow [Provenance attestations](https://docs.docker.com/build/metadata/attestations/slsa-provenance/) to be written to published Cypress Docker images.
- This changes Cypress Docker image manifest of published images for compatibility with the [Open Container Initiative](https://github.com/opencontainers) [OCI image spec](https://github.com/opencontainers/image-spec/blob/main/spec.md).

- Bump `FACTORY_VERSION` to `5.6.0`

| Environment variable | Before  | After   |
| -------------------- | ------- | ------- |
| `FACTORY_VERSION`    | `5.5.0` | `5.6.0` |
