### PR TITLE
build: reformat yml workflows according to Prettier

### DIFF
--- a/.prettierrc
+++ b/.prettierrc
@@ -1,5 +1,7 @@
 {
   "printWidth": 120,
+  "tabWidth": 2,
+  "useTabs": false,
   "semi": false,
   "trailingComma": "all",
   "arrowParens": "always",

--- a/circle.yml
+++ b/circle.yml
@@ -8,405 +8,400 @@
 version: 2.1
 
 commands:
-    expand-env-file:
-        description: Sets up bash env to load envs from the env file
-        steps:
-            - run:
-                   name: Sets up bash env to load envs from the env file
-                   command: |
-                        touch $BASH_ENV
-                        echo 'set -a && . ~/project/factory/.env && set +a' >> $BASH_ENV
-    halt-if-docker-image-exists:
-        description: Halt current CircleCI job if Docker image exists already
-        parameters:
-            target:
-                type: string
-                description: cypress/* repo name (factory, base, browser or included)
-        steps:
-            - run:
-                  name: Check if image for << parameters.target >> exists on Docker Hub
-                  # using Docker HUB API https://docs.docker.com/docker-hub/api/latest/
-                  # to check if Docker Hub definitely does not have this image
-                  command: |
-                      DOCKER_NAMESPACE='cypress'
-                      DOCKER_REPO=<< parameters.target >>
+  expand-env-file:
+    description: Sets up bash env to load envs from the env file
+    steps:
+      - run:
+          name: Sets up bash env to load envs from the env file
+          command: |
+            touch $BASH_ENV
+            echo 'set -a && . ~/project/factory/.env && set +a' >> $BASH_ENV
+  halt-if-docker-image-exists:
+    description: Halt current CircleCI job if Docker image exists already
+    parameters:
+      target:
+        type: string
+        description: cypress/* repo name (factory, base, browser or included)
+    steps:
+      - run:
+          name: Check if image for << parameters.target >> exists on Docker Hub
+          # using Docker HUB API https://docs.docker.com/docker-hub/api/latest/
+          # to check if Docker Hub definitely does not have this image
+          command: |
+            DOCKER_NAMESPACE='cypress'
+            DOCKER_REPO=<< parameters.target >>
 
-                      DOCKER_TAG=''
-                      if [ ${DOCKER_REPO} == factory ]; then DOCKER_TAG=${FACTORY_VERSION}; fi
-                      if [ ${DOCKER_REPO} == base ]; then DOCKER_TAG=${BASE_IMAGE_TAG}; fi
-                      if [ ${DOCKER_REPO} == browsers ]; then DOCKER_TAG=${BROWSERS_IMAGE_TAG}; fi
-                      if [ ${DOCKER_REPO} == included ]; then DOCKER_TAG=${INCLUDED_IMAGE_TAG}; fi
+            DOCKER_TAG=''
+            if [ ${DOCKER_REPO} == factory ]; then DOCKER_TAG=${FACTORY_VERSION}; fi
+            if [ ${DOCKER_REPO} == base ]; then DOCKER_TAG=${BASE_IMAGE_TAG}; fi
+            if [ ${DOCKER_REPO} == browsers ]; then DOCKER_TAG=${BROWSERS_IMAGE_TAG}; fi
+            if [ ${DOCKER_REPO} == included ]; then DOCKER_TAG=${INCLUDED_IMAGE_TAG}; fi
 
-                      DOCKER_NAME=${DOCKER_NAMESPACE}/${DOCKER_REPO}:${DOCKER_TAG}
+            DOCKER_NAME=${DOCKER_NAMESPACE}/${DOCKER_REPO}:${DOCKER_TAG}
 
-                      if curl -s https://hub.docker.com/v2/namespaces/${DOCKER_NAMESPACE}/repositories/${DOCKER_REPO}/tags/${DOCKER_TAG} \
-                        | grep -iq 'httperror 404'; then
-                        echo Docker Hub says image $DOCKER_NAME does not exist - HTTP status 404 returned
-                        echo $DOCKER_NAME available for publishing
-                      else
-                        echo Docker Hub found image $DOCKER_NAME - or error occurred
-                        echo Stopping to avoid republishing
-                        circleci-agent step halt
-                      fi
+            if curl -s https://hub.docker.com/v2/namespaces/${DOCKER_NAMESPACE}/repositories/${DOCKER_REPO}/tags/${DOCKER_TAG} \
+              | grep -iq 'httperror 404'; then
+              echo Docker Hub says image $DOCKER_NAME does not exist - HTTP status 404 returned
+              echo $DOCKER_NAME available for publishing
+            else
+              echo Docker Hub found image $DOCKER_NAME - or error occurred
+              echo Stopping to avoid republishing
+              circleci-agent step halt
+            fi
 
 jobs:
-    lint:
-        machine:
-            image: ubuntu-2204:2024.11.1
-        steps:
-            - checkout
-            - run: npm ci
-            - run: npm run lint
-    check-factory-versions:
-        machine:
-            image: ubuntu-2204:2024.11.1
-        steps:
-            - checkout
-            - expand-env-file
-            - run:
-                  name: building docker image
-                  command: |
-                      docker compose --progress plain build factory
-                  working_directory: factory
-            - run:
-                  name: build test image
-                  command: |
-                    docker compose --progress plain build test-factory-all-included
-                  working_directory: factory/test-project
-            - run:
-                  name: check node version
-                  command: |
-                    ACTUAL_VERSION=$(docker compose run --rm test-factory-all-included node -v)
-                    if [ v${NODE_VERSION} != "${ACTUAL_VERSION}" ]; then
-                      echo "Version mismatch, v${NODE_VERSION} != ${ACTUAL_VERSION}"
-                      exit 1;
-                    fi
-                    echo "Version ${ACTUAL_VERSION} confirmed"
-                  working_directory: factory/test-project
-            - run:
-                  name: check yarn version
-                  command: |
-                    ACTUAL_VERSION=$(docker compose run --rm test-factory-all-included yarn -v)
-                    if [ ${YARN_VERSION} != "${ACTUAL_VERSION}" ]; then
-                      echo "Version mismatch, ${YARN_VERSION} != ${ACTUAL_VERSION}"
-                      exit 1;
-                    fi
-                    echo "Version ${ACTUAL_VERSION} confirmed"
-                  working_directory: factory/test-project
-            - run:
-                  name: check chrome version
-                  command: |
-                    ACTUAL_VERSION=$(docker compose run --rm test-factory-all-included google-chrome --version | xargs)
-                    TRIMMED_CHROME_VERSION=$(echo ${CHROME_VERSION} | sed -e 's/-.*$//g')
-                    if [ "Google Chrome ${TRIMMED_CHROME_VERSION}" != "${ACTUAL_VERSION}" ]; then
-                      echo "Version mismatch, Google Chrome ${TRIMMED_CHROME_VERSION} != ${ACTUAL_VERSION}"
-                      exit 1;
-                    fi
-                    echo "Version ${ACTUAL_VERSION} confirmed"
-                  working_directory: factory/test-project
-            - run:
-                  name: check firefox version
-                  command: |
-                    ACTUAL_VERSION=$(docker compose run --rm test-factory-all-included firefox --version)
-                    if [ "Mozilla Firefox ${FIREFOX_VERSION}" != "${ACTUAL_VERSION}" ]; then
-                      echo "Version mismatch, Mozilla Firefox ${FIREFOX_VERSION} != ${ACTUAL_VERSION}"
-                      exit 1;
-                    fi
-                    echo "Version ${ACTUAL_VERSION} confirmed"
-                  working_directory: factory/test-project
-            - run:
-                  name: check edge version
-                  command: |
-                    ACTUAL_VERSION=$(docker compose run --rm test-factory-all-included edge --version | xargs)
-                    TRIMMED_EDGE_VERSION=$(echo ${EDGE_VERSION} | sed -e 's/-.*$//g')
-                    if [ "Microsoft Edge ${TRIMMED_EDGE_VERSION}" != "${ACTUAL_VERSION}" ]; then
-                      echo "Version mismatch, Microsoft Edge ${TRIMMED_EDGE_VERSION} != ${ACTUAL_VERSION}"
-                      exit 1;
-                    fi
-                    echo "Version ${ACTUAL_VERSION} confirmed"
-                  working_directory: factory/test-project
-            - run:
-                  name: check cypress version
-                  command: |
-                    ACTUAL_VERSION=$(docker compose run --rm test-factory-all-included cypress -v)
-                    TRIMMED_ACTUAL_VERSION=$(echo ${ACTUAL_VERSION} | sed -e 's/ Cypress binary version:.*$//g')
-                    if [  "Cypress package version: ${CYPRESS_VERSION}" != "${TRIMMED_ACTUAL_VERSION}" ]; then
-                      echo "Version mismatch, Cypress package version: ${CYPRESS_VERSION} != ${TRIMMED_ACTUAL_VERSION}"
-                      exit 1;
-                    fi
-                    echo "Version ${ACTUAL_VERSION} confirmed"
-                  working_directory: factory/test-project
-            - run:
-                  # The git version is determined by BASE_IMAGE and its online package sources
-                  # We check that git is installed and report its version
-                  # There is no check for a certain version of git
-                  name: check git version
-                  command: |
-                    ACTUAL_VERSION=$(docker compose run --rm test-factory-all-included git --version)
-                    echo "Version ${ACTUAL_VERSION} confirmed"
-                  working_directory: factory/test-project
-            - run:
-                  name: check ssh version # We don't really care what version ssh has as long as the command doesn't error
-                  command: |
-                    ACTUAL_VERSION=$(docker compose run --rm test-factory-all-included ssh -V 2>&1)
-                    echo "Version ${ACTUAL_VERSION} confirmed"
-                  working_directory: factory/test-project
-    check-node-override-version:
-        machine:
-            image: ubuntu-2204:2024.11.1
-        steps:
-            - checkout
-            - expand-env-file
-            - run:
-                  name: building docker image
-                  command: |
-                      docker compose --progress plain build factory
-                  working_directory: factory
-            - run:
-                  name: build test image
-                  command: |
-                    docker compose --progress plain build test-factory-node-override
-                  working_directory: factory/test-project
-            - run:
-                  name: check node version
-                  command: |
-                    ACTUAL_VERSION=$(docker compose run --rm test-factory-node-override node -v)
-                    if [ v18.17.1 != "${ACTUAL_VERSION}" ]; then
-                      echo "Version mismatch, v18.17.1 != ${ACTUAL_VERSION}"
-                      exit 1;
-                    fi
-                    echo "Version ${ACTUAL_VERSION} confirmed"
-                  working_directory: factory/test-project
-    test-image:
-        machine:
-            image: ubuntu-2204:2024.11.1
-        parameters:
-            target:
-                type: string
-                description: The docker compose target to build
-            resourceClass:
-                type: string
-                description: Resource class to use for this job
-            test-target:
-                type: string
-                description: The docker compose target to run the test
-        resource_class: << parameters.resourceClass >>
-        steps:
-            - checkout
-            - expand-env-file
-            - run:
-                  name: building docker image
-                  command: |
-                      if [ << parameters.target >> != factory ]; then docker compose --progress plain build factory; fi
-                      docker compose --progress plain build << parameters.target >>
-                  working_directory: factory
-            - run:
-                  name: test
-                  command: |
-                    docker compose --progress plain build << parameters.test-target >>
-                    docker compose run --rm << parameters.test-target >>
-                  working_directory: factory/test-project
+  lint:
+    machine:
+      image: ubuntu-2204:2024.11.1
+    steps:
+      - checkout
+      - run: npm ci
+      - run: npm run lint
+  check-factory-versions:
+    machine:
+      image: ubuntu-2204:2024.11.1
+    steps:
+      - checkout
+      - expand-env-file
+      - run:
+          name: building docker image
+          command: |
+            docker compose --progress plain build factory
+          working_directory: factory
+      - run:
+          name: build test image
+          command: |
+            docker compose --progress plain build test-factory-all-included
+          working_directory: factory/test-project
+      - run:
+          name: check node version
+          command: |
+            ACTUAL_VERSION=$(docker compose run --rm test-factory-all-included node -v)
+            if [ v${NODE_VERSION} != "${ACTUAL_VERSION}" ]; then
+              echo "Version mismatch, v${NODE_VERSION} != ${ACTUAL_VERSION}"
+              exit 1;
+            fi
+            echo "Version ${ACTUAL_VERSION} confirmed"
+          working_directory: factory/test-project
+      - run:
+          name: check yarn version
+          command: |
+            ACTUAL_VERSION=$(docker compose run --rm test-factory-all-included yarn -v)
+            if [ ${YARN_VERSION} != "${ACTUAL_VERSION}" ]; then
+              echo "Version mismatch, ${YARN_VERSION} != ${ACTUAL_VERSION}"
+              exit 1;
+            fi
+            echo "Version ${ACTUAL_VERSION} confirmed"
+          working_directory: factory/test-project
+      - run:
+          name: check chrome version
+          command: |
+            ACTUAL_VERSION=$(docker compose run --rm test-factory-all-included google-chrome --version | xargs)
+            TRIMMED_CHROME_VERSION=$(echo ${CHROME_VERSION} | sed -e 's/-.*$//g')
+            if [ "Google Chrome ${TRIMMED_CHROME_VERSION}" != "${ACTUAL_VERSION}" ]; then
+              echo "Version mismatch, Google Chrome ${TRIMMED_CHROME_VERSION} != ${ACTUAL_VERSION}"
+              exit 1;
+            fi
+            echo "Version ${ACTUAL_VERSION} confirmed"
+          working_directory: factory/test-project
+      - run:
+          name: check firefox version
+          command: |
+            ACTUAL_VERSION=$(docker compose run --rm test-factory-all-included firefox --version)
+            if [ "Mozilla Firefox ${FIREFOX_VERSION}" != "${ACTUAL_VERSION}" ]; then
+              echo "Version mismatch, Mozilla Firefox ${FIREFOX_VERSION} != ${ACTUAL_VERSION}"
+              exit 1;
+            fi
+            echo "Version ${ACTUAL_VERSION} confirmed"
+          working_directory: factory/test-project
+      - run:
+          name: check edge version
+          command: |
+            ACTUAL_VERSION=$(docker compose run --rm test-factory-all-included edge --version | xargs)
+            TRIMMED_EDGE_VERSION=$(echo ${EDGE_VERSION} | sed -e 's/-.*$//g')
+            if [ "Microsoft Edge ${TRIMMED_EDGE_VERSION}" != "${ACTUAL_VERSION}" ]; then
+              echo "Version mismatch, Microsoft Edge ${TRIMMED_EDGE_VERSION} != ${ACTUAL_VERSION}"
+              exit 1;
+            fi
+            echo "Version ${ACTUAL_VERSION} confirmed"
+          working_directory: factory/test-project
+      - run:
+          name: check cypress version
+          command: |
+            ACTUAL_VERSION=$(docker compose run --rm test-factory-all-included cypress -v)
+            TRIMMED_ACTUAL_VERSION=$(echo ${ACTUAL_VERSION} | sed -e 's/ Cypress binary version:.*$//g')
+            if [  "Cypress package version: ${CYPRESS_VERSION}" != "${TRIMMED_ACTUAL_VERSION}" ]; then
+              echo "Version mismatch, Cypress package version: ${CYPRESS_VERSION} != ${TRIMMED_ACTUAL_VERSION}"
+              exit 1;
+            fi
+            echo "Version ${ACTUAL_VERSION} confirmed"
+          working_directory: factory/test-project
+      - run:
+          # The git version is determined by BASE_IMAGE and its online package sources
+          # We check that git is installed and report its version
+          # There is no check for a certain version of git
+          name: check git version
+          command: |
+            ACTUAL_VERSION=$(docker compose run --rm test-factory-all-included git --version)
+            echo "Version ${ACTUAL_VERSION} confirmed"
+          working_directory: factory/test-project
+      - run:
+          name: check ssh version # We don't really care what version ssh has as long as the command doesn't error
+          command: |
+            ACTUAL_VERSION=$(docker compose run --rm test-factory-all-included ssh -V 2>&1)
+            echo "Version ${ACTUAL_VERSION} confirmed"
+          working_directory: factory/test-project
+  check-node-override-version:
+    machine:
+      image: ubuntu-2204:2024.11.1
+    steps:
+      - checkout
+      - expand-env-file
+      - run:
+          name: building docker image
+          command: |
+            docker compose --progress plain build factory
+          working_directory: factory
+      - run:
+          name: build test image
+          command: |
+            docker compose --progress plain build test-factory-node-override
+          working_directory: factory/test-project
+      - run:
+          name: check node version
+          command: |
+            ACTUAL_VERSION=$(docker compose run --rm test-factory-node-override node -v)
+            if [ v18.17.1 != "${ACTUAL_VERSION}" ]; then
+              echo "Version mismatch, v18.17.1 != ${ACTUAL_VERSION}"
+              exit 1;
+            fi
+            echo "Version ${ACTUAL_VERSION} confirmed"
+          working_directory: factory/test-project
+  test-image:
+    machine:
+      image: ubuntu-2204:2024.11.1
+    parameters:
+      target:
+        type: string
+        description: The docker compose target to build
+      resourceClass:
+        type: string
+        description: Resource class to use for this job
+      test-target:
+        type: string
+        description: The docker compose target to run the test
+    resource_class: << parameters.resourceClass >>
+    steps:
+      - checkout
+      - expand-env-file
+      - run:
+          name: building docker image
+          command: |
+            if [ << parameters.target >> != factory ]; then docker compose --progress plain build factory; fi
+            docker compose --progress plain build << parameters.target >>
+          working_directory: factory
+      - run:
+          name: test
+          command: |
+            docker compose --progress plain build << parameters.test-target >>
+            docker compose run --rm << parameters.test-target >>
+          working_directory: factory/test-project
 
-    push:
-        machine:
-            image: ubuntu-2204:2024.11.1
-        parameters:
-            target:
-                type: string
-                description: Name of the docker compose target to build and push.
-        steps:
-            - checkout
-            - expand-env-file
-            - halt-if-docker-image-exists:
-                 target: << parameters.target >>
-            - run:
-                name: Building Docker image for target << parameters.target >>
-                no_output_timeout: 20m # installing cypress on arm can take some time.
-                command: |
-                    echo Build environment is ...
-                    echo Node.js $(node --version)
-                    echo $(docker --version)
-                    echo $(docker buildx version)
+  push:
+    machine:
+      image: ubuntu-2204:2024.11.1
+    parameters:
+      target:
+        type: string
+        description: Name of the docker compose target to build and push.
+    steps:
+      - checkout
+      - expand-env-file
+      - halt-if-docker-image-exists:
+          target: << parameters.target >>
+      - run:
+          name: Building Docker image for target << parameters.target >>
+          no_output_timeout: 20m # installing cypress on arm can take some time.
+          command: |
+            echo Build environment is ...
+            echo Node.js $(node --version)
+            echo $(docker --version)
+            echo $(docker buildx version)
 
-                    ## see https://docs.docker.com/desktop/multi-arch/
-                    docker run --privileged --rm tonistiigi/binfmt --install linux/amd64,linux/arm64
-                    docker buildx create --name builder --use
+            ## see https://docs.docker.com/desktop/multi-arch/
+            docker run --privileged --rm tonistiigi/binfmt --install linux/amd64,linux/arm64
+            docker buildx create --name builder --use
 
-                    docker login -u "$DOCKERHUB_USERNAME" --password "$DOCKERHUB_PASS"
-                    docker buildx bake -f ./docker-compose.yml --progress plain --set *.platform=linux/arm64,linux/amd64 --push << parameters.target >>
+            docker login -u "$DOCKERHUB_USERNAME" --password "$DOCKERHUB_PASS"
+            docker buildx bake -f ./docker-compose.yml --progress plain --set *.platform=linux/arm64,linux/amd64 --push << parameters.target >>
 
-                    ## now, let's re-build those same images for Amazon ECR this is basically a re-tag and push because of the cache from the previous build.
-                    ## see https://docs.aws.amazon.com/AmazonECR/latest/userguide/docker-push-ecr-image.html
-                    docker login --username AWS --password "$(aws ecr-public get-login-password --region $AWS_ECR_REGION)" $AWS_ECR_PREFIX
-                    REPO_PREFIX=$AWS_ECR_PREFIX/ docker buildx bake -f ./docker-compose.yml --progress plain --set *.platform=linux/arm64,linux/amd64 --push << parameters.target >>
+            ## now, let's re-build those same images for Amazon ECR this is basically a re-tag and push because of the cache from the previous build.
+            ## see https://docs.aws.amazon.com/AmazonECR/latest/userguide/docker-push-ecr-image.html
+            docker login --username AWS --password "$(aws ecr-public get-login-password --region $AWS_ECR_REGION)" $AWS_ECR_PREFIX
+            REPO_PREFIX=$AWS_ECR_PREFIX/ docker buildx bake -f ./docker-compose.yml --progress plain --set *.platform=linux/arm64,linux/amd64 --push << parameters.target >>
 
-                working_directory: factory
+          working_directory: factory
 
 workflows:
-    test:
-        jobs:
-            - lint
-            - check-factory-versions
-            - check-node-override-version
-            - test-image:
-                matrix:
-                    alias: factory-arm
-                    parameters:
-                        test-target: [
-                            test-factory-electron,
-                            test-factory-firefox,
-                            test-factory-cypress-included-electron,
-                            test-factory-cypress-included-electron-non-root-user,
-                            test-factory-cypress-included-firefox,
-                            test-factory-cypress-included-firefox-non-root-user,
-                            test-factory-all-included-electron-only
-                            ]
-                        resourceClass: [arm.medium]
-                        target: [factory]
-            - test-image:
-                matrix:
-                    alias: factory
-                    parameters:
-                        test-target: [
-                            test-factory-electron,
-                            test-factory-chrome,
-                            test-factory-chrome-non-root-user,
-                            test-factory-firefox,
-                            test-factory-edge,
-                            test-factory-cypress-included-electron,
-                            test-factory-cypress-included-electron-non-root-user,
-                            test-factory-cypress-included-chrome,
-                            test-factory-cypress-included-firefox,
-                            test-factory-cypress-included-firefox-non-root-user,
-                            test-factory-cypress-included-edge,
-                            test-factory-all-included
-                            ]
-                        resourceClass: [medium]
-                        target: [factory]
-            - test-image:
-                matrix:
-                    alias: base
-                    parameters:
-                        test-target: [
-                            test-base
-                            ]
-                        resourceClass: [medium]
-                        target: [base]
-            - test-image:
-                matrix:
-                    alias: base-arm
-                    parameters:
-                        test-target: [
-                            test-base
-                            ]
-                        resourceClass: [arm.medium]
-                        target: [base]
-            - test-image:
-                matrix:
-                    alias: browsers
-                    parameters:
-                        test-target: [
-                            test-browsers-electron,
-                            test-browsers-chrome,
-                            test-browsers-firefox,
-                            test-browsers-edge
-                            ]
-                        resourceClass: [medium]
-                        target: [browsers]
+  test:
+    jobs:
+      - lint
+      - check-factory-versions
+      - check-node-override-version
+      - test-image:
+          matrix:
+            alias: factory-arm
+            parameters:
+              test-target:
+                [
+                  test-factory-electron,
+                  test-factory-firefox,
+                  test-factory-cypress-included-electron,
+                  test-factory-cypress-included-electron-non-root-user,
+                  test-factory-cypress-included-firefox,
+                  test-factory-cypress-included-firefox-non-root-user,
+                  test-factory-all-included-electron-only,
+                ]
+              resourceClass: [arm.medium]
+              target: [factory]
+      - test-image:
+          matrix:
+            alias: factory
+            parameters:
+              test-target:
+                [
+                  test-factory-electron,
+                  test-factory-chrome,
+                  test-factory-chrome-non-root-user,
+                  test-factory-firefox,
+                  test-factory-edge,
+                  test-factory-cypress-included-electron,
+                  test-factory-cypress-included-electron-non-root-user,
+                  test-factory-cypress-included-chrome,
+                  test-factory-cypress-included-firefox,
+                  test-factory-cypress-included-firefox-non-root-user,
+                  test-factory-cypress-included-edge,
+                  test-factory-all-included,
+                ]
+              resourceClass: [medium]
+              target: [factory]
+      - test-image:
+          matrix:
+            alias: base
+            parameters:
+              test-target: [test-base]
+              resourceClass: [medium]
+              target: [base]
+      - test-image:
+          matrix:
+            alias: base-arm
+            parameters:
+              test-target: [test-base]
+              resourceClass: [arm.medium]
+              target: [base]
+      - test-image:
+          matrix:
+            alias: browsers
+            parameters:
+              test-target: [
+                  test-browsers-electron, #
+                  test-browsers-chrome,
+                  test-browsers-firefox,
+                  test-browsers-edge,
+                ]
+              resourceClass: [medium]
+              target: [browsers]
 
-            - test-image:
-                matrix:
-                    alias: browsers-arm
-                    parameters:
-                        test-target: [
-                            test-browsers-electron,
-                            test-browsers-firefox
-                            ]
-                        resourceClass: [arm.medium]
-                        target: [browsers]
-            - test-image:
-                matrix:
-                    alias: included
-                    parameters:
-                        test-target: [
-                            test-included-electron,
-                            test-included-chrome,
-                            test-included-firefox,
-                            test-included-edge
-                            ]
-                        resourceClass: [medium]
-                        target: [included]
-            - test-image:
-                matrix:
-                    alias: included-arm
-                    parameters:
-                        test-target: [
-                            test-included-electron,
-                            test-included-firefox
-                            ]
-                        resourceClass: [arm.medium]
-                        target: [included]
-            # pushing the factory image must come first because the other images may pull it down to build
-            - push:
-                name: "Push Factory Image"
-                target: factory
-                context: test-runner:docker-push
-                filters:
-                    branches:
-                        only:
-                        # Only branches matching the below regex filters will run
-                        # Follow the instructions in the CONTRIBUTING document for alternate versions and
-                        # change to a feature branch such as <cypress-version>-node-<node.js version>-publish
-                        # if publishing an alternate (non-primary) version
-                        # This job must run because the base, browsers and included jobs depend on it
-                            - master
-                requires:
-                    - factory
-                    - factory-arm
-                    - check-node-override-version
-                    - check-factory-versions
-            - push:
-                name: "Push Base Image"
-                target: base
-                context: test-runner:docker-push
-                filters:
-                    branches:
-                        only:
-                        # Only branches matching the below regex filters will run
-                        # Change to a feature branch such as <cypress-version>-node-<node.js version>-publish
-                        # if publishing an alternate version
-                            - master
-                requires:
-                    - "Push Factory Image"
-                    - base
-                    - base-arm
-            - push:
-                name: "Push Browser Image"
-                target: browsers
-                context: test-runner:docker-push
-                filters:
-                    branches:
-                        only:
-                        # Only branches matching the below regex filters will run
-                        # Change to a feature branch such as <cypress-version>-node-<node.js version>-publish
-                        # if publishing an alternate version
-                            - master
-                requires:
-                    - "Push Factory Image"
-                    - browsers
-                    - browsers-arm
-            - push:
-                target: included
-                name: "Push Included Image"
-                context: test-runner:docker-push
-                filters:
-                    branches:
-                        only:
-                        # Only branches matching the below regex filters will run
-                        # Change to a feature branch such as <cypress-version>-node-<node.js version>-publish
-                        # if publishing an alternate version
-                            - master
-                requires:
-                    - "Push Factory Image"
-                    - included
-                    - included-arm
+      - test-image:
+          matrix:
+            alias: browsers-arm
+            parameters:
+              test-target: [test-browsers-electron, test-browsers-firefox]
+              resourceClass: [arm.medium]
+              target: [browsers]
+      - test-image:
+          matrix:
+            alias: included
+            parameters:
+              test-target: [
+                  test-included-electron, #
+                  test-included-chrome,
+                  test-included-firefox,
+                  test-included-edge,
+                ]
+              resourceClass: [medium]
+              target: [included]
+      - test-image:
+          matrix:
+            alias: included-arm
+            parameters:
+              test-target: [
+                  test-included-electron, #
+                  test-included-firefox,
+                ]
+              resourceClass: [arm.medium]
+              target: [included]
+      # pushing the factory image must come first because the other images may pull it down to build
+      - push:
+          name: 'Push Factory Image'
+          target: factory
+          context: test-runner:docker-push
+          filters:
+            branches:
+              only:
+                # Only branches matching the below regex filters will run
+                # Follow the instructions in the CONTRIBUTING document for alternate versions and
+                # change to a feature branch such as <cypress-version>-node-<node.js version>-publish
+                # if publishing an alternate (non-primary) version
+                # This job must run because the base, browsers and included jobs depend on it
+                - master
+          requires:
+            - factory
+            - factory-arm
+            - check-node-override-version
+            - check-factory-versions
+      - push:
+          name: 'Push Base Image'
+          target: base
+          context: test-runner:docker-push
+          filters:
+            branches:
+              only:
+                # Only branches matching the below regex filters will run
+                # Change to a feature branch such as <cypress-version>-node-<node.js version>-publish
+                # if publishing an alternate version
+                - master
+          requires:
+            - 'Push Factory Image'
+            - base
+            - base-arm
+      - push:
+          name: 'Push Browser Image'
+          target: browsers
+          context: test-runner:docker-push
+          filters:
+            branches:
+              only:
+                # Only branches matching the below regex filters will run
+                # Change to a feature branch such as <cypress-version>-node-<node.js version>-publish
+                # if publishing an alternate version
+                - master
+          requires:
+            - 'Push Factory Image'
+            - browsers
+            - browsers-arm
+      - push:
+          target: included
+          name: 'Push Included Image'
+          context: test-runner:docker-push
+          filters:
+            branches:
+              only:
+                # Only branches matching the below regex filters will run
+                # Change to a feature branch such as <cypress-version>-node-<node.js version>-publish
+                # if publishing an alternate version
+                - master
+          requires:
+            - 'Push Factory Image'
+            - included
+            - included-arm

--- a/factory/docker-compose.yml
+++ b/factory/docker-compose.yml
@@ -6,7 +6,6 @@
 ## Comment out the INCLUDED_IMAGE_SHORT_TAG so that this tag is not reassigned to a non-primary version.
 
 services:
-
   factory:
     image: ${REPO_PREFIX-}cypress/factory
     build:
@@ -17,8 +16,8 @@ services:
         BASE_IMAGE: ${BASE_IMAGE}
         FACTORY_DEFAULT_NODE_VERSION: ${FACTORY_DEFAULT_NODE_VERSION}
       tags:
-       - ${REPO_PREFIX-}cypress/factory:latest  # comment out for release of alternate version
-       - ${REPO_PREFIX-}cypress/factory:${FACTORY_VERSION}
+        - ${REPO_PREFIX-}cypress/factory:latest # comment out for release of alternate version
+        - ${REPO_PREFIX-}cypress/factory:${FACTORY_VERSION}
     command: node -v
 
   included:
@@ -36,9 +35,9 @@ services:
         YARN_VERSION: ${YARN_VERSION}
         # WEBKIT_VERSION: ${WEBKIT_VERSION}
       tags:
-       - ${REPO_PREFIX-}cypress/included:latest # comment out for release of alternate version
-       - ${REPO_PREFIX-}cypress/included:${INCLUDED_IMAGE_SHORT_TAG}  # comment out for release of alternate version
-       - ${REPO_PREFIX-}cypress/included:${INCLUDED_IMAGE_TAG}
+        - ${REPO_PREFIX-}cypress/included:latest # comment out for release of alternate version
+        - ${REPO_PREFIX-}cypress/included:${INCLUDED_IMAGE_SHORT_TAG} # comment out for release of alternate version
+        - ${REPO_PREFIX-}cypress/included:${INCLUDED_IMAGE_TAG}
     command: node -v
 
   browsers:
@@ -54,9 +53,9 @@ services:
         FIREFOX_VERSION: ${FIREFOX_VERSION}
         EDGE_VERSION: ${EDGE_VERSION}
       tags:
-       - ${REPO_PREFIX-}cypress/browsers:latest # comment out for release of alternate version
-       - ${REPO_PREFIX-}cypress/browsers:${BROWSERS_IMAGE_SHORT_TAG}
-       - ${REPO_PREFIX-}cypress/browsers:${BROWSERS_IMAGE_TAG}
+        - ${REPO_PREFIX-}cypress/browsers:latest # comment out for release of alternate version
+        - ${REPO_PREFIX-}cypress/browsers:${BROWSERS_IMAGE_SHORT_TAG}
+        - ${REPO_PREFIX-}cypress/browsers:${BROWSERS_IMAGE_TAG}
     command: node -v
 
   base:
@@ -69,13 +68,13 @@ services:
         FACTORY_VERSION: ${FACTORY_VERSION}
         YARN_VERSION: ${YARN_VERSION}
       tags:
-       - ${REPO_PREFIX-}cypress/base:latest # comment out for release of alternate version
-       - ${REPO_PREFIX-}cypress/base:${BASE_IMAGE_TAG}
+        - ${REPO_PREFIX-}cypress/base:latest # comment out for release of alternate version
+        - ${REPO_PREFIX-}cypress/base:${BASE_IMAGE_TAG}
     command: node -v
 
   ## Unused images that we could release in the future if we choose.
   chrome:
-    image: "${REPO_PREFIX-}cypress/chrome"
+    image: '${REPO_PREFIX-}cypress/chrome'
     build:
       target: default_image
       context: .
@@ -84,7 +83,7 @@ services:
         FACTORY_VERSION: ${FACTORY_VERSION}
         CHROME_VERSION: ${CHROME_VERSION}
       tags:
-       - ${REPO_PREFIX-}cypress/chrome:${CHROME_VERSION}
+        - ${REPO_PREFIX-}cypress/chrome:${CHROME_VERSION}
     command: google-chrome --version
 
   edge:
@@ -97,7 +96,7 @@ services:
         FACTORY_VERSION: ${FACTORY_VERSION}
         EDGE_VERSION: ${EDGE_VERSION}
       tags:
-       - ${REPO_PREFIX-}cypress/edge:${EDGE_VERSION}
+        - ${REPO_PREFIX-}cypress/edge:${EDGE_VERSION}
     command: edge --version
 
   firefox:
@@ -110,7 +109,7 @@ services:
         FACTORY_VERSION: ${FACTORY_VERSION}
         FIREFOX_VERSION: ${FIREFOX_VERSION}
       tags:
-       - ${REPO_PREFIX-}cypress/firefox:${FIREFOX_VERSION}
+        - ${REPO_PREFIX-}cypress/firefox:${FIREFOX_VERSION}
     command: firefox --version
 
   # webkit:
@@ -135,7 +134,7 @@ services:
         FACTORY_VERSION: ${FACTORY_VERSION}
         CYPRESS_VERSION: ${CYPRESS_VERSION}
       tags:
-       - ${REPO_PREFIX-}cypress/cypress:${CYPRESS_VERSION}
+        - ${REPO_PREFIX-}cypress/cypress:${CYPRESS_VERSION}
     command: cypress verify
 
   cypress-chrome:
@@ -149,7 +148,7 @@ services:
         CYPRESS_VERSION: ${CYPRESS_VERSION}
         CHROME_VERSION: ${CHROME_VERSION}
       tags:
-       - ${REPO_PREFIX-}cypress/cypress-chrome:cypress-${CYPRESS_VERSION}-chrome-${CHROME_VERSION}
+        - ${REPO_PREFIX-}cypress/cypress-chrome:cypress-${CYPRESS_VERSION}-chrome-${CHROME_VERSION}
     command: node -v
 
   cypress-edge:
@@ -163,7 +162,7 @@ services:
         CYPRESS_VERSION: ${CYPRESS_VERSION}
         EDGE_VERSION: ${EDGE_VERSION}
       tags:
-       - ${REPO_PREFIX-}cypress/cypress-edge:cypress-${CYPRESS_VERSION}-edge-${EDGE_VERSION}
+        - ${REPO_PREFIX-}cypress/cypress-edge:cypress-${CYPRESS_VERSION}-edge-${EDGE_VERSION}
     command: node -v
 
   cypress-firefox:
@@ -177,7 +176,7 @@ services:
         CYPRESS_VERSION: ${CYPRESS_VERSION}
         FIREFOX_VERSION: ${FIREFOX_VERSION}
       tags:
-       - ${REPO_PREFIX-}cypress/cypress-firefox:cypress-${CYPRESS_VERSION}-firefox-${FIREFOX_VERSION}
+        - ${REPO_PREFIX-}cypress/cypress-firefox:cypress-${CYPRESS_VERSION}-firefox-${FIREFOX_VERSION}
     command: node -v
 
   ## Test image


### PR DESCRIPTION
## Issue

Executing `npm run format` shows multiple suggested changes, including for `*.yml` workflows:

- [circle.yml](https://github.com/cypress-io/cypress-docker-images/blob/master/circle.yml) is formatted mostly with a 4 character indent, however this has not been consistently applied
- [factory/docker-compose.yml](https://github.com/cypress-io/cypress-docker-images/blob/master/factory/docker-compose.yml) is formatted with a 2 character indent, with some exceptions

The general Cypress development standard indent is 2 characters, as defined in https://github.com/cypress-io/cypress/blob/b60ac5ee7b84f44a435e304b5d4463a02eabb800/npm/eslint-plugin-dev/lib/index.js#L49-L58

```json
  'indent': [
    'error',
    2,
    {
      // TODO: fix this, we shouldn't need to ignore TemplateLiterals
      'ignoredNodes': ['TemplateLiteral'],
      'SwitchCase': 1,
      'MemberExpression': 0,
    },
  ]
```

## Change

Execute

```shell
npx prettier --write "**/*.yml"
```

to reformat `.yml` workflows according to Prettier conventions. For clarity of settings, add the following values to [.prettierrc](https://github.com/cypress-io/cypress-docker-images/blob/master/.prettierrc). These correspond to Prettier's default values:

```json
  "tabWidth": 2,
  "useTabs": false,
```

For `test-targets` I added a dummy comment character `#` to keep all lists vertically formatted.

Many of the changes are whitespace (indents) only. (Tip: view differences with "Hide whitespace" in GitHub UI.)