### PR TITLE
fix: prefer Node.js gpg keyserver.ubuntu.com

### DIFF
--- a/factory/.env
+++ b/factory/.env
@@ -18,7 +18,7 @@ NODE_VERSION="${FACTORY_DEFAULT_NODE_VERSION}"
 
 # Update the FACTORY_VERSION to deploy cypress/factory if you make changes to
 # BASE_IMAGE, FACTORY_DEFAULT_NODE_VERSION, YARN_VERSION, factory.Dockerfile or installScripts
-FACTORY_VERSION='5.11.1'
+FACTORY_VERSION='5.11.2'
 
 # Chrome versions: https://www.ubuntuupdates.org/package/google_chrome/stable/main/base/google-chrome-stable
 # Linux/amd64 only

--- a/factory/CHANGELOG.md
+++ b/factory/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Change log
 
+## 5.11.2
+
+- Load PGP keys for Node.js from keyserver.ubuntu.com with fallback to hkps://keys.openpgp.org, reversing the previous order. Addresses [#1375](https://github.com/cypress-io/cypress-docker-images/issues/1375) and [#1376](https://github.com/cypress-io/cypress-docker-images/issues/1376).
+
 ## 5.11.1
 
 - Updated default node version from `22.16.0` to `22.17.0`. Addressed in [#1374](https://github.com/cypress-io/cypress-docker-images/pull/1374).

--- a/factory/installScripts/node/default.sh
+++ b/factory/installScripts/node/default.sh
@@ -36,8 +36,8 @@ ARCH= && dpkgArch="$(dpkg --print-architecture)" \
       A363A499291CBBC940DD62E41F10027AF002F8B0 \
       C0D6248439F1D5604AAFFB4021D900FFDB233756 \
     ; do \
-      gpg --batch --keyserver hkps://keys.openpgp.org $keyserverOptions --recv-keys "$key"  || \
-      gpg --batch --keyserver keyserver.ubuntu.com --recv-keys "$key" ; \
+      gpg --batch --keyserver keyserver.ubuntu.com --recv-keys "$key"  || \
+      gpg --batch --keyserver hkps://keys.openpgp.org $keyserverOptions --recv-keys "$key" ; \
     done \
     && curl -fsSLO --compressed "https://nodejs.org/dist/v$1/node-v$1-linux-$ARCH.tar.xz" \
     && curl -fsSLO --compressed "https://nodejs.org/dist/v$1/SHASUMS256.txt.asc" \


### PR DESCRIPTION
- closes https://github.com/cypress-io/cypress-docker-images/issues/1375
- closes https://github.com/cypress-io/cypress-docker-images/issues/1376

## Situation

- `cypress/factory` is unable to build new Docker images that include Node.js versions which have been signed with the key `C0D6248439F1D5604AAFFB4021D900FFDB233756`
- `docker compose` reports the error

    ```text
    16.91 gpg: Signature made Wed Jun 25 00:12:40 2025 UTC
    16.91 gpg:                using RSA key C0D6248439F1D5604AAFFB4021D900FFDB233756
    16.91 gpg: Can't check signature: No public key
    ```

This also blocks Cypress from releasing any new `cypress/browsers` or `cypress/included` image, so long as the Active LTS version has been signed with `C0D6248439F1D5604AAFFB4021D900FFDB233756`, as is the case with [Node.js 22.17.0](https://nodejs.org/en/blog/release/v22.17.0)

## Change

- Reverse the keyserver order in https://github.com/cypress-io/cypress-docker-images/blob/08b8bfd4126ac25703e1a187ee0730180e7772c5/factory/installScripts/node/default.sh#L39-L40
- Release `cypress/factory:5.11.2`

## Verification

```shell
git clone https://github.com/cypress-io/cypress-docker-images
cd cypress-docker-images
cd factory
docker compose build factory
docker compose build base --no-cache
```

and ensure that the `cypress/base` image is built.