### PR TITLE
chore: update browsers and app to 14.5.4

### DIFF
--- a/factory/.env
+++ b/factory/.env
@@ -22,15 +22,15 @@ FACTORY_VERSION='5.12.1'
 
 # Chrome versions: https://www.ubuntuupdates.org/package/google_chrome/stable/main/base/google-chrome-stable
 # Linux/amd64 only
-CHROME_VERSION='138.0.7204.183-1'
+CHROME_VERSION='139.0.7258.66-1'
 
 # Chrome for Testing versions: https://googlechromelabs.github.io/chrome-for-testing/
 # not currently used for cypress/browsers and cypress/included images
 # Linux/amd64 only
-CHROME_FOR_TESTING_VERSION='138.0.7204.183'
+CHROME_FOR_TESTING_VERSION='139.0.7258.66'
 
 # Cypress versions: https://www.npmjs.com/package/cypress
-CYPRESS_VERSION='14.5.3'
+CYPRESS_VERSION='14.5.4'
 
 # Edge versions: https://packages.microsoft.com/repos/edge/pool/main/m/microsoft-edge-stable/
 # Linux/amd64 only
@@ -38,7 +38,7 @@ EDGE_VERSION='138.0.3351.121-1'
 
 # Firefox versions: https://download-installer.cdn.mozilla.net/pub/firefox/releases/
 # Linux/amd64 for all versions, Linux/arm64 for versions 136.0 and above
-FIREFOX_VERSION='141.0'
+FIREFOX_VERSION='141.0.3'
 
 # Geckodriver versions: https://github.com/mozilla/geckodriver/releases
 # Geckodriver documentation: https://firefox-source-docs.mozilla.org/testing/geckodriver/index.html


### PR DESCRIPTION
updates browsers to latest and cypress to 14.5.4