### PR TITLE
fix(deps): update to Node.js 22.15.1 (Rev 2)

### DIFF
--- a/factory/.env
+++ b/factory/.env
@@ -11,14 +11,14 @@ BASE_IMAGE='debian:12.10-slim'
 # Node Versions: https://nodejs.org/en/download/releases/
 # master branch needs "Active LTS" version
 # use feature branch for "Maintenance LTS" or "Current" versions
-FACTORY_DEFAULT_NODE_VERSION='22.15.0'
+FACTORY_DEFAULT_NODE_VERSION='22.15.1'
 
 # Node Versions: https://nodejs.org/en/download/releases/
 NODE_VERSION="${FACTORY_DEFAULT_NODE_VERSION}"
 
 # Update the FACTORY_VERSION to deploy cypress/factory if you make changes to
 # BASE_IMAGE, FACTORY_DEFAULT_NODE_VERSION, YARN_VERSION, factory.Dockerfile or installScripts
-FACTORY_VERSION='5.8.2'
+FACTORY_VERSION='5.8.3'
 
 # Chrome versions: https://www.ubuntuupdates.org/package/google_chrome/stable/main/base/google-chrome-stable
 # Linux/amd64 only

--- a/factory/CHANGELOG.md
+++ b/factory/CHANGELOG.md
@@ -1,8 +1,12 @@
 # Change log
 
+## 5.8.3
+
+- Updated default node version from `22.15.0` to `22.15.1`. Addressed in [#1350](https://github.com/cypress-io/cypress-docker-images/pull/1350).
+
 ## 5.8.2
 
-- Updated default node version from `22.15.0` to `22.15.1`. Addressed in [#1349](https://github.com/cypress-io/cypress-docker-images/pull/1349).
+- Updated browsers to latest versions. Addressed in [#1349](https://github.com/cypress-io/cypress-docker-images/pull/1349).
 
 ## 5.8.1
 


### PR DESCRIPTION
This PR adds the missing bump to Node.js `22.15.1` which PR https://github.com/cypress-io/cypress-docker-images/pull/1349 was supposed to have included.

## Issue

- Node.js issued a security release [Node.js v22.15.1 LTS](https://nodejs.org/en/blog/release/v22.15.1) on May 14, 2025.

## Change

In [factory/.env](https://github.com/cypress-io/cypress-docker-images/blob/master/factory/.env) make the following updates:

| Environment variable           | Before             | After     |
| ------------------------------ | ------------------ | --------- |
| `FACTORY_VERSION`              | `5.8.2`            | `5.8.3`   |
| `FACTORY_DEFAULT_NODE_VERSION` | `22.15.0`          | `22.15.1` |
| `CHROME_VERSION`               | `136.0.7103.113-1` | unchanged |
| `EDGE_VERSION`                 | `136.0.3240.64-1`  | unchanged |
| `FIREFOX_VERSION`              | `138.0.3`          | unchanged |

