### PR TITLE
fix(deps): update to Node.js 22.17.0

### DIFF
--- a/factory/.env
+++ b/factory/.env
@@ -11,34 +11,34 @@ BASE_IMAGE='debian:12.11-slim'
 # Node Versions: https://nodejs.org/en/download/releases/
 # master branch needs "Active LTS" version
 # use feature branch for "Maintenance LTS" or "Current" versions
-FACTORY_DEFAULT_NODE_VERSION='22.16.0'
+FACTORY_DEFAULT_NODE_VERSION='22.17.0'
 
 # Node Versions: https://nodejs.org/en/download/releases/
 NODE_VERSION="${FACTORY_DEFAULT_NODE_VERSION}"
 
 # Update the FACTORY_VERSION to deploy cypress/factory if you make changes to
 # BASE_IMAGE, FACTORY_DEFAULT_NODE_VERSION, YARN_VERSION, factory.Dockerfile or installScripts
-FACTORY_VERSION='5.11.0'
+FACTORY_VERSION='5.11.1'
 
 # Chrome versions: https://www.ubuntuupdates.org/package/google_chrome/stable/main/base/google-chrome-stable
 # Linux/amd64 only
-CHROME_VERSION='137.0.7151.119-1'
+CHROME_VERSION='138.0.7204.49-1'
 
 # Chrome for Testing versions: https://googlechromelabs.github.io/chrome-for-testing/
 # not currently used for cypress/browsers and cypress/included images
 # Linux/amd64 only
-CHROME_FOR_TESTING_VERSION='137.0.7151.119'
+CHROME_FOR_TESTING_VERSION='138.0.7204.49'
 
 # Cypress versions: https://www.npmjs.com/package/cypress
 CYPRESS_VERSION='14.5.0'
 
 # Edge versions: https://packages.microsoft.com/repos/edge/pool/main/m/microsoft-edge-stable/
 # Linux/amd64 only
-EDGE_VERSION='137.0.3296.62-1'
+EDGE_VERSION='137.0.3296.93-1'
 
 # Firefox versions: https://download-installer.cdn.mozilla.net/pub/firefox/releases/
 # Linux/amd64 for all versions, Linux/arm64 for versions 136.0 and above
-FIREFOX_VERSION='139.0.4'
+FIREFOX_VERSION='140.0'
 
 # Geckodriver versions: https://github.com/mozilla/geckodriver/releases
 # Geckodriver documentation: https://firefox-source-docs.mozilla.org/testing/geckodriver/index.html

--- a/factory/CHANGELOG.md
+++ b/factory/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Change log
 
+## 5.11.1
+
+- Updated default node version from `22.16.0` to `22.17.0`. Addressed in [#1374](https://github.com/cypress-io/cypress-docker-images/pull/1374).
+
 ## 5.11.0
 
 - Added ability to install Google [Chrome for Testing](https://developer.chrome.com/blog/chrome-for-testing/) with `CHROME_FOR_TESTING_VERSION`. Addresses [#1367](https://github.com/cypress-io/cypress-docker-images/issues/1367).


### PR DESCRIPTION
## Situation

- Node.js released an update [Node.js v22.17.0 LTS](https://nodejs.org/en/blog/release/v22.17.0) on Jun 24, 2025.

## Change

In [factory/.env](https://github.com/cypress-io/cypress-docker-images/blob/master/factory/.env) make the following updates:

| Environment variable           | Before             | After             |
| ------------------------------ | ------------------ | ----------------- |
| `FACTORY_VERSION`              | `5.11.0`           | `5.11.1`          |
| `FACTORY_DEFAULT_NODE_VERSION` | `22.16.0`          | `22.17.0`         |
| `CHROME_VERSION`               | `137.0.7151.119-1` | `138.0.7204.49-1` |
| `EDGE_VERSION`                 | `137.0.3296.62-1`  | `137.0.3296.93-1` |
| `FIREFOX_VERSION`              | `139.0.4`          | `140.0`           |

