### PR TITLE
test: update test-project to cypress 14.5.0

### DIFF
--- a/factory/test-project/README.MD
+++ b/factory/test-project/README.MD
@@ -11,8 +11,9 @@ npx cypress open
 ```
 
 - Select "E2E Testing"
-- Select "Electron" browser
 - Select "Continue"
+- Select "Electron" browser
+- Select "Start E2E Testing in Electron"
 - Select "Scaffold example specs"
 - Close all Cypress windows
 
@@ -27,6 +28,8 @@ Remove Cypress from `package.json`:
 ```shell
 npm uninstall cypress --no-package-lock
 ```
+
+Commit the changes.
 
 ## Tests
 

--- a/factory/test-project/cypress/e2e/2-advanced-examples/actions.cy.js
+++ b/factory/test-project/cypress/e2e/2-advanced-examples/actions.cy.js
@@ -17,9 +17,9 @@ context('Actions', () => {
     cy.get('.action-email').type('{del}{selectall}{backspace}')
 
     // .type() with key modifiers
-    cy.get('.action-email').type('{alt}{option}') //these are equivalent
-    cy.get('.action-email').type('{ctrl}{control}') //these are equivalent
-    cy.get('.action-email').type('{meta}{command}{cmd}') //these are equivalent
+    cy.get('.action-email').type('{alt}{option}') // these are equivalent
+    cy.get('.action-email').type('{ctrl}{control}') // these are equivalent
+    cy.get('.action-email').type('{meta}{command}{cmd}') // these are equivalent
     cy.get('.action-email').type('{shift}')
 
     // Delay each keypress by 0.1 sec

--- a/factory/test-project/cypress/e2e/2-advanced-examples/cypress_api.cy.js
+++ b/factory/test-project/cypress/e2e/2-advanced-examples/cypress_api.cy.js
@@ -1,7 +1,6 @@
 /// <reference types="cypress" />
 
 context('Cypress APIs', () => {
-
   context('Cypress.Commands', () => {
     beforeEach(() => {
       cy.visit('https://example.cypress.io/cypress-api')

--- a/factory/test-project/cypress/e2e/2-advanced-examples/misc.cy.js
+++ b/factory/test-project/cypress/e2e/2-advanced-examples/misc.cy.js
@@ -43,7 +43,8 @@ context('Misc', () => {
     if (Cypress.platform === 'win32') {
       cy.exec(`print ${Cypress.config('configFile')}`)
         .its('stderr').should('be.empty')
-    } else {
+    }
+    else {
       cy.exec(`cat ${Cypress.config('configFile')}`)
         .its('stderr').should('be.empty')
 

--- a/factory/test-project/cypress/e2e/2-advanced-examples/storage.cy.js
+++ b/factory/test-project/cypress/e2e/2-advanced-examples/storage.cy.js
@@ -64,9 +64,9 @@ context('Local Storage / Session Storage', () => {
       expect(storageMap).to.deep.equal({
         // other origins will also be present if localStorage is set on them
         'https://example.cypress.io': {
-          'prop1': 'red',
-          'prop2': 'blue',
-          'prop3': 'magenta',
+          prop1: 'red',
+          prop2: 'blue',
+          prop3: 'magenta',
         },
       })
     })
@@ -94,9 +94,9 @@ context('Local Storage / Session Storage', () => {
       expect(storageMap).to.deep.equal({
         // other origins will also be present if sessionStorage is set on them
         'https://example.cypress.io': {
-          'prop4': 'cyan',
-          'prop5': 'yellow',
-          'prop6': 'black',
+          prop4: 'cyan',
+          prop5: 'yellow',
+          prop6: 'black',
         },
       })
     })


### PR DESCRIPTION
## Situation

- [cypress@14.5.0](https://docs.cypress.io/app/references/changelog#14-5-0) updated to use [cypress-example-kitchensink@5.0.0](https://github.com/cypress-io/cypress-example-kitchensink/releases/tag/v5.0.0) in https://github.com/cypress-io/cypress/blob/develop/packages/example/package.json from previously [cypress-example-kitchensink@4.0.0](https://github.com/cypress-io/cypress-example-kitchensink/releases/tag/v4.0.0). This jump included some minor changes to the Cypress scaffolded example tests.
- The [factory/test-project](https://github.com/cypress-io/cypress-docker-images/tree/master/factory/test-project) is manually built from the above source

## Change

- Re-scaffold the [factory/test-project](https://github.com/cypress-io/cypress-docker-images/tree/master/factory/test-project) according to the instructions in the [factory/test-project/README.MD](https://github.com/cypress-io/cypress-docker-images/blob/master/factory/test-project/README.MD)
- Make corrections also to the instructions in the [factory/test-project/README.MD](https://github.com/cypress-io/cypress-docker-images/blob/master/factory/test-project/README.MD)

## Verification

```shell
cd factory/test-project
set -a && . ../.env && set +a
docker compose run --build --rm test-factory-all-included
```

All tests should pass