### PR TITLE
chore: add ubuntu22 and 24 node 20 images

### DIFF
--- a/base-internal/releases/ubuntu/ubuntu22-node20/Dockerfile
+++ b/base-internal/releases/ubuntu/ubuntu22-node20/Dockerfile
@@ -1,0 +1,68 @@
+FROM ubuntu:22.04
+
+RUN apt-get update && \
+  apt-get install -y apt-transport-https ca-certificates curl gnupg
+RUN mkdir -p /etc/apt/keyrings
+RUN curl -fsSL https://deb.nodesource.com/gpgkey/nodesource-repo.gpg.key | gpg --dearmor -o /etc/apt/keyrings/nodesource.gpg
+RUN echo "deb [signed-by=/etc/apt/keyrings/nodesource.gpg] https://deb.nodesource.com/node_20.x nodistro main" | tee /etc/apt/sources.list.d/nodesource.list
+RUN apt-get update && apt-get install -y nodejs
+
+# Install latest NPM and Yarn
+RUN npm install -g npm@latest
+RUN npm install -g yarn@latest
+
+# install additional native dependencies build tools
+RUN apt install -y build-essential
+
+# install Git client
+RUN apt-get install -y git
+# install unzip utility to speed up Cypress unzips
+# https://github.com/cypress-io/cypress/releases/tag/v3.8.0
+RUN apt-get install -y unzip
+
+# avoid any prompts
+ENV DEBIAN_FRONTEND noninteractive
+# install tzdata package
+RUN apt-get install -y tzdata
+# set your timezone
+RUN ln -fs /usr/share/zoneinfo/America/New_York /etc/localtime
+RUN dpkg-reconfigure --frontend noninteractive tzdata
+
+# install Cypress dependencies (separate commands to avoid time outs)
+RUN apt-get install -y \
+    libatk1.0-0 \
+    libgtk2.0-0 \
+    libglib2.0-0 \
+    libatk-bridge2.0-0 \
+    libcups2 \
+    libgtk-3-0 \
+    libgbm1 
+RUN apt-get install -y \
+    libnotify-dev
+RUN apt-get install -y \
+    libgconf-2-4 \
+    libnss3 \
+    libxss1
+RUN apt-get install -y \
+    libasound2 \
+    xvfb
+
+# a few environment variables to make NPM installs easier
+# good colors for most applications
+ENV TERM xterm
+# avoid million NPM install messages
+ENV npm_config_loglevel warn
+# allow installing when the main user is root
+ENV npm_config_unsafe_perm true
+
+# versions of local tools
+RUN echo  " node version:    $(node -v) \n" \
+  "npm version:     $(npm -v) \n" \
+  "yarn version:    $(yarn -v) \n" \
+  "debian version:  $(cat /etc/debian_version) \n" \
+  "user:            $(whoami) \n" \
+  "git:             $(git --version) \n"
+
+RUN echo "More version info"
+RUN cat /etc/lsb-release
+RUN cat /etc/os-release

--- a/base-internal/releases/ubuntu/ubuntu22-node20/README.md
+++ b/base-internal/releases/ubuntu/ubuntu22-node20/README.md
@@ -1,0 +1,22 @@
+# cypress/base-internal:ubuntu22-node20
+
+Image with Ubuntu 22.04 and Node 20.x.x. To be used internally by Cypress.io and is not intended for public use.
+
+```
+node version:    v20.x.x
+npm version:
+yarn version:
+debian version:
+user:            root
+git:             git version 2.20.1
+DISTRIB_ID=Ubuntu
+DISTRIB_RELEASE=22.04.2
+DISTRIB_CODENAME=jammy
+DISTRIB_DESCRIPTION="Ubuntu 22.04"
+NAME="Ubuntu"
+VERSION="22.04 (Jammy Jellyfish)"
+ID=ubuntu
+ID_LIKE=debian
+PRETTY_NAME="Ubuntu 22.04"
+VERSION_ID="22.04"
+```

--- a/base-internal/releases/ubuntu/ubuntu22-node20/build.sh
+++ b/base-internal/releases/ubuntu/ubuntu22-node20/build.sh
@@ -1,0 +1,7 @@
+set e+x
+
+# build image with Cypress dependencies
+LOCAL_NAME=cypress/base-internal:ubuntu22-node20
+
+echo "Building $LOCAL_NAME"
+docker build -t $LOCAL_NAME --platform linux/amd64 .

--- a/base-internal/releases/ubuntu/ubuntu24-node20/Dockerfile
+++ b/base-internal/releases/ubuntu/ubuntu24-node20/Dockerfile
@@ -1,0 +1,77 @@
+FROM ubuntu:24.04
+
+# set up NodeJS
+RUN apt-get update && \
+  apt-get install -y apt-transport-https ca-certificates curl gnupg
+RUN mkdir -p /etc/apt/keyrings
+RUN curl -fsSL https://deb.nodesource.com/gpgkey/nodesource-repo.gpg.key | gpg --dearmor -o /etc/apt/keyrings/nodesource.gpg
+RUN echo "deb [signed-by=/etc/apt/keyrings/nodesource.gpg] https://deb.nodesource.com/node_20.x nodistro main" | tee /etc/apt/sources.list.d/nodesource.list
+RUN apt-get update && apt-get install -y nodejs
+
+# set up Python 3.11
+RUN apt-get install software-properties-common -y
+RUN add-apt-repository ppa:deadsnakes/ppa
+RUN apt-get update && apt-get upgrade -y
+RUN apt-get install g++ make python3.11 -y
+ENV NODE_GYP_FORCE_PYTHON=/usr/bin/python3.11
+
+# Install latest NPM and Yarn
+RUN npm install -g npm@latest
+RUN npm install -g yarn@latest
+
+# install additional native dependencies build tools
+RUN apt install -y build-essential
+
+# install Git client
+RUN apt-get install -y git
+# install unzip utility to speed up Cypress unzips
+# https://github.com/cypress-io/cypress/releases/tag/v3.8.0
+RUN apt-get install -y unzip
+
+# avoid any prompts
+ENV DEBIAN_FRONTEND noninteractive
+# install tzdata package
+RUN apt-get install -y tzdata
+# set your timezone
+RUN ln -fs /usr/share/zoneinfo/America/New_York /etc/localtime
+RUN dpkg-reconfigure --frontend noninteractive tzdata
+
+# install Cypress dependencies (separate commands to avoid time outs)
+RUN apt-get install -y \
+    libatk1.0-0 \
+    libgtk2.0-0t64 \
+    libglib2.0-0 \
+    libatk-bridge2.0-0 \
+    libcups2 \
+    libgtk-3-0t64 \
+    libgbm1 \
+    libgbm-dev
+RUN apt-get install -y \
+    libnotify-dev
+RUN apt-get install -y \
+    libnss3 \
+    libxss1
+RUN apt-get install -y \
+    libasound2t64 \
+    libxtst6 \
+    xauth \
+    xvfb
+# a few environment variables to make NPM installs easier
+# good colors for most applications
+ENV TERM xterm
+# avoid million NPM install messages
+ENV npm_config_loglevel warn
+# allow installing when the main user is root
+ENV npm_config_unsafe_perm true
+
+# versions of local tools
+RUN echo  " node version:    $(node -v) \n" \
+  "npm version:     $(npm -v) \n" \
+  "yarn version:    $(yarn -v) \n" \
+  "debian version:  $(cat /etc/debian_version) \n" \
+  "user:            $(whoami) \n" \
+  "git:             $(git --version) \n"
+
+RUN echo "More version info"
+RUN cat /etc/lsb-release
+RUN cat /etc/os-release

--- a/base-internal/releases/ubuntu/ubuntu24-node20/README.md
+++ b/base-internal/releases/ubuntu/ubuntu24-node20/README.md
@@ -1,0 +1,22 @@
+# cypress/base-internal:ubuntu24-node20
+
+Image with Ubuntu 24.04 and Node 20.x.x. To be used internally by Cypress.io and is not intended for public use.
+
+```
+node version:    v20.x.x
+npm version:
+yarn version:
+debian version:
+user:            root
+git:             git version 2.20.1
+DISTRIB_ID=Ubuntu
+DISTRIB_RELEASE=24.04
+DISTRIB_CODENAME=noble
+DISTRIB_DESCRIPTION="Ubuntu 24.04"
+NAME="Ubuntu"
+VERSION="24.04 (Noble Numbat)"
+ID=ubuntu
+ID_LIKE=debian
+PRETTY_NAME="Ubuntu 24.04"
+VERSION_ID="24.04"
+```

--- a/base-internal/releases/ubuntu/ubuntu24-node20/build.sh
+++ b/base-internal/releases/ubuntu/ubuntu24-node20/build.sh
@@ -1,0 +1,7 @@
+set e+x
+
+# build image with Cypress dependencies
+LOCAL_NAME=cypress/base-internal:ubuntu24-node20
+
+echo "Building $LOCAL_NAME"
+docker build -t $LOCAL_NAME --platform linux/amd64 .


### PR DESCRIPTION
adds ubuntu 22 and ubuntu 24 images based off of node 20 as node 20 will be the lowest supported node in Cypress 15