### PR TITLE
feat: update to Debian 12.10 (bookworm)

### DIFF
--- a/factory/.env
+++ b/factory/.env
@@ -6,7 +6,7 @@
 
 # Use Debian stable release https://www.debian.org/releases/stable/
 # The Debian image cypress/factory is based on
-BASE_IMAGE='debian:12.9-slim'
+BASE_IMAGE='debian:12.10-slim'
 
 # Node Versions: https://nodejs.org/en/download/releases/
 # master branch needs "Active LTS" version
@@ -18,7 +18,7 @@ NODE_VERSION="${FACTORY_DEFAULT_NODE_VERSION}"
 
 # Update the FACTORY_VERSION to deploy cypress/factory if you make changes to
 # BASE_IMAGE, FACTORY_DEFAULT_NODE_VERSION, YARN_VERSION, factory.Dockerfile or installScripts
-FACTORY_VERSION='5.7.0'
+FACTORY_VERSION='5.8.0'
 
 # Chrome versions: https://www.ubuntuupdates.org/package/google_chrome/stable/main/base/google-chrome-stable
 # Linux/amd64 only

--- a/factory/CHANGELOG.md
+++ b/factory/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Change log
 
+## 5.8.0
+
+- Updated Debian base to `debian:12.10-slim` using [Debian 12.10](https://www.debian.org/News/2025/20250315), released on Mar 15, 2025. Addresses [#1324](https://github.com/cypress-io/cypress-docker-images/issues/1324).
+
 ## 5.7.0
 
 - Show user-friendly error message if Yarn Modern (`YARN_VERSION>=2`) specified for factory build. Addresses [#1317](https://github.com/cypress-io/cypress-docker-images/issues/1317).


### PR DESCRIPTION
- Closes https://github.com/cypress-io/cypress-docker-images/issues/1324

## Issue

[Debian 12.10](https://www.debian.org/News/2025/20250315) was released on Mar 15, 2025.

Cypress Factory is currently based on [Debian 12.9](https://www.debian.org/News/2025/20250111).

See [Debian Releases](https://www.debian.org/releases/) for an overview.

## Change

Update to `BASE_IMAGE='debian:12.10-slim'`
Update to `FACTORY_VERSION='5.8.0'`