### PR TITLE
fix(deps): update to Node.js 22.15.0

### DIFF
--- a/factory/.env
+++ b/factory/.env
@@ -11,14 +11,14 @@ BASE_IMAGE='debian:12.10-slim'
 # Node Versions: https://nodejs.org/en/download/releases/
 # master branch needs "Active LTS" version
 # use feature branch for "Maintenance LTS" or "Current" versions
-FACTORY_DEFAULT_NODE_VERSION='22.14.0'
+FACTORY_DEFAULT_NODE_VERSION='22.15.0'
 
 # Node Versions: https://nodejs.org/en/download/releases/
 NODE_VERSION="${FACTORY_DEFAULT_NODE_VERSION}"
 
 # Update the FACTORY_VERSION to deploy cypress/factory if you make changes to
 # BASE_IMAGE, FACTORY_DEFAULT_NODE_VERSION, YARN_VERSION, factory.Dockerfile or installScripts
-FACTORY_VERSION='5.8.0'
+FACTORY_VERSION='5.8.1'
 
 # Chrome versions: https://www.ubuntuupdates.org/package/google_chrome/stable/main/base/google-chrome-stable
 # Linux/amd64 only

--- a/factory/CHANGELOG.md
+++ b/factory/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Change log
 
+## 5.8.1
+
+- Updated default node version from `22.14.0` to `22.15.0`. Addressed in [#1335](https://github.com/cypress-io/cypress-docker-images/pull/1335).
+
 ## 5.8.0
 
 - Updated Debian base to `debian:12.10-slim` using [Debian 12.10](https://www.debian.org/News/2025/20250315), released on Mar 15, 2025. Addresses [#1324](https://github.com/cypress-io/cypress-docker-images/issues/1324).


### PR DESCRIPTION
## Issue

- The Node.js project released an update [Node.js v22.15.0 LTS](https://nodejs.org/en/blog/release/v22.15.0) on Apr 23, 2025.

## Change

In [factory/.env](https://github.com/cypress-io/cypress-docker-images/blob/master/factory/.env) make the following updates:

| Environment variable           | Before             | After     |
| ------------------------------ | ------------------ | --------- |
| `FACTORY_VERSION`              | `5.8.0`            | `5.8.1`   |
| `FACTORY_DEFAULT_NODE_VERSION` | `22.14.0`          | `22.15.0` |

