### PR TITLE
ci: add prettier to circleci linting

### DIFF
--- a/circle.yml
+++ b/circle.yml
@@ -57,6 +57,7 @@ jobs:
       - checkout
       - run: npm ci
       - run: npm run lint
+      - run: npm run format:check
   check-factory-versions:
     machine:
       image: ubuntu-2204:2024.11.1

--- a/package-lock.json
+++ b/package-lock.json
@@ -14,10 +14,10 @@
         "eslint-plugin-cypress": "^4.2.0",
         "globals": "^16.0.0",
         "markdown-link-check": "3.12.2",
-        "prettier": "3.3.3"
+        "prettier": "3.5.3"
       },
       "engines": {
-        "node": ">=12"
+        "node": ">=18.17"
       }
     },
     "node_modules/@eslint-community/eslint-utils": {
@@ -1907,9 +1907,9 @@
       }
     },
     "node_modules/prettier": {
-      "version": "3.3.3",
-      "resolved": "https://registry.npmjs.org/prettier/-/prettier-3.3.3.tgz",
-      "integrity": "sha512-i2tDNA0O5IrMO757lfrdQZCc2jPNDVntV0m/+4whiDfWaTKfMNgR7Qz0NAeGz/nRqF4m5/6CLzbP4/liHt12Ew==",
+      "version": "3.5.3",
+      "resolved": "https://registry.npmjs.org/prettier/-/prettier-3.5.3.tgz",
+      "integrity": "sha512-QQtaxnoDJeAkDvDKWCLiwIXkTgRhwYDEQCghU9Z6q03iyek/rxRh/2lC3HB7P8sWT2xC/y5JDctPLBIGzHKbhw==",
       "dev": true,
       "license": "MIT",
       "bin": {

--- a/package.json
+++ b/package.json
@@ -9,6 +9,7 @@
   "scripts": {
     "check:markdown": "find . -type f -name '*.md' ! -path '*/node_modules/*' | xargs -L1 npx markdown-link-check -c markdownLinkConfig.json",
     "format": "prettier --write .",
+    "format:check": "prettier --check .",
     "lint": "eslint"
   },
   "engines": {
@@ -31,6 +32,6 @@
     "eslint-plugin-cypress": "^4.2.0",
     "globals": "^16.0.0",
     "markdown-link-check": "3.12.2",
-    "prettier": "3.3.3"
+    "prettier": "3.5.3"
   }
 }


### PR DESCRIPTION
## Situation

- The version of Prettier [prettier@3.3.3](https://github.com/prettier/prettier/releases/tag/3.3.3) used is not the latest.

- Prettier is now able to run without error in the repo.

- Prettier is not checked in CI.

## Change

- Update to [prettier@3.5.3](https://github.com/prettier/prettier/releases/tag/3.5.3)

- Add script `format:check` to [package.json](https://github.com/cypress-io/cypress-docker-images/blob/master/package.json) equivalent to:

    ```shell
    npx prettier --check .
    ```

- Execute script `format:check` in `lint` job of [circle.yml](https://github.com/cypress-io/cypress-docker-images/blob/master/circle.yml)

## Verification

Execute

```shell
npm run format:check
```

and confirm output is:

> Checking formatting...
> All matched files use Prettier code style!