### PR TITLE
feat: add geckodriver to cypress/browsers and cypress/included

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,6 +52,12 @@ Cypress officially [supports][Cypress Browser Support] the latest 3 major versio
 [Chromium]: https://www.chromium.org/Home/
 [Cypress Browser Support]: https://docs.cypress.io/app/references/launching-browsers#Browser-versions-supported
 
+### Mozilla geckodriver
+
+[cypress/browsers](./browsers/) and [cypress/included](./included/) images with Firefox `139.0.1` and above are built with the [Mozilla geckodriver](https://github.com/mozilla/geckodriver) included. This driver is needed to test when using Firefox with Cypress versions >= [13.15.1](https://docs.cypress.io/app/references/changelog#13-15-1). The environment variable `GECKODRIVER_PATH` points to the driver located at `/opt/geckodriver/geckodriver`. Earlier images, that do not include the driver, may attempt to download the driver at run-time when testing Firefox, causing failures in air-gapped network environments with no Internet access.
+
+[cypress/factory](./factory/) provides the parameter [GECKODRIVER_VERSION](./factory/README.md#geckodriver_version) to optionally add the driver to a custom image.
+
 ### Debian packages
 
 [Debian][Debian packages] provides two Cypress-compatible browsers as packages covering both `amd64` and `arm64` architectures.

--- a/circle.yml
+++ b/circle.yml
@@ -260,7 +260,6 @@ workflows:
                   test-factory-cypress-included-electron,
                   test-factory-cypress-included-electron-non-root-user,
                   test-factory-cypress-included-firefox,
-                  test-factory-cypress-included-firefox-geckodriver,
                   test-factory-cypress-included-firefox-non-root-user,
                   test-factory-all-included-electron-only,
                 ]
@@ -281,7 +280,6 @@ workflows:
                   test-factory-cypress-included-electron-non-root-user,
                   test-factory-cypress-included-chrome,
                   test-factory-cypress-included-firefox,
-                  test-factory-cypress-included-firefox-geckodriver,
                   test-factory-cypress-included-firefox-non-root-user,
                   test-factory-cypress-included-edge,
                   test-factory-all-included,

--- a/factory/.env
+++ b/factory/.env
@@ -33,7 +33,7 @@ EDGE_VERSION='136.0.3240.76-1'
 
 # Firefox versions: https://download-installer.cdn.mozilla.net/pub/firefox/releases/
 # Linux/amd64 for all versions, Linux/arm64 for versions 136.0 and above
-FIREFOX_VERSION='138.0.4'
+FIREFOX_VERSION='139.0.1'
 
 # Geckodriver versions: https://github.com/mozilla/geckodriver/releases
 # Geckodriver documentation: https://firefox-source-docs.mozilla.org/testing/geckodriver/index.html

--- a/factory/docker-compose.yml
+++ b/factory/docker-compose.yml
@@ -32,6 +32,7 @@ services:
         CYPRESS_VERSION: ${CYPRESS_VERSION}
         EDGE_VERSION: ${EDGE_VERSION}
         FIREFOX_VERSION: ${FIREFOX_VERSION}
+        GECKODRIVER_VERSION: ${GECKODRIVER_VERSION}
         YARN_VERSION: ${YARN_VERSION}
         # WEBKIT_VERSION: ${WEBKIT_VERSION}
       tags:
@@ -51,6 +52,7 @@ services:
         YARN_VERSION: ${YARN_VERSION}
         CHROME_VERSION: ${CHROME_VERSION}
         FIREFOX_VERSION: ${FIREFOX_VERSION}
+        GECKODRIVER_VERSION: ${GECKODRIVER_VERSION}
         EDGE_VERSION: ${EDGE_VERSION}
       tags:
         - ${REPO_PREFIX-}cypress/browsers:latest # comment out for release of alternate version
@@ -108,22 +110,9 @@ services:
         NODE_VERSION: ${NODE_VERSION}
         FACTORY_VERSION: ${FACTORY_VERSION}
         FIREFOX_VERSION: ${FIREFOX_VERSION}
-      tags:
-        - ${REPO_PREFIX-}cypress/firefox:${FIREFOX_VERSION}
-    command: firefox --version
-
-  firefox-geckodriver:
-    image: ${REPO_PREFIX-}cypress/firefox-geckodriver
-    build:
-      target: default_image
-      context: .
-      args:
-        NODE_VERSION: ${NODE_VERSION}
-        FACTORY_VERSION: ${FACTORY_VERSION}
-        FIREFOX_VERSION: ${FIREFOX_VERSION}
         GECKODRIVER_VERSION: ${GECKODRIVER_VERSION}
       tags:
-        - ${REPO_PREFIX-}cypress/firefox-geckodriver:${FIREFOX_VERSION}-${GECKODRIVER_VERSION}
+        - ${REPO_PREFIX-}cypress/firefox:${FIREFOX_VERSION}
     command: firefox --version
 
   # webkit:
@@ -189,23 +178,9 @@ services:
         FACTORY_VERSION: ${FACTORY_VERSION}
         CYPRESS_VERSION: ${CYPRESS_VERSION}
         FIREFOX_VERSION: ${FIREFOX_VERSION}
-      tags:
-        - ${REPO_PREFIX-}cypress/cypress-firefox:cypress-${CYPRESS_VERSION}-firefox-${FIREFOX_VERSION}
-    command: node -v
-
-  cypress-firefox-geckodriver:
-    image: ${REPO_PREFIX-}cypress/cypress-firefox-geckodriver
-    build:
-      target: default_image
-      context: .
-      args:
-        NODE_VERSION: ${NODE_VERSION}
-        FACTORY_VERSION: ${FACTORY_VERSION}
-        CYPRESS_VERSION: ${CYPRESS_VERSION}
-        FIREFOX_VERSION: ${FIREFOX_VERSION}
         GECKODRIVER_VERSION: ${GECKODRIVER_VERSION}
       tags:
-        - ${REPO_PREFIX-}cypress/cypress-firefox:cypress-${CYPRESS_VERSION}-firefox-${FIREFOX_VERSION}-geckodriver-${GECKODRIVER_VERSION}
+        - ${REPO_PREFIX-}cypress/cypress-firefox:cypress-${CYPRESS_VERSION}-firefox-${FIREFOX_VERSION}
     command: node -v
 
   ## Test image

--- a/factory/test-project/docker-compose.yml
+++ b/factory/test-project/docker-compose.yml
@@ -44,15 +44,6 @@ services:
       args:
         NODE_VERSION: ${NODE_VERSION}
         FIREFOX_VERSION: ${FIREFOX_VERSION}
-        BASE_TEST_IMAGE: cypress/factory:${FACTORY_VERSION}
-      context: .
-    command: npm run test -- -b firefox
-
-  test-factory-firefox-geckodriver:
-    build:
-      args:
-        NODE_VERSION: ${NODE_VERSION}
-        FIREFOX_VERSION: ${FIREFOX_VERSION}
         GECKODRIVER_VERSION: ${GECKODRIVER_VERSION}
         BASE_TEST_IMAGE: cypress/factory:${FACTORY_VERSION}
       context: .
@@ -105,17 +96,6 @@ services:
         NODE_VERSION: ${NODE_VERSION}
         CYPRESS_VERSION: ${CYPRESS_VERSION}
         FIREFOX_VERSION: ${FIREFOX_VERSION}
-        BASE_TEST_IMAGE: cypress/factory:${FACTORY_VERSION}
-      dockerfile: included.Dockerfile
-      context: .
-    command: cypress run -b firefox
-
-  test-factory-cypress-included-firefox-geckodriver:
-    build:
-      args:
-        NODE_VERSION: ${NODE_VERSION}
-        CYPRESS_VERSION: ${CYPRESS_VERSION}
-        FIREFOX_VERSION: ${FIREFOX_VERSION}
         GECKODRIVER_VERSION: ${GECKODRIVER_VERSION}
         BASE_TEST_IMAGE: cypress/factory:${FACTORY_VERSION}
       dockerfile: included.Dockerfile
@@ -129,6 +109,7 @@ services:
         NODE_VERSION: ${NODE_VERSION}
         CYPRESS_VERSION: ${CYPRESS_VERSION}
         FIREFOX_VERSION: ${FIREFOX_VERSION}
+        GECKODRIVER_VERSION: ${GECKODRIVER_VERSION}
         BASE_TEST_IMAGE: cypress/factory:${FACTORY_VERSION}
       dockerfile: included-non-root-user.Dockerfile
       context: .
@@ -162,6 +143,7 @@ services:
         CYPRESS_VERSION: ${CYPRESS_VERSION}
         CHROME_VERSION: ${CHROME_VERSION}
         FIREFOX_VERSION: ${FIREFOX_VERSION}
+        GECKODRIVER_VERSION: ${GECKODRIVER_VERSION}
         EDGE_VERSION: ${EDGE_VERSION}
         BASE_TEST_IMAGE: cypress/factory:${FACTORY_VERSION}
       dockerfile: included.Dockerfile
@@ -176,6 +158,7 @@ services:
         CYPRESS_VERSION: ${CYPRESS_VERSION}
         CHROME_VERSION: ${CHROME_VERSION}
         FIREFOX_VERSION: ${FIREFOX_VERSION}
+        GECKODRIVER_VERSION: ${GECKODRIVER_VERSION}
         EDGE_VERSION: ${EDGE_VERSION}
         BASE_TEST_IMAGE: cypress/factory:${FACTORY_VERSION}
       dockerfile: included.Dockerfile


### PR DESCRIPTION
- Closes https://github.com/cypress-io/cypress-docker-images/issues/1354
- Closes https://github.com/cypress-io/cypress-docker-images/issues/1348

## Situation

 `cypress/browsers` and `cypress/included` images do not include the [Mozilla geckodriver](https://github.com/mozilla/geckodriver) that is required for Firefox testing.

## Change

- Update `FIREFOX_VERSION` to `139.0.1` in [factory/.env](https://github.com/cypress-io/cypress-docker-images/blob/master/factory/.env)

- Add [Mozilla geckodriver](https://github.com/mozilla/geckodriver) to  `cypress/browsers` and `cypress/included` by using the build parameter `GECKODRIVER_VERSION` in [factory/docker-compose.yml](https://github.com/cypress-io/cypress-docker-images/blob/master/factory/docker-compose.yml) and in [factory/test-project/docker-compose.yml](https://github.com/cypress-io/cypress-docker-images/blob/master/factory/test-project/docker-compose.yml)

- Add "Mozilla geckodriver" sub-section to [Browsers](https://github.com/cypress-io/cypress-docker-images/blob/master/README.md#browsers)

- Remove unneeded separate `firefox-geckodriver` build and test definitions. These were used in the interim situation where geckodriver was added to the `cypress/factory` build and not yet to the `cypress/browsers` and `cypress/included` builds.

## Tests

```shell
cd factory
docker compose build factory
docker compose build browsers
docker compose build included
cd ../examples/basic
npm ci
docker build -f Dockerfile.browsers -t test-browsers .
cd ../..
```

Disconnect from network

```shell
cd examples/basic
docker run -it --rm -v .:/app -w /app --entrypoint bash test-browsers -c "npx cypress run -b firefox"
cd ..

cd basic-mini
docker run -it --rm -v .:/app -w /app --entrypoint cypress cypress/included run -b firefox
cd ../..
```
