### PR TITLE
chore: update cypress to 14.5.0 and browsers to latest

### DIFF
--- a/factory/.env
+++ b/factory/.env
@@ -22,15 +22,15 @@ FACTORY_VERSION='5.11.0'
 
 # Chrome versions: https://www.ubuntuupdates.org/package/google_chrome/stable/main/base/google-chrome-stable
 # Linux/amd64 only
-CHROME_VERSION='137.0.7151.68-1'
+CHROME_VERSION='137.0.7151.119-1'
 
 # Chrome for Testing versions: https://googlechromelabs.github.io/chrome-for-testing/
 # not currently used for cypress/browsers and cypress/included images
 # Linux/amd64 only
-CHROME_FOR_TESTING_VERSION='137.0.7151.70'
+CHROME_FOR_TESTING_VERSION='137.0.7151.119'
 
 # Cypress versions: https://www.npmjs.com/package/cypress
-CYPRESS_VERSION='14.4.1'
+CYPRESS_VERSION='14.5.0'
 
 # Edge versions: https://packages.microsoft.com/repos/edge/pool/main/m/microsoft-edge-stable/
 # Linux/amd64 only
@@ -38,7 +38,7 @@ EDGE_VERSION='137.0.3296.62-1'
 
 # Firefox versions: https://download-installer.cdn.mozilla.net/pub/firefox/releases/
 # Linux/amd64 for all versions, Linux/arm64 for versions 136.0 and above
-FIREFOX_VERSION='139.0.1'
+FIREFOX_VERSION='139.0.4'
 
 # Geckodriver versions: https://github.com/mozilla/geckodriver/releases
 # Geckodriver documentation: https://firefox-source-docs.mozilla.org/testing/geckodriver/index.html


### PR DESCRIPTION
updates Cypress to `14.5.0` and browsers to latest