### PR TITLE
test: update chrome for testing example versions to 136.x

### DIFF
--- a/examples/chrome-for-testing/scripts/test.sh
+++ b/examples/chrome-for-testing/scripts/test.sh
@@ -19,8 +19,8 @@ case $ARCHITECTURE in
         'beta'
         'dev'
         'canary'
-        '130'
-        '131.0.6778.204'
+        '136'
+        '136.0.7103.92'
         )
     # Build, show Cypress info and run Cypress test
     for i in ${!chromeVersion[@]}; do


### PR DESCRIPTION
## Situation

The script [master/examples/chrome-for-testing/scripts/test.sh](https://github.com/cypress-io/cypress-docker-images/blob/master/examples/chrome-for-testing/scripts/test.sh) tests "Chrome for Testing" using versions:

```text
'stable'
'beta'
'dev'
'canary'
'130'
'131.0.6778.204'
```

In the meantime, Cypress supports latest 3 browser versions. The current Chrome version is 136, meaning that the numerical versions used in the test are now unsupported.

The alias `stable` is always supported by Cypress. The other aliases `beta`, `dev` and `canary` give advance access to functionality that is planned to flow into a stable supported release.

## Change

Update the numerical versions tested through [master/examples/chrome-for-testing/scripts/test.sh](https://github.com/cypress-io/cypress-docker-images/blob/master/examples/chrome-for-testing/scripts/test.sh) to use current stable versions:

'136'
'136.0.7103.92'
