### PR TITLE
chore: update factory to use cypress 14.3.2 and update chrome to latest

### DIFF
--- a/factory/.env
+++ b/factory/.env
@@ -22,10 +22,10 @@ FACTORY_VERSION='5.8.0'
 
 # Chrome versions: https://www.ubuntuupdates.org/package/google_chrome/stable/main/base/google-chrome-stable
 # Linux/amd64 only
-CHROME_VERSION='135.0.7049.95-1'
+CHROME_VERSION='135.0.7049.114-1'
 
 # Cypress versions: https://www.npmjs.com/package/cypress
-CYPRESS_VERSION='14.3.1'
+CYPRESS_VERSION='14.3.2'
 
 # Edge versions: https://packages.microsoft.com/repos/edge/pool/main/m/microsoft-edge-stable/
 # Linux/amd64 only


### PR DESCRIPTION
updates factory to cypress `14.3.2` and updates Chrome to latest