### PR TITLE
build: add factory Yarn Modern (version >=2) unsupported message

### DIFF
--- a/factory/.env
+++ b/factory/.env
@@ -18,7 +18,7 @@ NODE_VERSION="${FACTORY_DEFAULT_NODE_VERSION}"
 
 # Update the FACTORY_VERSION to deploy cypress/factory if you make changes to
 # BASE_IMAGE, FACTORY_DEFAULT_NODE_VERSION, YARN_VERSION, factory.Dockerfile or installScripts
-FACTORY_VERSION='5.6.0'
+FACTORY_VERSION='5.7.0'
 
 # Chrome versions: https://www.ubuntuupdates.org/package/google_chrome/stable/main/base/google-chrome-stable
 # Linux/amd64 only
@@ -36,7 +36,8 @@ EDGE_VERSION='134.0.3124.68-1'
 FIREFOX_VERSION='136.0.2'
 
 # Yarn versions: https://www.npmjs.com/package/yarn and
-# https://classic.yarnpkg.com/latest-version
+# Yarn v1 Classic only https://classic.yarnpkg.com/latest-version
+# Yarn Modern (versions 2 and above) are not supported https://yarnpkg.com/
 YARN_VERSION='1.22.22'
 
 # Webkit versions: https://www.npmjs.com/package/playwright-webkit

--- a/factory/CHANGELOG.md
+++ b/factory/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Change log
 
+## 5.7.0
+
+- Show user-friendly error message if Yarn Modern (`YARN_VERSION>=2`) specified for factory build. Addresses [#1317](https://github.com/cypress-io/cypress-docker-images/issues/1317).
+
 ## 5.6.0
 
 - Change image manifest to [Provenance attestations](https://docs.docker.com/build/metadata/attestations/slsa-provenance/) for compatibility with [Open Container Initiative](https://github.com/opencontainers) [OCI image spec](https://github.com/opencontainers/image-spec/blob/main/spec.md). Addresses [#1316](https://github.com/cypress-io/cypress-docker-images/issues/1316).

--- a/factory/README.md
+++ b/factory/README.md
@@ -52,7 +52,10 @@ The version of Yarn v1 Classic to install (via npm). If the `ARG` variable is un
 
 Example: `YARN_VERSION='1.22.22'`
 
-[Yarn versions](https://www.npmjs.com/package/yarn)
+[Yarn v1 versions](https://www.npmjs.com/package/yarn)
+
+[Yarn Modern](https://yarnpkg.com/) (versions 2 and above) are not supported.
+They are not currently published to the npm registry and require the experimental [Corepack](https://yarnpkg.com/corepack) to [install](https://yarnpkg.com/getting-started/install).
 
 ### CYPRESS_VERSION
 

--- a/factory/installScripts/yarn/install-yarn-version.js
+++ b/factory/installScripts/yarn/install-yarn-version.js
@@ -8,6 +8,11 @@ if (!yarnVersion) {
   return
 }
 
+if (yarnVersion >= '2') {
+  console.log(`Yarn ${yarnVersion} is not supported, Yarn installation failed`)
+  process.exit(1)
+}
+
 console.log('Installing Yarn version: ', yarnVersion)
 
 // Insert logic here if needed to run a different install script based on version.


### PR DESCRIPTION
- relates to https://github.com/cypress-io/cypress-docker-images/issues/882
- closes https://github.com/cypress-io/cypress-docker-images/issues/1317

## Situation

If `YARN_VERSION` is set to Yarn version >=2, corresponding to Yarn Modern, Cypress factory outputs a 404 message.

Yarn Modern is not published to the npm registry, like Yarn v1 Classic is, explaining the 404 error.
Yarn Modern prefers being [installed](https://yarnpkg.com/getting-started/install) with [Corepack](https://yarnpkg.com/corepack) which however remains in [experimental status](https://nodejs.org/docs/latest/api/corepack.html) and is not recommended for production use.

## Change

In [factory/installScripts/yarn/install-yarn-version.js](https://github.com/cypress-io/cypress-docker-images/blob/master/factory/installScripts/yarn/install-yarn-version.js) trap and reject `YARN_VERSION >=2` with a user-friendly error message.

Add corresponding information to

- [factory/README.md](https://github.com/cypress-io/cypress-docker-images/blob/master/factory/README.md)
- [factory/.env](https://github.com/cypress-io/cypress-docker-images/blob/master/factory/.env)

| Environment variable | Before   | After    |
| -------------------- | -------- | -------- |
| `FACTORY_VERSION`    | `5.6.0` | `5.7.0` |

## Verification

```shell
git clone --branch factory/yarn-modern-unsupported https://github.com/MikeMcC399/cypress-docker-images
cd cypress-docker-images
cd factory
docker compose build factory
cd $(mktemp -d)
cat > Dockerfile <<EOT
ARG YARN_VERSION='2.0.0'
FROM cypress/factory
EOT
docker build -t test .
docker build --build-arg YARN_VERSION='3.8.7' -t test .
docker build --build-arg YARN_VERSION='4.7.0' -t test .
```

and confirm build failure with error message, for each unsupported version, similar to:

> Yarn 2.0.0 is not supported, Yarn installation failed

Test supported Yarn version:

```shell
docker build --build-arg YARN_VERSION='1.22.22' -t test .
```

which should succeed with:

>  => exporting to image
