### PR TITLE
fix: add chrome for testing dependencies to example

### DIFF
--- a/examples/chrome-for-testing/Dockerfile
+++ b/examples/chrome-for-testing/Dockerfile
@@ -8,5 +8,9 @@ ARG CHROME_VERSION=stable
 RUN INSTALL_OUTPUT=$(npx @puppeteer/browsers install chrome@${CHROME_VERSION} --path /tmp/chrome-for-testing) && \
 DOWNLOAD_DIR=$(echo "$INSTALL_OUTPUT" | grep -o '\/.*\/chrome-linux64') && \
 mv $DOWNLOAD_DIR /opt/chrome-for-testing
+RUN apt-get update && \
+    while read -r pkg; do \
+        apt-get satisfy -y --no-install-recommends "$pkg"; \
+    done < /opt/chrome-for-testing/deb.deps
 RUN ln -fs /opt/chrome-for-testing/chrome /usr/local/bin/chrome
 RUN rm -rf /tmp/chrome-for-testing


### PR DESCRIPTION
## Situation

In the [examples/chrome-for-testing > README](https://github.com/cypress-io/cypress-docker-images/blob/master/examples/chrome-for-testing/README.md) [Google Chrome for Testing](https://developer.chrome.com/blog/chrome-for-testing/) is installed using [@puppeteer/browsers](https://www.npmjs.com/package/@puppeteer/browsers)

The instructions to install system dependencies using the following from the README for [@puppeteer/browsers](https://www.npmjs.com/package/@puppeteer/browsers) was not used, because it did not work:

```shell
npx puppeteer browsers install chrome --install-deps
```

Although the example runs without checking for all dependencies, there may be some edge cases that need the complete set of dependencies installed.

## Change

In [examples/chrome-for-testing/Dockerfile](https://github.com/cypress-io/cypress-docker-images/blob/master/examples/chrome-for-testing/Dockerfile) use installed contents of `/opt/chrome-for-testing/deb.deps` to install any missing dependencies.

## Verification

Execute the following:

```shell
cd examples/chrome-for-testing              # Use a pre-configured simple Cypress E2E project
npm ci                                      # Install all dependencies
docker build --progress plain -t test-chrome-for-testing .   # Build a new image
docker run --rm --entrypoint bash test-chrome-for-testing -c "npx cypress run --browser chrome-for-testing" # Run Cypress test using Chrome for Testing
```
