### PR TITLE
Update Firefox not found in GitHub Actions for Firefox 138

### DIFF
--- a/README.md
+++ b/README.md
@@ -144,20 +144,20 @@ To enable all Cypress debug logs when running Cypress in a Docker container, set
 
 ### Problem
 
-When running in [GitHub Actions](https://docs.github.com/en/actions) using a `cypress/browsers` or `cypress/included` image and testing against the Mozilla Firefox browser with the default `root` user, Cypress may fail to detect an installed Firefox browser. Instead Cypress shows the following error message:
+When running in [GitHub Actions](https://docs.github.com/en/actions) using a `cypress/browsers` or `cypress/included` image and testing against the Mozilla Firefox browser with the default `root` user, Cypress may fail to detect an installed Firefox browser for Firefox versions below `138`. Instead Cypress shows the following error message:
 
 > Browser: firefox was not found on your system or is not supported by Cypress.
 > Can't run because you've entered an invalid browser name.
 
-The [GitHub Actions Runner](https://github.com/actions/runner) creates the `/github/home` directory with non-root ownership `1001` (`runner`) and sets the environment variable `HOME` to point to this directory. Firefox will not run with these settings. If the command `firefox --version` is executed, Firefox explains the restriction:
+The [GitHub Actions Runner](https://github.com/actions/runner) creates the `/github/home` directory with non-root ownership `1001` (`runner`) and sets the environment variable `HOME` to point to this directory. Firefox will not run with these settings. If the command `firefox --version` is executed, Firefox versions below `138` explain the restriction:
 
 > Running Firefox as root in a regular user's session is not supported. ($HOME is /github/home which is owned by uid 1001.)
 
-See [Cypress issue #27121](https://github.com/cypress-io/cypress/issues/27121).
+Note: Firefox `138` has changed, compared to lower versions. In response to `firefox --version`, it displays the version, for instance "Mozilla Firefox 138.0.3", but then when attempting to run Firefox as `root` user in GitHub Actions, Firefox hangs indefinitely.
 
 ### Resolution
 
-To allow Firefox to run in GitHub Actions in a Docker container, add `options: --user 1001` to the workflow to match GitHub Actions' `runner` user.
+To allow Firefox to run in GitHub Actions in a Docker container, add `options: --user 1001` to the workflow to match GitHub Actions' `runner` user. This setting should be used for all Firefox versions.
 
 ```yml
 container:


### PR DESCRIPTION
## Situation

The [README > Known problems > Firefox not found](https://github.com/cypress-io/cypress-docker-images/blob/master/README.md#firefox-not-found) description applies to Firefox < `138`, not to the current Firefox 138 version.

Instead of Cypress not finding Firefox, it **does** find Firefox `138.x` and then hangs when attempting to test.

The resolution is the same as when Firefox is not found for previous Firefox versions: the user `1001` must be specified.

## Change

Modify [README > Known problems > Firefox not found](https://github.com/cypress-io/cypress-docker-images/blob/master/README.md#firefox-not-found)

- Make it clear that the issue applies only to Firefox < `138`.

- The workflow parameter `options: --user 1001` is correct for all versions.

- Remove the link to https://github.com/cypress-io/cypress/issues/27121 which is now closed, since it is no longer reproducible with Firefox `138.x`