### PR TITLE
feat: update BASE_IMAGE to debian:13.0-slim (trixie)

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -122,7 +122,7 @@ To release a new [factory](./factory/README.md), open a PR with the desired chan
 
 ## Minimize image sizes
 
-The `BASE_IMAGE` defined in [factory/.env](./factory/.env) uses a [Debian Docker image](https://hub.docker.com/_/debian) and the current `BASE_IMAGE` is `debian:12-slim` (codename `bookworm`). To keep the image size of the generated Cypress Docker images to a minimum, choose the `slim` variant when other versions of Debian are used, for instance when [Debian releases](https://www.debian.org/releases/) a new major version.
+The `BASE_IMAGE` defined in [factory/.env](./factory/.env) uses a [Debian Docker image](https://hub.docker.com/_/debian). To keep the image size of the generated Cypress Docker images to a minimum, choose the `slim` variant when other versions of Debian are used, for instance when [Debian releases](https://www.debian.org/releases/) a new major version.
 
 To see the size of an image, you can use the command [`docker images`](https://docs.docker.com/engine/reference/commandline/images/), for instance with:
 
@@ -130,7 +130,7 @@ To see the size of an image, you can use the command [`docker images`](https://d
 docker images --format "table {{.Repository}} {{.Tag}} {{.Size}}"
 ```
 
-A snapshot of current sizes shows:
+A snapshot of sizes shows:
 
 | REPOSITORY       | TAG                                                               | SIZE   |
 | ---------------- | ----------------------------------------------------------------- | ------ |

--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ We build four images: click on the image name to see the available tags with ver
 
 ## Platforms
 
-Cypress Docker images are Linux based, using the Docker image [debian:12-slim](https://hub.docker.com/_/debian) as the default base image. Each of the above listed Cypress Docker images is published with [multi-architecture](https://docs.docker.com/contribute/style/terminology/#multi-architecture--multi-arch) support for `Linux/amd64` and `Linux/arm64` platforms.
+Cypress Docker images are Linux based, using the Docker image [debian:13-slim](https://hub.docker.com/_/debian) as the default base image. Each of the above listed Cypress Docker images is published with [multi-architecture](https://docs.docker.com/contribute/style/terminology/#multi-architecture--multi-arch) support for `Linux/amd64` and `Linux/arm64` platforms.
 
 Cypress Docker images can be run as containers on Continuous Integration (CI) systems which support Docker. Cypress Docker images can also be run locally under [Docker Desktop](https://docs.docker.com/desktop/) for Mac, Linux or Windows environments.
 

--- a/factory/.env
+++ b/factory/.env
@@ -6,7 +6,7 @@
 
 # Use Debian stable release https://www.debian.org/releases/stable/
 # The Debian image cypress/factory is based on
-BASE_IMAGE='debian:12.11-slim'
+BASE_IMAGE='debian:13.0-slim'
 
 # Node Versions: https://nodejs.org/en/download/releases/
 # master branch needs "Active LTS" version
@@ -18,11 +18,11 @@ NODE_VERSION="${FACTORY_DEFAULT_NODE_VERSION}"
 
 # Update the FACTORY_VERSION to deploy cypress/factory if you make changes to
 # BASE_IMAGE, FACTORY_DEFAULT_NODE_VERSION, YARN_VERSION, factory.Dockerfile or installScripts
-FACTORY_VERSION='5.12.1'
+FACTORY_VERSION='6.0.0'
 
 # Chrome versions: https://www.ubuntuupdates.org/package/google_chrome/stable/main/base/google-chrome-stable
 # Linux/amd64 only
-CHROME_VERSION='139.0.7258.66-1'
+CHROME_VERSION='139.0.7258.127-1'
 
 # Chrome for Testing versions: https://googlechromelabs.github.io/chrome-for-testing/
 # not currently used for cypress/browsers and cypress/included images
@@ -34,7 +34,7 @@ CYPRESS_VERSION='14.5.4'
 
 # Edge versions: https://packages.microsoft.com/repos/edge/pool/main/m/microsoft-edge-stable/
 # Linux/amd64 only
-EDGE_VERSION='138.0.3351.121-1'
+EDGE_VERSION='139.0.3405.86-1'
 
 # Firefox versions: https://download-installer.cdn.mozilla.net/pub/firefox/releases/
 # Linux/amd64 for all versions, Linux/arm64 for versions 136.0 and above

--- a/factory/CHANGELOG.md
+++ b/factory/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Change log
 
+## 6.0.0
+
+- Updated Debian base image from `debian:12.11-slim` to `debian:13.0-slim` using [Debian 13.0 (trixie)](https://www.debian.org/releases/trixie/). Addressed in [#1396](https://github.com/cypress-io/cypress-docker-images/pull/1396).
+
 ## 5.12.1
 
 - Updated default node version from `22.17.1` to `22.18.0`. Addressed in [#1394](https://github.com/cypress-io/cypress-docker-images/pull/1394).
@@ -11,6 +15,7 @@
 ## 5.11.6
 
 - Failed installs of Cypress no longer get cached as a docker layer. Addressed in [#1390](https://github.com/cypress-io/cypress-docker-images/pull/1390).
+
 
 ## 5.11.5
 

--- a/factory/CHANGELOG.md
+++ b/factory/CHANGELOG.md
@@ -16,7 +16,6 @@
 
 - Failed installs of Cypress no longer get cached as a docker layer. Addressed in [#1390](https://github.com/cypress-io/cypress-docker-images/pull/1390).
 
-
 ## 5.11.5
 
 - When importing PGP keys for Node.js, allow individual key imports to fail. Log an error and continue to build. Resolves an issue when there is a network connectivity problem to the fallback keyserver keyserver.ubuntu.com. Addressed in [#1385](https://github.com/cypress-io/cypress-docker-images/issues/1385).

--- a/factory/factory.Dockerfile
+++ b/factory/factory.Dockerfile
@@ -1,7 +1,7 @@
 # BASE_IMAGE is expected to be overridden
 # Regular builds, using docker compose, take the value from
 # the .env file in the same directory as this file
-ARG BASE_IMAGE='debian:12-slim'
+ARG BASE_IMAGE='debian:13-slim'
 
 FROM ${BASE_IMAGE} AS factory
 


### PR DESCRIPTION
- Closes https://github.com/cypress-io/cypress-docker-images/issues/1387

## Situation

Cypress Docker images built from [factory/.env](https://github.com/cypress-io/cypress-docker-images/blob/master/factory/.env) currently use `BASE_IMAGE='debian:12.11-slim'`. [Debian 13.0 (trixie)](https://www.debian.org/releases/trixie/), which was [released](https://www.debian.org/News/2025/20250809) on Aug 9, 2025, supersedes [Debian 12.x (bookworm)](https://www.debian.org/releases/bookworm/).

Corresponding Debian Docker images were made available on Aug 13, 2025.

## Change

Update the base image for `cypress/factory` to use [Debian 13.0 (trixie)](https://www.debian.org/releases/trixie/).

In detail, the environment variables in [factory/.env](https://github.com/cypress-io/cypress-docker-images/blob/master/factory/.env) that control the default build process, are updated as follows:

| Environment variable           | Before             | After              |
| ------------------------------ | ------------------ | ------------------ |
| `BASE_IMAGE`                   | `debian:12.11-slim` | `debian:13.0-slim` |
| `FACTORY_VERSION`              | `5.12.1`           | `6.0.0`            |
| `FACTORY_DEFAULT_NODE_VERSION` | `22.18.0`          | no change          |
| `CHROME_VERSION`               | `139.0.7258.66-1`  | `139.0.7258.127-1` |
| `CHROME_FOR_TESTING_VERSION`   | `139.0.7258.66`    | no change          |
| `EDGE_VERSION`                 | `138.0.3351.121-1` | `139.0.3405.86-1`  |
| `FIREFOX_VERSION`              | `141.0.3`          | no change          |

## Debian library names (t64)

Debian library package names in the installation scripts are not updated to their `t64` equivalents. Debian 13 automatically translates old library package names to new package names, for instance

```text
# apt-get install libglib2.0-0
Reading package lists... Done
Building dependency tree... Done
Reading state information... Done
Note, selecting 'libglib2.0-0t64' instead of 'libglib2.0-0'
```

Keeping the old names means that [factory/factory.Dockerfile](https://github.com/cypress-io/cypress-docker-images/blob/master/factory/factory.Dockerfile) retains backwards compatibility with Debian 11 (bullseye) and 12 (bookworm), whilst also being usable with Debian 13 (trixie).

