### PR TITLE
test: add firefox arm64 examples tests for gha

### DIFF
--- a/.github/workflows/example-tests.yml
+++ b/.github/workflows/example-tests.yml
@@ -14,24 +14,20 @@ jobs:
       fail-fast: false
       matrix:
         directory: [
-          basic-mini,
-          basic,
-          chrome-for-testing,
-          chromium,
-          firefox-esr,
-          included-as-non-root
+            basic-mini, # testing cypress/included
+            basic, # testing cypress/browsers
+            chrome-for-testing,
+            chromium,
+            firefox-esr,
+            included-as-non-root,
           ]
         os: [
-          ubuntu-24.04     # testing Linux/amd64 platform
-          #
-          # temporarily disable testing on arm due to reliability issues
-          # see https://github.com/actions/partner-runner-images/issues for updates
-          #
-          # ubuntu-24.04-arm  # testing Linux/arm64 platform
+            ubuntu-24.04, # testing Linux/amd64 platform
+            ubuntu-24.04-arm, # testing Linux/arm64 platform
           ]
-        # exclude:
-        #   - os: ubuntu-24.04-arm
-        #     directory: chrome-for-testing #browser not available for Linux/arm64
+        exclude:
+          - os: ubuntu-24.04-arm
+            directory: chrome-for-testing # browser not available for Linux/arm64
     runs-on: ${{ matrix.os }}
     steps:
       - uses: actions/checkout@v4

--- a/examples/basic-mini/scripts/test.sh
+++ b/examples/basic-mini/scripts/test.sh
@@ -14,9 +14,8 @@ case $ARCHITECTURE in
       docker run --rm -v .:/app -w /app --entrypoint cypress cypress/included run -b chrome
     ;;
   aarch64)
-    echo Testing cypress/included in arm64 using Electron
-    echo No other browsers available
-      docker run --rm -v .:/app -w /app cypress/included
+    echo Testing cypress/included in arm64 using Firefox
+      docker run --rm -v .:/app -w /app --entrypoint cypress cypress/included run -b firefox
     ;;
   *)
     echo Unsupported architecture

--- a/examples/basic/scripts/test.sh
+++ b/examples/basic/scripts/test.sh
@@ -20,8 +20,10 @@ case $ARCHITECTURE in
       docker run --rm --entrypoint bash test-browsers -c "npx cypress run -b chrome" # Run Cypress test in container using Chrome
     ;;
   aarch64)
-    echo Skipping browser tests for arm64
-    echo No browsers available
+    echo Testing browsers in amd64
+    echo Build and test with cypress/browsers in Firefox
+      docker build -f Dockerfile.browsers -t test-browsers . # Build a new image
+      docker run --rm --entrypoint bash test-browsers -c "npx cypress run -b firefox" # Run Cypress test in container using Firefox
     ;;
   *)
     echo Unsupported architecture


### PR DESCRIPTION
## Situation

- [.github/workflows/example-tests.yml](https://github.com/cypress-io/cypress-docker-images/blob/master/.github/workflows/example-tests.yml) is disabled for the public beta runner image `ubuntu-24.04-arm` from https://github.com/actions/partner-runner-images. The Ubuntu arm64 runner image has however now stabilized.

### Browsers in examples

| Browser                                | `arm64`     | Test state |
| -------------------------------------- | ----------- | ---------- |
| Chrome for Testing                     | unavailable | -          |
| Chromium                               | available   | tested     |
| Firefox Rapid Release (RR)             | available   | untested   |
| Firefox Extended Support Release (ESR) | available   | tested     |

### Scripts

- [examples/basic/scripts/test.sh](https://github.com/cypress-io/cypress-docker-images/blob/master/examples/basic/scripts/test.sh) skip testing in `arm64`
- [basic-mini/scripts/test.sh](https://github.com/cypress-io/cypress-docker-images/blob/master/examples/basic-mini/scripts/test.sh) test in Electron only

## Change

- Re-enable `ubuntu-24.04-arm` in the GitHub Actions workflow [.github/workflows/example-tests.yml](https://github.com/cypress-io/cypress-docker-images/blob/master/.github/workflows/example-tests.yml) in addition to `ubuntu-24.04`

Test Firefox Rapid Release (RR) `arm64` in scripts:

- [examples/basic/scripts/test.sh](https://github.com/cypress-io/cypress-docker-images/blob/master/examples/basic/scripts/test.sh)
- [examples/basic-mini/scripts/test.sh](https://github.com/cypress-io/cypress-docker-images/blob/master/examples/basic-mini/scripts/test.sh)

## Browsers in examples after PR

| Browser                                | `arm64`     | Test state before | Test state after |
| -------------------------------------- | ----------- | ----------------- | ---------------- |
| Chrome for Testing                     | unavailable | -                 | -                |
| Chromium                               | available   | tested            | tested           |
| Firefox Rapid Release (RR)             | available   | untested          | tested           |
| Firefox Extended Support Release (ESR) | available   | tested            | tested           |
