### PR TITLE
fix(deps): update to Node.js 22.18.0

### DIFF
--- a/factory/.env
+++ b/factory/.env
@@ -11,34 +11,34 @@ BASE_IMAGE='debian:12.11-slim'
 # Node Versions: https://nodejs.org/en/download/releases/
 # master branch needs "Active LTS" version
 # use feature branch for "Maintenance LTS" or "Current" versions
-FACTORY_DEFAULT_NODE_VERSION='22.17.1'
+FACTORY_DEFAULT_NODE_VERSION='22.18.0'
 
 # Node Versions: https://nodejs.org/en/download/releases/
 NODE_VERSION="${FACTORY_DEFAULT_NODE_VERSION}"
 
 # Update the FACTORY_VERSION to deploy cypress/factory if you make changes to
 # BASE_IMAGE, FACTORY_DEFAULT_NODE_VERSION, YARN_VERSION, factory.Dockerfile or installScripts
-FACTORY_VERSION='5.12.0'
+FACTORY_VERSION='5.12.1'
 
 # Chrome versions: https://www.ubuntuupdates.org/package/google_chrome/stable/main/base/google-chrome-stable
 # Linux/amd64 only
-CHROME_VERSION='138.0.7204.157-1'
+CHROME_VERSION='138.0.7204.183-1'
 
 # Chrome for Testing versions: https://googlechromelabs.github.io/chrome-for-testing/
 # not currently used for cypress/browsers and cypress/included images
 # Linux/amd64 only
-CHROME_FOR_TESTING_VERSION='138.0.7204.157'
+CHROME_FOR_TESTING_VERSION='138.0.7204.183'
 
 # Cypress versions: https://www.npmjs.com/package/cypress
 CYPRESS_VERSION='14.5.3'
 
 # Edge versions: https://packages.microsoft.com/repos/edge/pool/main/m/microsoft-edge-stable/
 # Linux/amd64 only
-EDGE_VERSION='138.0.3351.83-1'
+EDGE_VERSION='138.0.3351.121-1'
 
 # Firefox versions: https://download-installer.cdn.mozilla.net/pub/firefox/releases/
 # Linux/amd64 for all versions, Linux/arm64 for versions 136.0 and above
-FIREFOX_VERSION='140.0.4'
+FIREFOX_VERSION='141.0'
 
 # Geckodriver versions: https://github.com/mozilla/geckodriver/releases
 # Geckodriver documentation: https://firefox-source-docs.mozilla.org/testing/geckodriver/index.html

--- a/factory/CHANGELOG.md
+++ b/factory/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Change log
 
+## 5.12.1
+
+- Updated default node version from `22.17.1` to `22.18.0`. Addressed in [#1394](https://github.com/cypress-io/cypress-docker-images/pull/1394).
+
 ## 5.12.0
 
 - Import all PGP keys for Node.js from `pgp` keyring in https://github.com/nodejs/release-keys repo. Addressed in [#1388](https://github.com/cypress-io/cypress-docker-images/issues/1388).

--- a/factory/installScripts/node/default.sh
+++ b/factory/installScripts/node/default.sh
@@ -3,9 +3,7 @@
 groupadd --gid 1000 node \
   && useradd --uid 1000 --gid node --shell /bin/bash --create-home node
 
-# The following is borrowed from https://github.com/nodejs/docker-node/blob/main/20/bookworm-slim/Dockerfile
-# Node.js GPG keys are taken from https://github.com/nodejs/node/
-# Tweaked for gpg proxy management
+# The following was originally based on https://github.com/nodejs/docker-node/blob/main/20/bookworm-slim/Dockerfile
 ARCH= && dpkgArch="$(dpkg --print-architecture)" \
     && case "${dpkgArch##*-}" in \
       amd64) ARCH='x64';; \


### PR DESCRIPTION
## Situation

- Node.js released an update [Node.js v22.18.0 LTS](https://nodejs.org/en/blog/release/v22.18.0) on Jul 31, 2025.

## Change

In [factory/.env](https://github.com/cypress-io/cypress-docker-images/blob/master/factory/.env) make the following updates:

| Environment variable           | Before             | After              |
| ------------------------------ | ------------------ | ------------------ |
| `FACTORY_VERSION`              | `5.12.0`           | `5.12.1`           |
| `FACTORY_DEFAULT_NODE_VERSION` | `22.17.1`          | `22.18.0`          |
| `CHROME_VERSION`               | `138.0.7204.157-1` | `138.0.7204.183-1` |
| `CHROME_FOR_TESTING_VERSION`   | `138.0.7204.157`   | `138.0.7204.183`   |
| `EDGE_VERSION`                 | `138.0.3351.83-1`  | `138.0.3351.121-1` |
| `FIREFOX_VERSION`              | `140.0.4`          | `141.0`            |

Outdated comments in [factory/installScripts/node/default.sh](https://github.com/cypress-io/cypress-docker-images/blob/master/factory/installScripts/node/default.sh) are updated.