### PR TITLE
fix: skip individual failed Node.js key imports

### DIFF
--- a/factory/.env
+++ b/factory/.env
@@ -18,7 +18,7 @@ NODE_VERSION="${FACTORY_DEFAULT_NODE_VERSION}"
 
 # Update the FACTORY_VERSION to deploy cypress/factory if you make changes to
 # BASE_IMAGE, FACTORY_DEFAULT_NODE_VERSION, YARN_VERSION, factory.Dockerfile or installScripts
-FACTORY_VERSION='5.11.4'
+FACTORY_VERSION='5.11.5'
 
 # Chrome versions: https://www.ubuntuupdates.org/package/google_chrome/stable/main/base/google-chrome-stable
 # Linux/amd64 only

--- a/factory/CHANGELOG.md
+++ b/factory/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Change log
 
+## 5.11.5
+
+- When importing PGP keys for Node.js, allow individual key imports to fail. Log an error and continue to build. Resolves an issue when there is a network connectivity problem to the fallback keyserver keyserver.ubuntu.com. Addressed in [#1385](https://github.com/cypress-io/cypress-docker-images/issues/1385).
+
 ## 5.11.4
 
 - Updated default node version from `22.17.0` to `22.17.1`. Addressed in [#1384](https://github.com/cypress-io/cypress-docker-images/pull/1384).

--- a/factory/installScripts/node/default.sh
+++ b/factory/installScripts/node/default.sh
@@ -37,7 +37,8 @@ ARCH= && dpkgArch="$(dpkg --print-architecture)" \
       C0D6248439F1D5604AAFFB4021D900FFDB233756 \
     ; do \
       { gpg --batch --keyserver hkps://keys.openpgp.org $keyserverOptions --recv-keys "$key" && gpg --batch --fingerprint "$key" ; } ||
-      { gpg --batch --keyserver keyserver.ubuntu.com --recv-keys "$key" && gpg --batch --fingerprint "$key" ; } ; \
+      { gpg --batch --keyserver keyserver.ubuntu.com --recv-keys "$key" && gpg --batch --fingerprint "$key" ; } ||
+      { echo failed to import Node.js release key "$key" ; } ; \
     done \
     && curl -fsSLO --compressed "https://nodejs.org/dist/v$1/node-v$1-linux-$ARCH.tar.xz" \
     && curl -fsSLO --compressed "https://nodejs.org/dist/v$1/SHASUMS256.txt.asc" \


### PR DESCRIPTION
- closes https://github.com/cypress-io/cypress-docker-images/issues/1386
- responds to build and connectivity issues reported in https://github.com/cypress-io/cypress-docker-images/issues/1382

## Situation

When importing [Node.js release keys](https://github.com/nodejs/node/blob/main/README.md#release-keys), if a key cannot be imported from the primary keyserver hkps://keys.openpgp.orgs and there is a network connection issue to the fallback keyserver `keyserver.ubuntu.com`, then importing **ALL** Node.js keys fails. This in turn causes a build failure, even if the corresponding key, that could not be imported, is not subsequently needed to verify the actual Node.js version selected with `NODE_VERSION`.

## Environment

- `cypress/factory:5.11.3`
- `cypress/factory:5.11.4`

## Background

As a consequence of catastrophic verification issues with the then Active LTS Node.js version `22.17.0`:

- PR https://github.com/cypress-io/cypress-docker-images/pull/1377 implemented an emergency workaround to allow releasing `cypress/included:14.5.1`
- then, following a corresponding fix to the reference repo [nodejs/docker-node](https://github.com/nodejs/docker-node), PR https://github.com/cypress-io/cypress-docker-images/pull/1380 was implemented which avoided the failure to import a key from hkps://keys.openpgp.org that had been stripped of its identity due to the restriction that an email address can only be a associated with a single key (see hkps://keys.openpgp.orgs FAQ [Can I verify more than one key for some email address?](https://keys.openpgp.org/about/faq#verify-multiple))

## Change

In [factory/installScripts/node/default.sh](https://github.com/cypress-io/cypress-docker-images/blob/master/factory/installScripts/node/default.sh) trap any import failure and log a failure message allowing the workflow instead to continue.

The result is that a network connection issue to the fallback keyserver `keyserver.ubuntu.com` or similar issue will no longer fail the build at the stage of importing Node.js keys. Instead, the build will fail as a consequence **ONLY** if there is a failure to import the exact key needed to verify the selected version of Node.js through the `NODE_VERSION` parameter.

In [factory/.env](https://github.com/cypress-io/cypress-docker-images/blob/master/factory/.env) increment `FACTORY_VERSION`

| Environment variable | Before   | After    |
| -------------------- | -------- | -------- |
| `FACTORY_VERSION`    | `5.11.4` | `5.11.5` |