### PR TITLE
docs: add chrome for testing dependencies to example readme

### DIFF
--- a/examples/chrome-for-testing/README.md
+++ b/examples/chrome-for-testing/README.md
@@ -23,6 +23,10 @@ ARG CHROME_VERSION=stable
 RUN INSTALL_OUTPUT=$(npx @puppeteer/browsers install chrome@${CHROME_VERSION} --path /tmp/chrome-for-testing) && \
 DOWNLOAD_DIR=$(echo "$INSTALL_OUTPUT" | grep -o '\/.*\/chrome-linux64') && \
 mv $DOWNLOAD_DIR /opt/chrome-for-testing
+RUN apt-get update && \
+    while read -r pkg; do \
+        apt-get satisfy -y --no-install-recommends "$pkg"; \
+    done < /opt/chrome-for-testing/deb.deps
 RUN ln -fs /opt/chrome-for-testing/chrome /usr/local/bin/chrome
 RUN rm -rf /tmp/chrome-for-testing
 ```


### PR DESCRIPTION
## Situation

In the [examples/chrome-for-testing > README](https://github.com/cypress-io/cypress-docker-images/blob/master/examples/chrome-for-testing/README.md) [Google Chrome for Testing](https://developer.chrome.com/blog/chrome-for-testing/) is installed using [@puppeteer/browsers](https://www.npmjs.com/package/@puppeteer/browsers)

- https://github.com/cypress-io/cypress-docker-images/pull/1368 updated the [examples/chrome-for-testing/Dockerfile](https://github.com/cypress-io/cypress-docker-images/blob/master/examples/chrome-for-testing/Dockerfile) to use the installed contents of `/opt/chrome-for-testing/deb.deps` to install any missing dependencies.

This change was not added to the [examples/chrome-for-testing > README](https://github.com/cypress-io/cypress-docker-images/blob/master/examples/chrome-for-testing/README.md) which is now out of sync with the [examples/chrome-for-testing/Dockerfile](https://github.com/cypress-io/cypress-docker-images/blob/master/examples/chrome-for-testing/Dockerfile).

## Change

Copy the contents of the current [examples/chrome-for-testing/Dockerfile](https://github.com/cypress-io/cypress-docker-images/blob/master/examples/chrome-for-testing/Dockerfile) into the [examples/chrome-for-testing > README](https://github.com/cypress-io/cypress-docker-images/blob/master/examples/chrome-for-testing/README.md)