### PR TITLE
test: Cypress 15 test-project preparation

### DIFF
--- a/factory/test-project/cypress/e2e/2-advanced-examples/misc.cy.js
+++ b/factory/test-project/cypress/e2e/2-advanced-examples/misc.cy.js
@@ -48,8 +48,15 @@ context('Misc', () => {
       cy.exec(`cat ${Cypress.config('configFile')}`)
         .its('stderr').should('be.empty')
 
-      cy.exec('pwd')
-        .its('code').should('eq', 0)
+      cy.log(`Cypress version ${Cypress.version}`)
+      if (Cypress.version.split('.').map(Number)[0] < 15 ) {
+        cy.exec('pwd')
+          .its('code').should('eq', 0)
+      }
+      else {
+        cy.exec('pwd')
+          .its('exitCode').should('eq', 0)
+      }
     }
   })
 


### PR DESCRIPTION
## Situation

PR https://github.com/cypress-io/cypress/pull/32238 plans to update [execa](https://www.npmjs.com/package/execa) in Cypress from [execa@1.0.0](https://github.com/sindresorhus/execa/releases/tag/v1.0.0) to [execa@4.1.0](https://github.com/sindresorhus/execa/releases/tag/v4.1.0) and for [cy.exec()](https://docs.cypress.io/api/commands/exec#Yields) to yield property `exitCode` instead of `code`.

To adapt scaffold tests to work with both Cypress 14 and 15, PR https://github.com/cypress-io/cypress-example-kitchensink/pull/984 has been proposed, which would adapt the [cypress/e2e/2-advanced-examples/misc.cy.js](https://github.com/cypress-io/cypress-example-kitchensink/blob/master/cypress/e2e/2-advanced-examples/misc.cy.js) test spec accordingly.

These changes will be needed in the corresponding scaffolded test spec [factory/test-project/cypress/e2e/2-advanced-examples/misc.cy.js](https://github.com/cypress-io/cypress-docker-images/blob/master/factory/test-project/cypress/e2e/2-advanced-examples/misc.cy.js) in this repo during the planned publication of Cypress 15.

## Change

To avoid extra work and corresponding delays on the release day of Cypress `15.0.0`. Test changes to [factory/test-project/cypress/e2e/2-advanced-examples/misc.cy.js](https://github.com/cypress-io/cypress-docker-images/blob/master/factory/test-project/cypress/e2e/2-advanced-examples/misc.cy.js) are added in preparation for Cypress 15 Docker image generation now.

In the test "'cy.exec() - execute a system command'" conditional logic is added which allows tests to be successful with Cypress 14 and below, and the planned Cypress 15 version.

## Test

This currently tests against Cypress `14.5.4`. The repo is not set up to test against beta / pre-release versions of Cypress.

```shell
cd factory
docker compose build factory
cd test-project
set -a && . ../.env && set +a
docker compose run --build --rm test-factory-all-included
```
