### PR TITLE
chore: remove test/src/.Trash-0/ from .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,5 @@
 .DS_Store
 .vscode
-test/src/.Trash-0/
 **/cypress/videos
 **/cypress/screenshots
 **/cypress/logs


### PR DESCRIPTION
## Situation

The [.gitignore](https://github.com/cypress-io/cypress-docker-images/blob/master/.gitignore) file contains an obsolete entry:

```text
test/src/.Trash-0/
```

The directory `test` was removed from the repo in PR https://github.com/cypress-io/cypress-docker-images/pull/812 that transitioned to `cypress/factory` in Jan 2023.

https://github.com/cypress-io/cypress-docker-images/tree/5f5272a44c233d5f584d05f86fd041149ad214cc from Jan 3, 2023 includes the `test` directory and then in

https://github.com/cypress-io/cypress-docker-images/tree/4b2ebca497281b6793ece39292edb16ce6eaecae from Jan 17, 2023, the directory `test` is no longer present.

## Change

Remove the obsolete reference `test/src/.Trash-0/` from the [.gitignore](https://github.com/cypress-io/cypress-docker-images/blob/master/.gitignore) file.