### PR TITLE
fix(deps): update to Node.js 22.15.1

### DIFF
--- a/factory/.env
+++ b/factory/.env
@@ -18,22 +18,22 @@ NODE_VERSION="${FACTORY_DEFAULT_NODE_VERSION}"
 
 # Update the FACTORY_VERSION to deploy cypress/factory if you make changes to
 # BASE_IMAGE, FACTORY_DEFAULT_NODE_VERSION, YARN_VERSION, factory.Dockerfile or installScripts
-FACTORY_VERSION='5.8.1'
+FACTORY_VERSION='5.8.2'
 
 # Chrome versions: https://www.ubuntuupdates.org/package/google_chrome/stable/main/base/google-chrome-stable
 # Linux/amd64 only
-CHROME_VERSION='136.0.7103.92-1'
+CHROME_VERSION='136.0.7103.113-1'
 
 # Cypress versions: https://www.npmjs.com/package/cypress
 CYPRESS_VERSION='14.3.3'
 
 # Edge versions: https://packages.microsoft.com/repos/edge/pool/main/m/microsoft-edge-stable/
 # Linux/amd64 only
-EDGE_VERSION='136.0.3240.50-1'
+EDGE_VERSION='136.0.3240.64-1'
 
 # Firefox versions: https://download-installer.cdn.mozilla.net/pub/firefox/releases/
 # Linux/amd64 for all versions, Linux/arm64 for versions 136.0 and above
-FIREFOX_VERSION='138.0.1'
+FIREFOX_VERSION='138.0.3'
 
 # Yarn versions: https://www.npmjs.com/package/yarn and
 # Yarn v1 Classic only https://classic.yarnpkg.com/latest-version

--- a/factory/CHANGELOG.md
+++ b/factory/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Change log
 
+## 5.8.2
+
+- Updated default node version from `22.15.0` to `22.15.1`. Addressed in [#1349](https://github.com/cypress-io/cypress-docker-images/pull/1349).
+
 ## 5.8.1
 
 - Updated default node version from `22.14.0` to `22.15.0`. Addressed in [#1335](https://github.com/cypress-io/cypress-docker-images/pull/1335).


### PR DESCRIPTION
## Issue

- Node.js issued a security release [Node.js v22.15.1 LTS](https://nodejs.org/en/blog/release/v22.15.1) on May 14, 2025.

## Change

In [factory/.env](https://github.com/cypress-io/cypress-docker-images/blob/master/factory/.env) make the following updates:

| Environment variable           | Before            | After              |
| ------------------------------ | ----------------- | ------------------ |
| `FACTORY_VERSION`              | `5.8.1`           | `5.8.2`            |
| `FACTORY_DEFAULT_NODE_VERSION` | `22.15.0`         | `22.15.1`          |
| `CHROME_VERSION`               | `136.0.7103.92-1` | `136.0.7103.113-1` |
| `EDGE_VERSION`                 | `136.0.3240.50-1` | `136.0.3240.64-1`  |
| `FIREFOX_VERSION`              | `138.0.1`         | `138.0.3`          |

