### PR TITLE
chore: update to Cypress 14.5.1 and update browsers to latest

### DIFF
--- a/factory/.env
+++ b/factory/.env
@@ -22,23 +22,23 @@ FACTORY_VERSION='5.11.2'
 
 # Chrome versions: https://www.ubuntuupdates.org/package/google_chrome/stable/main/base/google-chrome-stable
 # Linux/amd64 only
-CHROME_VERSION='138.0.7204.49-1'
+CHROME_VERSION='138.0.7204.92-1'
 
 # Chrome for Testing versions: https://googlechromelabs.github.io/chrome-for-testing/
 # not currently used for cypress/browsers and cypress/included images
 # Linux/amd64 only
-CHROME_FOR_TESTING_VERSION='138.0.7204.49'
+CHROME_FOR_TESTING_VERSION='138.0.7204.92'
 
 # Cypress versions: https://www.npmjs.com/package/cypress
-CYPRESS_VERSION='14.5.0'
+CYPRESS_VERSION='14.5.1'
 
 # Edge versions: https://packages.microsoft.com/repos/edge/pool/main/m/microsoft-edge-stable/
 # Linux/amd64 only
-EDGE_VERSION='137.0.3296.93-1'
+EDGE_VERSION='138.0.3351.65-1'
 
 # Firefox versions: https://download-installer.cdn.mozilla.net/pub/firefox/releases/
 # Linux/amd64 for all versions, Linux/arm64 for versions 136.0 and above
-FIREFOX_VERSION='140.0'
+FIREFOX_VERSION='140.0.2'
 
 # Geckodriver versions: https://github.com/mozilla/geckodriver/releases
 # Geckodriver documentation: https://firefox-source-docs.mozilla.org/testing/geckodriver/index.html


### PR DESCRIPTION
Updates browsers to latest and Cypress to `14.5.1`