### PR TITLE
chore: release images for Node.js 24.0.0

### DIFF
--- a/circle.yml
+++ b/circle.yml
@@ -355,7 +355,7 @@ workflows:
                 # change to a feature branch such as <cypress-version>-node-<node.js version>-publish
                 # if publishing an alternate (non-primary) version
                 # This job must run because the base, browsers and included jobs depend on it
-                - master
+                - 14.3.3-node-24.0.0-publish
           requires:
             - factory
             - factory-arm
@@ -371,7 +371,7 @@ workflows:
                 # Only branches matching the below regex filters will run
                 # Change to a feature branch such as <cypress-version>-node-<node.js version>-publish
                 # if publishing an alternate version
-                - master
+                - 14.3.3-node-24.0.0-publish
           requires:
             - 'Push Factory Image'
             - base
@@ -386,7 +386,7 @@ workflows:
                 # Only branches matching the below regex filters will run
                 # Change to a feature branch such as <cypress-version>-node-<node.js version>-publish
                 # if publishing an alternate version
-                - master
+                - 14.3.3-node-24.0.0-publish
           requires:
             - 'Push Factory Image'
             - browsers
@@ -401,7 +401,7 @@ workflows:
                 # Only branches matching the below regex filters will run
                 # Change to a feature branch such as <cypress-version>-node-<node.js version>-publish
                 # if publishing an alternate version
-                - master
+                - 14.3.3-node-24.0.0-publish
           requires:
             - 'Push Factory Image'
             - included

--- a/factory/.env
+++ b/factory/.env
@@ -14,7 +14,7 @@ BASE_IMAGE='debian:12.10-slim'
 FACTORY_DEFAULT_NODE_VERSION='22.15.0'
 
 # Node Versions: https://nodejs.org/en/download/releases/
-NODE_VERSION="${FACTORY_DEFAULT_NODE_VERSION}"
+NODE_VERSION='24.0.0'
 
 # Update the FACTORY_VERSION to deploy cypress/factory if you make changes to
 # BASE_IMAGE, FACTORY_DEFAULT_NODE_VERSION, YARN_VERSION, factory.Dockerfile or installScripts

--- a/factory/.env
+++ b/factory/.env
@@ -22,18 +22,18 @@ FACTORY_VERSION='5.8.1'
 
 # Chrome versions: https://www.ubuntuupdates.org/package/google_chrome/stable/main/base/google-chrome-stable
 # Linux/amd64 only
-CHROME_VERSION='135.0.7049.114-1'
+CHROME_VERSION='136.0.7103.92-1'
 
 # Cypress versions: https://www.npmjs.com/package/cypress
-CYPRESS_VERSION='14.3.2'
+CYPRESS_VERSION='14.3.3'
 
 # Edge versions: https://packages.microsoft.com/repos/edge/pool/main/m/microsoft-edge-stable/
 # Linux/amd64 only
-EDGE_VERSION='135.0.3179.85-1'
+EDGE_VERSION='136.0.3240.50-1'
 
 # Firefox versions: https://download-installer.cdn.mozilla.net/pub/firefox/releases/
 # Linux/amd64 for all versions, Linux/arm64 for versions 136.0 and above
-FIREFOX_VERSION='137.0.2'
+FIREFOX_VERSION='138.0.1'
 
 # Yarn versions: https://www.npmjs.com/package/yarn and
 # Yarn v1 Classic only https://classic.yarnpkg.com/latest-version

--- a/factory/docker-compose.yml
+++ b/factory/docker-compose.yml
@@ -16,7 +16,7 @@ services:
         BASE_IMAGE: ${BASE_IMAGE}
         FACTORY_DEFAULT_NODE_VERSION: ${FACTORY_DEFAULT_NODE_VERSION}
       tags:
-        - ${REPO_PREFIX-}cypress/factory:latest # comment out for release of alternate version
+        # - ${REPO_PREFIX-}cypress/factory:latest # comment out for release of alternate version
         - ${REPO_PREFIX-}cypress/factory:${FACTORY_VERSION}
     command: node -v
 
@@ -35,8 +35,8 @@ services:
         YARN_VERSION: ${YARN_VERSION}
         # WEBKIT_VERSION: ${WEBKIT_VERSION}
       tags:
-        - ${REPO_PREFIX-}cypress/included:latest # comment out for release of alternate version
-        - ${REPO_PREFIX-}cypress/included:${INCLUDED_IMAGE_SHORT_TAG} # comment out for release of alternate version
+        # - ${REPO_PREFIX-}cypress/included:latest # comment out for release of alternate version
+        # - ${REPO_PREFIX-}cypress/included:${INCLUDED_IMAGE_SHORT_TAG} # comment out for release of alternate version
         - ${REPO_PREFIX-}cypress/included:${INCLUDED_IMAGE_TAG}
     command: node -v
 
@@ -53,7 +53,7 @@ services:
         FIREFOX_VERSION: ${FIREFOX_VERSION}
         EDGE_VERSION: ${EDGE_VERSION}
       tags:
-        - ${REPO_PREFIX-}cypress/browsers:latest # comment out for release of alternate version
+        # - ${REPO_PREFIX-}cypress/browsers:latest # comment out for release of alternate version
         - ${REPO_PREFIX-}cypress/browsers:${BROWSERS_IMAGE_SHORT_TAG}
         - ${REPO_PREFIX-}cypress/browsers:${BROWSERS_IMAGE_TAG}
     command: node -v
@@ -68,7 +68,7 @@ services:
         FACTORY_VERSION: ${FACTORY_VERSION}
         YARN_VERSION: ${YARN_VERSION}
       tags:
-        - ${REPO_PREFIX-}cypress/base:latest # comment out for release of alternate version
+        # - ${REPO_PREFIX-}cypress/base:latest # comment out for release of alternate version
         - ${REPO_PREFIX-}cypress/base:${BASE_IMAGE_TAG}
     command: node -v
 


### PR DESCRIPTION
- closes https://github.com/cypress-io/cypress-docker-images/issues/1336

## Situation

[Node.js 24.0.0](https://nodejs.org/en/blog/release/v24.0.0) was released as a new current version on May 6, 2025. The Node.js 24 release line is planned to be [promoted to LTS status](https://github.com/nodejs/release#release-schedule) on Oct 28, 2025. Cypress should provide Docker images based on the Node.js 24 release line to enable internal and external testing in advance of the change of status to LTS.

## Change

Using the feature branch

[14.3.3-node-24.0.0-publish](https://github.com/cypress-io/cypress-docker-images/tree/14.3.3-node-24.0.0-publish)

and following the process described in [Alternate versions](https://github.com/cypress-io/cypress-docker-images/blob/master/CONTRIBUTING.md#alternate-versions), generate and publish images based on `NODE_VERSION='24.0.0'`.

The set of Docker images are:

| Image type         | Short tag | Long tag                                                                            |
| ------------------ | --------- | ----------------------------------------------------------------------------------- |
| `cypress/base`     | `24.0.0`  | -                                                                                   |
| `cypress/browsers` | `24.0.0`  | `node-24.0.0-chrome-136.0.7103.92-1-ff-138.0.1-edge-136.0.3240.50-1`                |
| `cypress/included` | -         | `cypress-14.3.3-node-24.0.0-chrome-136.0.7103.92-1-ff-138.0.1-edge-136.0.3240.50-1` |

The `latest` tags are not changed.

