### PR TITLE
chore: update browsers and cypress to latest

### DIFF
--- a/factory/.env
+++ b/factory/.env
@@ -22,18 +22,18 @@ FACTORY_VERSION='5.8.0'
 
 # Chrome versions: https://www.ubuntuupdates.org/package/google_chrome/stable/main/base/google-chrome-stable
 # Linux/amd64 only
-CHROME_VERSION='134.0.6998.165-1'
+CHROME_VERSION='135.0.7049.84-1'
 
 # Cypress versions: https://www.npmjs.com/package/cypress
-CYPRESS_VERSION='14.2.1'
+CYPRESS_VERSION='14.3.0'
 
 # Edge versions: https://packages.microsoft.com/repos/edge/pool/main/m/microsoft-edge-stable/
 # Linux/amd64 only
-EDGE_VERSION='134.0.3124.85-1'
+EDGE_VERSION='135.0.3179.54-1'
 
 # Firefox versions: https://download-installer.cdn.mozilla.net/pub/firefox/releases/
 # Linux/amd64 for all versions, Linux/arm64 for versions 136.0 and above
-FIREFOX_VERSION='136.0.3'
+FIREFOX_VERSION='137.0.1'
 
 # Yarn versions: https://www.npmjs.com/package/yarn and
 # Yarn v1 Classic only https://classic.yarnpkg.com/latest-version


### PR DESCRIPTION
updates cypress to `14.3.0` and chrome/edge from 134 to 135 and firefox from 136 to 137