### PR TITLE
chore: update to Cypress `15.0.0`

### DIFF
--- a/factory/.env
+++ b/factory/.env
@@ -22,23 +22,23 @@ FACTORY_VERSION='6.0.0'
 
 # Chrome versions: https://www.ubuntuupdates.org/package/google_chrome/stable/main/base/google-chrome-stable
 # Linux/amd64 only
-CHROME_VERSION='139.0.7258.127-1'
+CHROME_VERSION='139.0.7258.138-1'
 
 # Chrome for Testing versions: https://googlechromelabs.github.io/chrome-for-testing/
 # not currently used for cypress/browsers and cypress/included images
 # Linux/amd64 only
-CHROME_FOR_TESTING_VERSION='139.0.7258.66'
+CHROME_FOR_TESTING_VERSION='139.0.7258.138'
 
 # Cypress versions: https://www.npmjs.com/package/cypress
-CYPRESS_VERSION='14.5.4'
+CYPRESS_VERSION='15.0.0'
 
 # Edge versions: https://packages.microsoft.com/repos/edge/pool/main/m/microsoft-edge-stable/
 # Linux/amd64 only
-EDGE_VERSION='139.0.3405.86-1'
+EDGE_VERSION='139.0.3405.102-1'
 
 # Firefox versions: https://download-installer.cdn.mozilla.net/pub/firefox/releases/
 # Linux/amd64 for all versions, Linux/arm64 for versions 136.0 and above
-FIREFOX_VERSION='141.0.3'
+FIREFOX_VERSION='142.0'
 
 # Geckodriver versions: https://github.com/mozilla/geckodriver/releases
 # Geckodriver documentation: https://firefox-source-docs.mozilla.org/testing/geckodriver/index.html


### PR DESCRIPTION
updates factory to Cypress 15 and updates browsers