### PR TITLE
feat: add Chrome for Testing to cypress/factory build process

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,7 +57,7 @@ Cypress officially [supports][Cypress Browser Support] the latest 3 major versio
 
 The [Google Chrome for Testing][Chrome for Testing] browser is supported by [Cypress 13.17.0](https://docs.cypress.io/app/references/changelog#13-17-0) and above.
 
-[cypress/factory](./factory/) provides the parameter [CHROME_FOR_TESTING_VERSION](./factory/README.md#chrome_for_testing_version) to optionally add Chrome for Testing to a custom image. The [examples/chrome-for-testing](./examples/chrome-for-testing/) directory describes an alternate way to install Chrome for Testing into a custom image using the [@puppeteer/browsers command-line utility](https://pptr.dev/browsers-api). At this time, Chrome for Testing is not included in [cypress/browsers](./browsers/) or [cypress/included](./included/) images.
+[cypress/factory](./factory/) provides the parameter [CHROME_FOR_TESTING_VERSION](./factory/README.md#chrome_for_testing_version) to optionally add Chrome for Testing to a custom image. The [examples/chrome-for-testing](./examples/chrome-for-testing/) directory describes an alternate way to install Chrome for Testing into a custom image using the [@puppeteer/browsers command-line utility](https://pptr.dev/browsers-api). At this time, Chrome for Testing is not included in [cypress/browsers](./browsers/) or [cypress/included](./included/) images. Chrome for Testing is currently not available for the `linux/arm64` platform.
 
 ### Mozilla geckodriver
 

--- a/README.md
+++ b/README.md
@@ -55,7 +55,9 @@ Cypress officially [supports][Cypress Browser Support] the latest 3 major versio
 
 ### Chrome for Testing
 
-[Google Chrome for Testing][Chrome for Testing] is an alternate version of Chrome which is supported by [Cypress 13.17.0](https://docs.cypress.io/app/references/changelog#13-17-0) and above. The [examples/chrome-for-testing](./examples/chrome-for-testing/) directory shows how it can be built into a custom Cypress Docker image.
+The [Google Chrome for Testing][Chrome for Testing] browser is supported by [Cypress 13.17.0](https://docs.cypress.io/app/references/changelog#13-17-0) and above.
+
+[cypress/factory](./factory/) provides the parameter [CHROME_FOR_TESTING_VERSION](./factory/README.md#chrome_for_testing_version) to optionally add Chrome for Testing to a custom image. The [examples/chrome-for-testing](./examples/chrome-for-testing/) directory describes an alternate way to install Chrome for Testing into a custom image using the [@puppeteer/browsers command-line utility](https://pptr.dev/browsers-api). At this time, Chrome for Testing is not included in [cypress/browsers](./browsers/) or [cypress/included](./included/) images.
 
 ### Mozilla geckodriver
 

--- a/circle.yml
+++ b/circle.yml
@@ -273,6 +273,7 @@ workflows:
                 [
                   test-factory-electron,
                   test-factory-chrome,
+                  test-factory-chrome-for-testing,
                   test-factory-chrome-non-root-user,
                   test-factory-firefox,
                   test-factory-edge,

--- a/examples/chrome-for-testing/README.md
+++ b/examples/chrome-for-testing/README.md
@@ -8,7 +8,7 @@ Note that Chrome for Testing is currently not available for the `linux/arm64` pl
 
 The example below downloads Chrome for Testing using [@puppeteer/browsers](https://pptr.dev/browsers-api).
 
-[cypress/factory](../../factory/) also supports building a customer Docker image with Chrome for Testing using the parameter [CHROME_FOR_TESTING_VERSION](../../factory/README.md#chrome_for_testing_version) which must be a full version specification. This is more restrictive than the example below with [@puppeteer/browsers](https://pptr.dev/browsers-api), which has the flexibility of using a version alias, such as `stable` or a short version specification.
+[cypress/factory](../../factory/) also supports building a custom Docker image with Chrome for Testing using the parameter [CHROME_FOR_TESTING_VERSION](../../factory/README.md#chrome_for_testing_version) which must be a full version specification. This is more restrictive than the example below with [@puppeteer/browsers](https://pptr.dev/browsers-api), which has the flexibility of using a version alias, such as `stable` or a short version specification.
 
 ### Docker build and run
 

--- a/examples/chrome-for-testing/README.md
+++ b/examples/chrome-for-testing/README.md
@@ -6,11 +6,15 @@ Note that Chrome for Testing is currently not available for the `linux/arm64` pl
 
 ## Docker
 
+The example below downloads Chrome for Testing using [@puppeteer/browsers](https://pptr.dev/browsers-api).
+
+[cypress/factory](../../factory/) also supports building a customer Docker image with Chrome for Testing using the parameter [CHROME_FOR_TESTING_VERSION](../../factory/README.md#chrome_for_testing_version) which must be a full version specification. This is more restrictive than the example below with [@puppeteer/browsers](https://pptr.dev/browsers-api), which has the flexibility of using a version alias, such as `stable` or a short version specification.
+
 ### Docker build and run
 
 In this example we use a customized `Dockerfile` which bases a new image on `cypress/base`, copies the complete Cypress project into the image, including installed dependencies, then installs the Cypress binary and Chrome for Testing into the image.
 
-The file is [examples/chrome-for-testing/Dockerfile](./Dockerfile). It has the following contents which build a custom Docker image using the `stable` version of Chrome for Testing:
+The file is [examples/chrome-for-testing/Dockerfile](./Dockerfile). It has the following contents which build a custom Docker image using the `stable` version of Chrome for Testing, downloaded with [@puppeteer/browsers](https://pptr.dev/browsers-api):
 
 ```dockerfile
 FROM cypress/base

--- a/factory/.env
+++ b/factory/.env
@@ -26,6 +26,7 @@ CHROME_VERSION='137.0.7151.68-1'
 
 # Chrome for Testing versions: https://googlechromelabs.github.io/chrome-for-testing/
 # not currently used for cypress/browsers and cypress/included images
+# Linux/amd64 only
 CHROME_FOR_TESTING_VERSION='137.0.7151.70'
 
 # Cypress versions: https://www.npmjs.com/package/cypress

--- a/factory/.env
+++ b/factory/.env
@@ -18,11 +18,15 @@ NODE_VERSION="${FACTORY_DEFAULT_NODE_VERSION}"
 
 # Update the FACTORY_VERSION to deploy cypress/factory if you make changes to
 # BASE_IMAGE, FACTORY_DEFAULT_NODE_VERSION, YARN_VERSION, factory.Dockerfile or installScripts
-FACTORY_VERSION='5.10.0'
+FACTORY_VERSION='5.11.0'
 
 # Chrome versions: https://www.ubuntuupdates.org/package/google_chrome/stable/main/base/google-chrome-stable
 # Linux/amd64 only
 CHROME_VERSION='137.0.7151.68-1'
+
+# Chrome for Testing versions: https://googlechromelabs.github.io/chrome-for-testing/
+# not currently used for cypress/browsers and cypress/included images
+CHROME_FOR_TESTING_VERSION='137.0.7151.70'
 
 # Cypress versions: https://www.npmjs.com/package/cypress
 CYPRESS_VERSION='14.4.1'

--- a/factory/CHANGELOG.md
+++ b/factory/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Change log
 
+## 5.11.0
+
+- Added ability to install Google [Chrome for Testing](https://developer.chrome.com/blog/chrome-for-testing/) with `CHROME_FOR_TESTING_VERSION`. Addresses [#1367](https://github.com/cypress-io/cypress-docker-images/issues/1367).
+
 ## 5.10.0
 
 - Updated Debian base image to `debian:12.11-slim` using [Debian 12.11](https://www.debian.org/News/2025/20250517), released on May 17, 2025. Addresses [#1352](https://github.com/cypress-io/cypress-docker-images/issues/1352).

--- a/factory/README.md
+++ b/factory/README.md
@@ -5,6 +5,7 @@
 - Node.js
 - Yarn v1 Classic
 - Chrome
+- Chrome for Testing
 - Firefox
 - geckodriver
 - Edge
@@ -75,6 +76,16 @@ Example: `CHROME_VERSION='131.0.6778.264-1'`
 [Chrome versions](https://www.ubuntuupdates.org/package/google_chrome/stable/main/base/google-chrome-stable)
 
 This browser is currently available only for the `Linux/amd64` platform.
+
+### CHROME_FOR_TESTING_VERSION
+
+The version of [Google Chrome for Testing](https://developer.chrome.com/blog/chrome-for-testing/) to install. If the `ARG` variable is unset or an empty string, Chrome for Testing is not installed.
+
+Example: `CHROME_FOR_TESTING_VERSION='137.0.7151.70'`
+
+Refer to [Chrome for Testing availability](https://googlechromelabs.github.io/chrome-for-testing/) for current versions or [available downloads](https://googlechromelabs.github.io/chrome-for-testing/files) for other versions.
+
+The parameter `CHROME_FOR_TESTING_VERSION` can be used for custom-built images based on `cypress/factory`. The browser is however not currently built into `cypress/browsers` or `cypress/included` images and is currently available only for the `Linux/amd64` platform.
 
 ### FIREFOX_VERSION
 

--- a/factory/docker-compose.yml
+++ b/factory/docker-compose.yml
@@ -88,6 +88,19 @@ services:
         - ${REPO_PREFIX-}cypress/chrome:${CHROME_VERSION}
     command: google-chrome --version
 
+  chrome-for-testing:
+    image: '${REPO_PREFIX-}cypress/chrome-for-testing'
+    build:
+      target: default_image
+      context: .
+      args:
+        NODE_VERSION: ${NODE_VERSION}
+        FACTORY_VERSION: ${FACTORY_VERSION}
+        CHROME_FOR_TESTING_VERSION: ${CHROME_FOR_TESTING_VERSION}
+      tags:
+        - ${REPO_PREFIX-}cypress/chrome-for-testing:${CHROME_FOR_TESTING_VERSION}
+    command: chrome --version
+
   edge:
     image: ${REPO_PREFIX-}cypress/edge
     build:
@@ -152,6 +165,20 @@ services:
         CHROME_VERSION: ${CHROME_VERSION}
       tags:
         - ${REPO_PREFIX-}cypress/cypress-chrome:cypress-${CYPRESS_VERSION}-chrome-${CHROME_VERSION}
+    command: node -v
+
+  cypress-chrome-for-testing:
+    image: ${REPO_PREFIX-}cypress/cypress-chrome
+    build:
+      target: default_image
+      context: .
+      args:
+        NODE_VERSION: ${NODE_VERSION}
+        FACTORY_VERSION: ${FACTORY_VERSION}
+        CYPRESS_VERSION: ${CYPRESS_VERSION}
+        CHROME_FOR_TESTING_VERSION: ${CHROME_FOR_TESTING_VERSION}
+      tags:
+        - ${REPO_PREFIX-}cypress/cypress-chrome-for-testing:cypress-${CYPRESS_VERSION}-chrome-for-testing-${CHROME_FOR_TESTING_VERSION}
     command: node -v
 
   cypress-edge:

--- a/factory/factory.Dockerfile
+++ b/factory/factory.Dockerfile
@@ -93,6 +93,11 @@ ONBUILD ARG CHROME_VERSION
 
 ONBUILD RUN node /opt/installScripts/chrome/install-chrome-version.js ${CHROME_VERSION}
 
+# Install Chrome for Testing: optional
+ONBUILD ARG CHROME_FOR_TESTING_VERSION
+
+ONBUILD RUN node /opt/installScripts/chrome-for-testing/install-chrome-for-testing-version.js ${CHROME_FOR_TESTING_VERSION}
+
 # Install Edge: optional
 ONBUILD ARG EDGE_VERSION
 

--- a/factory/installScripts/chrome-for-testing/default.sh
+++ b/factory/installScripts/chrome-for-testing/default.sh
@@ -1,0 +1,14 @@
+#! /bin/bash
+
+# Download locations on https://googlechromelabs.github.io/chrome-for-testing/ - see JSON endpoints
+
+wget --no-verbose -P /tmp/chrome-for-testing https://storage.googleapis.com/chrome-for-testing-public/${1}/linux64/chrome-linux64.zip
+unzip /tmp/chrome-for-testing/chrome-linux64.zip -d /tmp/chrome-for-testing
+mv /tmp/chrome-for-testing/chrome-linux64 /opt/chrome-for-testing
+apt-get update
+while read -r pkg
+do
+apt-get satisfy -y --no-install-recommends "${pkg}"
+done < /opt/chrome-for-testing/deb.deps
+ln -fs /opt/chrome-for-testing/chrome /usr/local/bin/chrome
+rm -rf /tmp/chrome-for-testing

--- a/factory/installScripts/chrome-for-testing/install-chrome-for-testing-version.js
+++ b/factory/installScripts/chrome-for-testing/install-chrome-for-testing-version.js
@@ -1,0 +1,29 @@
+#!/usr/bin/node
+const { spawn } = require('child_process')
+
+const chromeVersion = process.argv.slice(2)[0]
+
+if (!chromeVersion) {
+  console.log('No Chrome for Testing version provided, skipping Chrome for Testing install')
+  process.exit(0)
+}
+
+if (process.arch !== 'x64') {
+  console.log(`Chrome for Testing only available for x64. Not currently available for architecture: ${process.arch}`)
+  process.exit(0)
+}
+
+console.log('Installing Chrome for Testing version: ', chromeVersion)
+
+// Insert logic here if needed to run a different install script based on chrome version.
+const install = spawn(`${__dirname}/default.sh`, [chromeVersion], { stdio: 'inherit' })
+
+install.on('error', function (error) {
+  console.log('child process errored with ' + error.toString())
+  process.exit(1)
+})
+
+install.on('exit', function (code) {
+  console.log('child process exited with code ' + code.toString())
+  process.exit(code)
+})

--- a/factory/test-project/docker-compose.yml
+++ b/factory/test-project/docker-compose.yml
@@ -28,6 +28,15 @@ services:
       context: .
     command: npm run test -- -b chrome
 
+  test-factory-chrome-for-testing:
+    build:
+      args:
+        NODE_VERSION: ${NODE_VERSION}
+        CHROME_FOR_TESTING_VERSION: ${CHROME_FOR_TESTING_VERSION}
+        BASE_TEST_IMAGE: cypress/factory:${FACTORY_VERSION}
+      context: .
+    command: npm run test -- -b chrome-for-testing
+
   test-factory-chrome-non-root-user:
     user: node
     build:


### PR DESCRIPTION
- closes https://github.com/cypress-io/cypress-docker-images/issues/1367

## Situation

Google targets web app testing with their [Chrome for Testing](https://developer.chrome.com/blog/chrome-for-testing/) flavor of Chrome.

Currently the [cypress/factory](https://github.com/cypress-io/cypress-docker-images/tree/master/factory) build process supports the installation of [Google Chrome](https://www.google.com/chrome) by specifying [CHROME_VERSION](https://github.com/cypress-io/cypress-docker-images/tree/master/factory#chrome_version). It does not support Chrome for Testing.

Cypress introduced support for Chrome for Testing in [cypress@13.17.0](https://docs.cypress.io/app/references/changelog#13-17-0).

Google has restricted the use of the `--load-extension` flag in Chrome version 137 and above and continues to allow its use in Chrome for Testing. See also [cypress@14.4.0 changelog](https://docs.cypress.io/app/references/changelog#14-4-0).

The directory [examples/chrome-for-testing](https://github.com/cypress-io/cypress-docker-images/tree/master/examples/chrome-for-testing) shows how to add Chrome for Testing to a custom Cypress Docker image using shell commands in a [Dockerfile](https://github.com/cypress-io/cypress-docker-images/blob/master/examples/chrome-for-testing/Dockerfile). This diverges from the method used to install other browsers through `cypress/factory` that require only a single version parameter to install any of the browsers: Chrome, Edge or Firefox.

## Change

Add an option to install the [Google Chrome for Testing](https://developer.chrome.com/blog/chrome-for-testing/) browser using the [cypress/factory](https://github.com/cypress-io/cypress-docker-images/tree/master/factory) build process.

- Chrome for Testing is downloaded from `https://storage.googleapis.com/chrome-for-testing-public` as defined in [Chrome for Testing > JSON API endpoints](https://github.com/GoogleChromeLabs/chrome-for-testing/blob/main/README.md#json-api-endpoints). Puppeteer is not used.

- The Docker ARG parameter is `CHROME_FOR_TESTING_VERSION`

- Factory version is bumped to `5.11.0`

- CircleCI contains an additional test: `test-factory-chrome-for-testing`

## Verification

```shell
cd factory
docker compose --progress plain build factory
docker compose --progress plain build chrome-for-testing
docker compose --progress plain build cypress-chrome-for-testing
cd test-project
set -a && . ../.env && set +a
docker compose --progress plain run --build --rm test-factory-chrome-for-testing
```
