### PR TITLE
chore: add cypress 14.4.0 and update browsers to latest

### DIFF
--- a/factory/.env
+++ b/factory/.env
@@ -25,15 +25,15 @@ FACTORY_VERSION='5.8.3'
 CHROME_VERSION='136.0.7103.113-1'
 
 # Cypress versions: https://www.npmjs.com/package/cypress
-CYPRESS_VERSION='14.3.3'
+CYPRESS_VERSION='14.4.0'
 
 # Edge versions: https://packages.microsoft.com/repos/edge/pool/main/m/microsoft-edge-stable/
 # Linux/amd64 only
-EDGE_VERSION='136.0.3240.64-1'
+EDGE_VERSION='136.0.3240.76-1'
 
 # Firefox versions: https://download-installer.cdn.mozilla.net/pub/firefox/releases/
 # Linux/amd64 for all versions, Linux/arm64 for versions 136.0 and above
-FIREFOX_VERSION='138.0.3'
+FIREFOX_VERSION='138.0.4'
 
 # Yarn versions: https://www.npmjs.com/package/yarn and
 # Yarn v1 Classic only https://classic.yarnpkg.com/latest-version


### PR DESCRIPTION
updates cypress to `14.4.0` and updates browsers to latest