### PR TITLE
fix: catch Cypress installation script download error

### DIFF
--- a/factory/.env
+++ b/factory/.env
@@ -18,7 +18,7 @@ NODE_VERSION="${FACTORY_DEFAULT_NODE_VERSION}"
 
 # Update the FACTORY_VERSION to deploy cypress/factory if you make changes to
 # BASE_IMAGE, FACTORY_DEFAULT_NODE_VERSION, YARN_VERSION, factory.Dockerfile or installScripts
-FACTORY_VERSION='5.11.5'
+FACTORY_VERSION='5.11.6'
 
 # Chrome versions: https://www.ubuntuupdates.org/package/google_chrome/stable/main/base/google-chrome-stable
 # Linux/amd64 only

--- a/factory/CHANGELOG.md
+++ b/factory/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Change log
 
+## 5.11.6
+
+- When building an image that includes Cypress, ensure that a failed download results in a failure exit code. Fixes [#1391](https://github.com/cypress-io/cypress-docker-images/issues/1391).
+
 ## 5.11.5
 
 - When importing PGP keys for Node.js, allow individual key imports to fail. Log an error and continue to build. Resolves an issue when there is a network connectivity problem to the fallback keyserver keyserver.ubuntu.com. Addressed in [#1385](https://github.com/cypress-io/cypress-docker-images/issues/1385).

--- a/factory/installScripts/cypress/default.sh
+++ b/factory/installScripts/cypress/default.sh
@@ -1,12 +1,13 @@
 #! /bin/bash
+set -e
 
-# TODO: should typescript be versioned? Should it have it's own ARG for the factory?
-# Typescript is installed to allow testing of .ts spec files.
+# TODO: should TypeScript be versioned? Should it have its own ARG for the factory?
+# TypeScript is installed to allow testing of .ts spec files.
 npm install -g "cypress@${1}" typescript
 
-# Loosen file priveleges for the cypress cache. The first time that cypress runs it will create a
+# Loosen file privileges for the Cypress cache. The first time that Cypress runs, it will create a
 # binary_state.json file if it hasn't already been created. This was causing issues with non-root
-# users, they do not have access to write to this directory. Since this is a develompent docker container
+# users who do not have access to write to this directory. Since this is a develompent Docker image
 # and to lower barriers as much as possible, we are loosening privs to allow the binary_state.json file
 # to be created. Previously this file was created by root when cypress verify was called, but this would
 # apply to amd processors since cypress verify was not called on arm processors.


### PR DESCRIPTION
- closes https://github.com/cypress-io/cypress-docker-images/issues/1391

## Situation

If there is an `npm install` error in the shell installation script for Cypress [factory/installScripts/cypress/default.sh](https://github.com/cypress-io/cypress-docker-images/blob/master/factory/installScripts/cypress/default.sh), the script continues and does not pass the error to the caller. The exit code is then incorrect `0` (success):

> child process exited with code 0

In the CircleCI config [circle.yml](https://github.com/cypress-io/cypress-docker-images/blob/master/circle.yml), jobs which build and test images with Cypress included then fail when testing the image, instead of failing at the stage of image build. The image build reports success even if the `npm install cypress` step failed.


## Change

In the script [factory/installScripts/cypress/default.sh](https://github.com/cypress-io/cypress-docker-images/blob/master/factory/installScripts/cypress/default.sh)

- use [set -e](https://www.gnu.org/software/bash/manual/bash.html#The-Set-Builtin) to ensure that a failure in `npm install` is reflected in the process exit code
- correct typos

- bump `FACTORY_VERSION` to `5.11.6`