### PR TITLE
docs: add 3 major browser versions supportability

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,6 +41,8 @@ For `Linux/arm64` images, the lowest available Firefox version is `136`.
 
 Building a custom image with [cypress/factory](./factory/) allows selection of individual browsers from the above list.
 
+Cypress officially [supports][Cypress Browser Support] the latest 3 major versions of Chrome, Firefox, and Edge browsers. We recommend using up to date Cypress Docker images for supportability.
+
 <!-- browser links -->
 
 [Chrome]: https://developer.chrome.com/
@@ -48,6 +50,7 @@ Building a custom image with [cypress/factory](./factory/) allows selection of i
 [Firefox Channel Choice]: https://support.mozilla.org/en-US/kb/choosing-firefox-update-channel
 [Edge]: https://developer.microsoft.com/microsoft-edge/
 [Chromium]: https://www.chromium.org/Home/
+[Cypress Browser Support]: https://docs.cypress.io/app/references/launching-browsers#Browser-versions-supported
 
 ### Debian packages
 


### PR DESCRIPTION
## Situation

The [Cypress 14.0.0 changelog](https://docs.cypress.io/app/references/changelog#14-0-0) includes the text:

> Cypress now only officially supports the latest 3 major versions of Chrome, Firefox, and Edge - older browser versions may still work, but we recommend keeping your browsers up to date to ensure compatibility with Cypress.

This is not reflected in the Cypress Docker image documentation.

## Change

Add a corresponding statement to the [README > Browsers](https://github.com/cypress-io/cypress-docker-images/blob/master/README.md#browsers) section.

Link to https://docs.cypress.io/app/references/launching-browsers#Browser-versions-supported

> Cypress officially supports the latest 3 major versions of Chrome, Firefox, and Edge. We recommend using up to date Cypress Docker images for supportability.
