### PR TITLE
chore: update factory to latest browsers and cypress to 14.5.2

### DIFF
--- a/factory/.env
+++ b/factory/.env
@@ -22,23 +22,23 @@ FACTORY_VERSION='5.11.3'
 
 # Chrome versions: https://www.ubuntuupdates.org/package/google_chrome/stable/main/base/google-chrome-stable
 # Linux/amd64 only
-CHROME_VERSION='138.0.7204.92-1'
+CHROME_VERSION='138.0.7204.157-1'
 
 # Chrome for Testing versions: https://googlechromelabs.github.io/chrome-for-testing/
 # not currently used for cypress/browsers and cypress/included images
 # Linux/amd64 only
-CHROME_FOR_TESTING_VERSION='138.0.7204.92'
+CHROME_FOR_TESTING_VERSION='138.0.7204.157'
 
 # Cypress versions: https://www.npmjs.com/package/cypress
-CYPRESS_VERSION='14.5.1'
+CYPRESS_VERSION='14.5.2'
 
 # Edge versions: https://packages.microsoft.com/repos/edge/pool/main/m/microsoft-edge-stable/
 # Linux/amd64 only
-EDGE_VERSION='138.0.3351.65-1'
+EDGE_VERSION='138.0.3351.83-1'
 
 # Firefox versions: https://download-installer.cdn.mozilla.net/pub/firefox/releases/
 # Linux/amd64 for all versions, Linux/arm64 for versions 136.0 and above
-FIREFOX_VERSION='140.0.2'
+FIREFOX_VERSION='140.0.4'
 
 # Geckodriver versions: https://github.com/mozilla/geckodriver/releases
 # Geckodriver documentation: https://firefox-source-docs.mozilla.org/testing/geckodriver/index.html


### PR DESCRIPTION
Updates the cypress factory version to `14.5.2` and browsers to latest stable