### PR TITLE
docs: add Chrome for Testing to main README

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,11 +46,16 @@ Cypress officially [supports][Cypress Browser Support] the latest 3 major versio
 <!-- browser links -->
 
 [Chrome]: https://developer.chrome.com/
+[Chrome for Testing]: https://developer.chrome.com/blog/chrome-for-testing
 [Firefox]: https://www.mozilla.org/firefox
 [Firefox Channel Choice]: https://support.mozilla.org/en-US/kb/choosing-firefox-update-channel
 [Edge]: https://developer.microsoft.com/microsoft-edge/
 [Chromium]: https://www.chromium.org/Home/
 [Cypress Browser Support]: https://docs.cypress.io/app/references/launching-browsers#Browser-versions-supported
+
+### Chrome for Testing
+
+[Google Chrome for Testing][Chrome for Testing] is an alternate version of Chrome which is supported by [Cypress 13.17.0](https://docs.cypress.io/app/references/changelog#13-17-0) and above. The [examples/chrome-for-testing](./examples/chrome-for-testing/) directory shows how it can be built into a custom Cypress Docker image.
 
 ### Mozilla geckodriver
 


### PR DESCRIPTION
## Situation

As noted in the Cypress documentation:

- [cypress@14.4.0 changelog](https://docs.cypress.io/app/references/changelog#14-4-0)
- [API > Node Events > before:browser:launch > Add browser extensions](https://docs.cypress.io/api/node-events/browser-launch-api#Add-browser-extensions)

> - Chrome-branded browsers (e.g., standard Chrome) version 137 and above no longer support extension loading via this API, due to the removal of the `--load-extension` flag by Chrome. We recommend using Chrome for Testing or Chromium instead. See Cypress Docker image examples for [Chrome for Testing](https://github.com/cypress-io/cypress-docker-images/tree/master/examples/chrome-for-testing) and [Chromium](https://github.com/cypress-io/cypress-docker-images/tree/master/examples/chromium).

In the Cypress Docker images main [README](https://github.com/cypress-io/cypress-docker-images/blob/master/README.md):

- "Chrome for Testing" is not mentioned
- "Chromium" is described in the [Browsers](https://github.com/cypress-io/cypress-docker-images/blob/master/README.md#browsers) sub-section [Debian packages](https://github.com/cypress-io/cypress-docker-images/blob/master/README.md#debian-packages) together with "Firefox ESR"

## Change

Add a "Chrome for Testing" sub-section to the [Browsers](https://github.com/cypress-io/cypress-docker-images/blob/master/README.md#browsers) section in the main [README](https://github.com/cypress-io/cypress-docker-images/blob/master/README.md) document.