### PR TITLE
chore: update factory and browsers to latest

### DIFF
--- a/factory/.env
+++ b/factory/.env
@@ -22,14 +22,14 @@ FACTORY_VERSION='5.10.0'
 
 # Chrome versions: https://www.ubuntuupdates.org/package/google_chrome/stable/main/base/google-chrome-stable
 # Linux/amd64 only
-CHROME_VERSION='136.0.7103.113-1'
+CHROME_VERSION='137.0.7151.68-1'
 
 # Cypress versions: https://www.npmjs.com/package/cypress
-CYPRESS_VERSION='14.4.0'
+CYPRESS_VERSION='14.4.1'
 
 # Edge versions: https://packages.microsoft.com/repos/edge/pool/main/m/microsoft-edge-stable/
 # Linux/amd64 only
-EDGE_VERSION='136.0.3240.76-1'
+EDGE_VERSION='137.0.3296.62-1'
 
 # Firefox versions: https://download-installer.cdn.mozilla.net/pub/firefox/releases/
 # Linux/amd64 for all versions, Linux/arm64 for versions 136.0 and above


### PR DESCRIPTION
updates cypress to 14.4.1 and browsers to latest at time of writing inside the factory