### PR TITLE
fix: use microsoft-edge.list for Edge installation

### DIFF
--- a/factory/.env
+++ b/factory/.env
@@ -34,7 +34,7 @@ CYPRESS_VERSION='15.1.0'
 
 # Edge versions: https://packages.microsoft.com/repos/edge/pool/main/m/microsoft-edge-stable/
 # Linux/amd64 only
-EDGE_VERSION='139.0.3405.125-1'
+EDGE_VERSION='140.0.3485.54-1'
 
 # Firefox versions: https://download-installer.cdn.mozilla.net/pub/firefox/releases/
 # Linux/amd64 for all versions, Linux/arm64 for versions 136.0 and above

--- a/factory/.env
+++ b/factory/.env
@@ -18,7 +18,7 @@ NODE_VERSION="${FACTORY_DEFAULT_NODE_VERSION}"
 
 # Update the FACTORY_VERSION to deploy cypress/factory if you make changes to
 # BASE_IMAGE, FACTORY_DEFAULT_NODE_VERSION, YARN_VERSION, factory.Dockerfile or installScripts
-FACTORY_VERSION='6.0.1'
+FACTORY_VERSION='6.0.2'
 
 # Chrome versions: https://www.ubuntuupdates.org/package/google_chrome/stable/main/base/google-chrome-stable
 # Linux/amd64 only

--- a/factory/.env
+++ b/factory/.env
@@ -22,12 +22,12 @@ FACTORY_VERSION='6.0.2'
 
 # Chrome versions: https://www.ubuntuupdates.org/package/google_chrome/stable/main/base/google-chrome-stable
 # Linux/amd64 only
-CHROME_VERSION='139.0.7258.154-1'
+CHROME_VERSION='140.0.7339.80-1'
 
 # Chrome for Testing versions: https://googlechromelabs.github.io/chrome-for-testing/
 # not currently used for cypress/browsers and cypress/included images
 # Linux/amd64 only
-CHROME_FOR_TESTING_VERSION='139.0.7258.154'
+CHROME_FOR_TESTING_VERSION='140.0.7339.80'
 
 # Cypress versions: https://www.npmjs.com/package/cypress
 CYPRESS_VERSION='15.1.0'

--- a/factory/CHANGELOG.md
+++ b/factory/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Change log
 
+## 6.0.2
+
+- When installing Microsoft Edge, use only `/etc/apt/sources.list.d/microsoft-edge.list` to resolve a multiple configuration warning from Debian package management. Addresses [#1404](https://github.com/cypress-io/cypress-docker-images/issues/1404).
+
 ## 6.0.1
 
 - Updated `FACTORY_DEFAULT_NODE_VERSION` from `22.18.0` to `22.19.0`. Addressed in [#1408](https://github.com/cypress-io/cypress-docker-images/pull/1408).

--- a/factory/installScripts/edge/default.sh
+++ b/factory/installScripts/edge/default.sh
@@ -3,7 +3,7 @@
 # Microsoft offers a debian package, here we're adding the package list and then installing the specific version we want to install.
 curl https://packages.microsoft.com/keys/microsoft.asc | gpg --dearmor > microsoft.gpg \
   && install -o root -g root -m 644 microsoft.gpg /etc/apt/trusted.gpg.d \
-  && sh -c 'echo "deb [arch=amd64] https://packages.microsoft.com/repos/edge stable main" > /etc/apt/sources.list.d/microsoft-edge-stable.list' \
+  && sh -c 'echo "deb [arch=amd64] https://packages.microsoft.com/repos/edge stable main" > /etc/apt/sources.list.d/microsoft-edge.list' \
   && rm microsoft.gpg \
   && apt-get update \
   && apt-get install -y microsoft-edge-stable=${1} \


### PR DESCRIPTION
- closes https://github.com/cypress-io/cypress-docker-images/issues/1404
- supersedes and closes https://github.com/cypress-io/cypress-docker-images/pull/1405

## Situation

Installing Microsoft Edge through the `cypress/factory` process using the script [factory/installScripts/edge/default.sh](https://github.com/cypress-io/cypress-docker-images/blob/master/factory/installScripts/edge/default.sh) causes two entries to be placed into `/etc/apt/sources.list.d`

- `microsoft-edge-stable.list`

    The filename `/etc/apt/sources.list.d/microsoft-edge-stable.list` is explicitly generated by the Cypress Edge installation script [factory/installScripts/edge/default.sh](https://github.com/cypress-io/cypress-docker-images/blob/master/factory/installScripts/edge/default.sh) and the installation process causes it to be populated with:

    ```text
    deb [arch=amd64] https://packages.microsoft.com/repos/edge stable main
    ```

- `microsoft-edge.list`

    The filename `/etc/apt/sources.list.d/microsoft-edge.list` and contents are generated by the `postinstall` script of the Debian Edge package:

    ```text
    ### THIS FILE IS AUTOMATICALLY CONFIGURED ###
    # You may comment out this entry, but any other modifications may be lost.
    deb [arch=amd64] https://packages.microsoft.com/repos/edge/ stable main
    ```

Since the non-commented contents of the two files are identical, executing `apt-get update` causes a warning:

```
W: Target Packages (main/binary-amd64/Packages) is configured multiple times in /etc/apt/sources.list.d/microsoft-edge-stable.list:1 and /etc/apt/sources.list.d/microsoft-edge.list:3
W: Target Packages (main/binary-all/Packages) is configured multiple times in /etc/apt/sources.list.d/microsoft-edge-stable.list:1 and /etc/apt/sources.list.d/microsoft-edge.list:3
W: Target Packages (main/binary-amd64/Packages) is configured multiple times in /etc/apt/sources.list.d/microsoft-edge-stable.list:1 and /etc/apt/sources.list.d/microsoft-edge.list:3
W: Target Packages (main/binary-all/Packages) is configured multiple times in /etc/apt/sources.list.d/microsoft-edge-stable.list:1 and /etc/apt/sources.list.d/microsoft-edge.list:3
```

## Change

Modify [factory/installScripts/edge/default.sh](https://github.com/cypress-io/cypress-docker-images/blob/master/factory/installScripts/edge/default.sh) to use only the filename `microsoft-edge.list`. This allows the Debian Edge package to update the file instead of creating a new one in its `postinstall` phase and remediates the warning concerning multiple configurations.

In [factory/.env](https://github.com/cypress-io/cypress-docker-images/blob/master/factory/.env) make the following updates:

| Environment variable           | Before             | After             |
| ------------------------------ | ------------------ | ----------------- |
| `FACTORY_VERSION`              | `6.0.1`            | `6.0.2`           |
| `FACTORY_DEFAULT_NODE_VERSION` | `22.19.0`          | no change         |
| `CHROME_VERSION`               | `139.0.7258.154-1` | `140.0.7339.80-1` |
| `CHROME_FOR_TESTING_VERSION`   | `139.0.7258.154`   | `140.0.7339.80`   |
| `EDGE_VERSION`                 | `139.0.3405.125-1` | `140.0.3485.54-1` |
| `FIREFOX_VERSION`              | `142.0.1`          | no change         |

## Verification

```shell
cd factory
docker compose build factory --no-cache
docker compose build edge --no-cache
cd test-project
set -a && . ../.env && set +a
docker compose run --build --rm test-factory-all-included
```

```shell
docker run -it --rm cypress/edge
```

```shell
apt-get update # check no warnings
apt-get upgrade microsoft-edge-stable # if offered, confirm that microsoft-edge-stable upgrade is successful
microsoft-edge --version
```

## Reference

- [Debian package management](https://www.debian.org/doc/manuals/debian-reference/ch02.en.html)
