### PR TITLE
chore: update browsers to latest and cypress to 14.3.1

### DIFF
--- a/factory/.env
+++ b/factory/.env
@@ -22,18 +22,18 @@ FACTORY_VERSION='5.8.0'
 
 # Chrome versions: https://www.ubuntuupdates.org/package/google_chrome/stable/main/base/google-chrome-stable
 # Linux/amd64 only
-CHROME_VERSION='135.0.7049.84-1'
+CHROME_VERSION='135.0.7049.95-1'
 
 # Cypress versions: https://www.npmjs.com/package/cypress
-CYPRESS_VERSION='14.3.0'
+CYPRESS_VERSION='14.3.1'
 
 # Edge versions: https://packages.microsoft.com/repos/edge/pool/main/m/microsoft-edge-stable/
 # Linux/amd64 only
-EDGE_VERSION='135.0.3179.54-1'
+EDGE_VERSION='135.0.3179.85-1'
 
 # Firefox versions: https://download-installer.cdn.mozilla.net/pub/firefox/releases/
 # Linux/amd64 for all versions, Linux/arm64 for versions 136.0 and above
-FIREFOX_VERSION='137.0.1'
+FIREFOX_VERSION='137.0.2'
 
 # Yarn versions: https://www.npmjs.com/package/yarn and
 # Yarn v1 Classic only https://classic.yarnpkg.com/latest-version


### PR DESCRIPTION
updates browsers to latest and Cypress to 14.3.1