### PR TITLE
fix: explicit check for Node.js key import

### DIFF
--- a/factory/.env
+++ b/factory/.env
@@ -18,7 +18,7 @@ NODE_VERSION="${FACTORY_DEFAULT_NODE_VERSION}"
 
 # Update the FACTORY_VERSION to deploy cypress/factory if you make changes to
 # BASE_IMAGE, FACTORY_DEFAULT_NODE_VERSION, YARN_VERSION, factory.Dockerfile or installScripts
-FACTORY_VERSION='5.11.2'
+FACTORY_VERSION='5.11.3'
 
 # Chrome versions: https://www.ubuntuupdates.org/package/google_chrome/stable/main/base/google-chrome-stable
 # Linux/amd64 only

--- a/factory/CHANGELOG.md
+++ b/factory/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Change log
 
+## 5.11.3
+
+- Implement PGP key import checks for Node.js and restore the keyserver order to use hkps://keys.openpgp.org first with fallback to keyserver.ubuntu.com. Addressed in [#1380](https://github.com/cypress-io/cypress-docker-images/issues/1380).
+
 ## 5.11.2
 
 - Load PGP keys for Node.js from keyserver.ubuntu.com with fallback to hkps://keys.openpgp.org, reversing the previous order. Addresses [#1375](https://github.com/cypress-io/cypress-docker-images/issues/1375) and [#1376](https://github.com/cypress-io/cypress-docker-images/issues/1376).

--- a/factory/installScripts/node/default.sh
+++ b/factory/installScripts/node/default.sh
@@ -36,8 +36,8 @@ ARCH= && dpkgArch="$(dpkg --print-architecture)" \
       A363A499291CBBC940DD62E41F10027AF002F8B0 \
       C0D6248439F1D5604AAFFB4021D900FFDB233756 \
     ; do \
-      gpg --batch --keyserver keyserver.ubuntu.com --recv-keys "$key"  || \
-      gpg --batch --keyserver hkps://keys.openpgp.org $keyserverOptions --recv-keys "$key" ; \
+      { gpg --batch --keyserver hkps://keys.openpgp.org $keyserverOptions --recv-keys "$key" && gpg --batch --fingerprint "$key" ; } ||
+      { gpg --batch --keyserver keyserver.ubuntu.com --recv-keys "$key" && gpg --batch --fingerprint "$key" ; } ; \
     done \
     && curl -fsSLO --compressed "https://nodejs.org/dist/v$1/node-v$1-linux-$ARCH.tar.xz" \
     && curl -fsSLO --compressed "https://nodejs.org/dist/v$1/SHASUMS256.txt.asc" \


### PR DESCRIPTION
## Situation

PR https://github.com/cypress-io/cypress-docker-images/pull/1377 implemented an emergency workaround to unblock building a Cypress Docker image based on Node.js 22.17.0 (Active LTS version) and signed with the key `C0D6248439F1D5604AAFFB4021D900FFDB233756`.

The original issue was that the keyserver hkps://keys.openpgp.org recognized the key `C0D6248439F1D5604AAFFB4021D900FFDB233756` and then skipped importing it. The user ID `duhamelantoine1995@gmail.com` had been moved to the newly created key `5BE8A3F6C8A5C01D106C0AD820B1A390B168D356` and was no longer available for the older key. This left the `cypress/factory` process unable to verify the Node.js 22.17.0 package and so the build failed. (https://github.com/cypress-io/cypress-docker-images/issues/1376 contains slightly more background information about the issue.)

In the meantime, the [nodejs/docker-node](https://github.com/nodejs/docker-node) repo has faced the same issue and has implemented a more robust solution which checks the presence of the key after attempting to import, and thus does not rely on the misleading "success" return code if a key import is skipped.

## Change

Add a check to list an imported key. If the key has not been imported, then an explicit error code is generated. In the case of the problematic key, this will then fallback to an attempt on the second keyserver.

```shell
gpg --batch --fingerprint "$key"
```

The original priority of keyservers:

1. hkps://keys.openpgp.org
2. keyserver.ubuntu.com

is also restored.

`FACTORY_VERSION` becomes `5.11.3`

## Verification

```shell
git clone https://github.com/cypress-io/cypress-docker-images
cd cypress-docker-images
cd factory
docker compose build factory
docker compose --progress plain build base --no-cache
```

Confirm that key is imported

```text
#6 7.310 + gpg --batch --fingerprint C0D6248439F1D5604AAFFB4021D900FFDB233756
#6 7.318 pub   rsa4096 2022-01-25 [SC]
#6 7.318       C0D6 2484 39F1 D560 4AAF  FB40 21D9 00FF DB23 3756
#6 7.318 uid           [ unknown] Antoine du Hamel <duhamelantoine1995@gmail.com>
#6 7.318 sub   rsa4096 2022-01-25 [E]
```
