### PR TITLE
chore: publish base-internal with node 22.18.0

### DIFF
--- a/base-internal/releases/node-22/22.18.0-bullseye/Dockerfile
+++ b/base-internal/releases/node-22/22.18.0-bullseye/Dockerfile
@@ -1,0 +1,94 @@
+# build it with command
+#   docker build -t cypress/base-internal:22.18.0-bullseye --platform linux/amd64 .
+#
+FROM node:22.18.0-bullseye-slim
+
+RUN apt-get update && \
+  apt-get install --no-install-recommends -y \
+  libgtk2.0-0 \
+  libgtk-3-0 \
+  libnotify-dev \
+  libgconf-2-4 \
+  libgbm-dev \
+  libnss3 \
+  libxss1 \
+  libasound2 \
+  libxtst6 \
+  procps \
+  xauth \
+  xvfb \
+  build-essential \
+  # install text editors
+  vim-tiny \
+  nano \
+  # install emoji font
+  fonts-noto-color-emoji \
+  # install Chinese fonts
+  # this list was copied from https://github.com/jim3ma/docker-leanote
+  fonts-arphic-bkai00mp \
+  fonts-arphic-bsmi00lp \
+  fonts-arphic-gbsn00lp \
+  fonts-arphic-gkai00mp \
+  fonts-arphic-ukai \
+  fonts-arphic-uming \
+  ttf-wqy-zenhei \
+  ttf-wqy-microhei \
+  xfonts-wqy \
+  # clean up
+  && rm -rf /var/lib/apt/lists/* \
+  && apt-get clean
+
+USER root
+
+RUN node --version
+
+# Install dependencies
+RUN apt-get update && \
+  apt-get install -y \
+  fonts-liberation \
+  git \
+  libcurl4 \
+  libcurl3-gnutls \
+  libcurl3-nss \
+  libvulkan1 \
+  xdg-utils \
+  wget \
+  # needed for circle orb browsers to install firefox
+  gpg \
+  # needed for circle orb browsers to install chromedriver
+  jq \
+  curl \
+  # chrome dependencies
+  libu2f-udev \
+  # firefox dependencies
+  bzip2 \
+  # add codecs needed for video playback in firefox
+  # https://github.com/cypress-io/cypress-docker-images/issues/150
+  mplayer \
+  \
+  # clean up
+  && rm -rf /var/lib/apt/lists/* \
+  && apt-get clean
+
+# install libappindicator3-1 - not included with Debian 11
+RUN wget --no-verbose /usr/src/libappindicator3-1_0.4.92-7_amd64.deb "http://ftp.us.debian.org/debian/pool/main/liba/libappindicator/libappindicator3-1_0.4.92-7_amd64.deb" && \
+  dpkg -i /usr/src/libappindicator3-1_0.4.92-7_amd64.deb ; \
+  apt-get install -f -y && \
+  rm -f /usr/src/libappindicator3-1_0.4.92-7_amd64.deb
+
+# a few environment variables to make NPM installs easier
+# good colors for most applications
+ENV TERM=xterm
+# avoid million NPM install messages
+ENV npm_config_loglevel=warn
+
+RUN npm --version \
+  && npm install -g yarn@latest --force \
+  && yarn --version \
+  && node -p process.versions \
+  && node -p 'module.paths' \
+  && echo  " node version:    $(node -v) \n" \
+    "npm version:     $(npm -v) \n" \
+    "yarn version:    $(yarn -v) \n" \
+    "debian version:  $(cat /etc/debian_version) \n" \
+    "user:            $(whoami) \n" 

--- a/base-internal/releases/node-22/22.18.0-bullseye/README.md
+++ b/base-internal/releases/node-22/22.18.0-bullseye/README.md
@@ -1,0 +1,14 @@
+# cypress/base-internal:22.18.0-bullseye
+
+A Docker image with all dependencies pre-installed.
+
+NOTE: This image is intended for internal use with https://github.com/cypress-io/cypress. It contains a few differences from the factory, such as:
+
+#### Dependency Additions
+
+- xauth (to run xvfb inside system-tests)
+- build-essential to install `make` and other linux build packages
+
+#### Env variables
+
+- Does not contain the `CACHE_FOLDER` and `FACTORY_DEFAULT_NODE_VERSION` env variables to keep unit tests non environment specific

--- a/base-internal/releases/node-22/22.18.0-bullseye/build.sh
+++ b/base-internal/releases/node-22/22.18.0-bullseye/build.sh
@@ -1,0 +1,8 @@
+#!/bin/bash
+set e+x
+
+# build image with Cypress dependencies
+LOCAL_NAME=cypress/base-internal:22.18.0-bullseye
+
+echo "Building $LOCAL_NAME"
+docker build -t $LOCAL_NAME . --platform linux/amd64

--- a/base-internal/releases/node-22/22.18.0-glibc-2.31/Dockerfile
+++ b/base-internal/releases/node-22/22.18.0-glibc-2.31/Dockerfile
@@ -1,0 +1,26 @@
+# build it with command
+#   docker build -t cypress/base-internal:22.18.0-glibc-2.31 --platform linux/amd64 .
+#
+FROM cypress/base-internal:22.18.0-bullseye
+
+RUN apt-get update && \
+  apt-get install -y \
+  wget \
+  xz-utils \
+  bzip2 \
+  make \
+  autoconf \
+  gcc-multilib \
+  g++-multilib \
+  # clean up
+  && rm -rf /var/lib/apt/lists/* \
+  && apt-get clean
+
+  # # Install Python 3.8
+  # # Bullseye comes with 3.9, so we need to downgrade
+RUN wget https://www.python.org/ftp/python/3.8.0/Python-3.8.0.tgz
+RUN tar xvf Python-3.8.0.tgz
+RUN cd Python-3.8.0 && ./configure --enable-optimizations --prefix=/usr && make altinstall
+RUN rm /usr/bin/python3 && ln -s /usr/bin/python3.8 /usr/bin/python3
+  # # Clean up
+RUN rm -rf Python-3.8.0 Python-3.8.0.tgz

--- a/base-internal/releases/node-22/22.18.0-glibc-2.31/README.md
+++ b/base-internal/releases/node-22/22.18.0-glibc-2.31/README.md
@@ -1,0 +1,20 @@
+# cypress/base-internal:22.18.0-bullseye-glibc2.31
+
+A Docker image with all dependencies pre-installed. This image is labeled separately from the other bullseye images, because it is used in a specific step in the Cypress CI process. As a part of the build process, Cypress' CI builds an optimized version of `better-sqlite3`'s addon. The range of operating systems this addon can be used in is determined by the glibc version of the system that builds it.
+
+This image is labeled according the the glibc version so that the Cypress CI pipeline is more self-documenting when it comes to the minimum glibc version required to run Cypress.
+
+It may require additional dependencies for this build process; for example, in Buster, we needed
+to upgrade both Python and GCC. In Bullseye, we need to downgrade Python.
+
+NOTE: This image is intended for internal use with https://github.com/cypress-io/cypress. It contains a few differences from the factory, such as:
+
+#### Dependency Additions
+
+- xauth (to run xvfb inside system-tests)
+- build-essential to install `make` and other linux build packages
+- python3.8 to be able to build better-sqlite3
+
+#### Env variables
+
+- Does not contain the `CACHE_FOLDER` and `FACTORY_DEFAULT_NODE_VERSION` env variables to keep unit tests non environment specific

--- a/base-internal/releases/node-22/22.18.0-glibc-2.31/build.sh
+++ b/base-internal/releases/node-22/22.18.0-glibc-2.31/build.sh
@@ -1,0 +1,7 @@
+set e+x
+
+# build image with Cypress dependencies
+LOCAL_NAME=cypress/base-internal:22.18.0-bullseye-glibc-2.31
+
+echo "Building $LOCAL_NAME"
+docker build -t $LOCAL_NAME . --platform linux/amd64

--- a/base-internal/releases/node-22/22.18.0-yarn-berry/Dockerfile
+++ b/base-internal/releases/node-22/22.18.0-yarn-berry/Dockerfile
@@ -1,0 +1,68 @@
+# build it with command
+#   docker build -t cypress/base-internal:22.18.0-yarn-berry --platform linux/amd64 .
+#
+FROM node:22.18.0-bookworm-slim
+
+RUN apt-get update && \
+  apt-get install --no-install-recommends -y \
+  libgtk2.0-0 \
+  libgtk-3-0 \
+  libnotify-dev \
+  libgconf-2-4 \
+  libgbm-dev \
+  libnss3 \
+  libxss1 \
+  libasound2 \
+  libxtst6 \
+  procps \
+  xauth \
+  xvfb \
+  build-essential \
+  # install text editors
+  vim-tiny \
+  nano \
+  wget \
+  curl \
+  git \
+  # install emoji font
+  fonts-noto-color-emoji \
+  # install Chinese fonts
+  # this list was copied from https://github.com/jim3ma/docker-leanote
+  fonts-arphic-bkai00mp \
+  fonts-arphic-bsmi00lp \
+  fonts-arphic-gbsn00lp \
+  fonts-arphic-gkai00mp \
+  fonts-arphic-ukai \
+  fonts-arphic-uming \
+  ttf-wqy-zenhei \
+  ttf-wqy-microhei \
+  xfonts-wqy \
+  # clean up
+  && rm -rf /var/lib/apt/lists/* \
+  && apt-get clean
+
+RUN apt-get update && \
+  apt-get install --no-install-recommends -y \
+  ca-certificates
+
+# a few environment variables to make NPM installs easier
+# good colors for most applications
+ENV TERM=xterm
+# avoid million NPM install messages
+ENV npm_config_loglevel=warn
+# allow installing when the main user is root
+ENV npm_config_unsafe_perm=true
+# need to enable corepack to set yarn version
+RUN corepack enable
+# set the yarn version to 4 to get yarn berry, which does not install modules into node_modules
+RUN yarn set version 4.3.1
+
+RUN npm --version \
+  && yarn --version \
+  && node -p process.versions \
+  && node -p 'module.paths' \
+  && echo  " node version:    $(node -v) \n" \
+    "npm version:     $(npm -v) \n" \
+    "yarn version:    $(yarn -v) \n" \
+    "debian version:  $(cat /etc/debian_version) \n" \
+    "user:            $(whoami) \n" 

--- a/base-internal/releases/node-22/22.18.0-yarn-berry/README.md
+++ b/base-internal/releases/node-22/22.18.0-yarn-berry/README.md
@@ -1,0 +1,15 @@
+# cypress/base-internal:22.18.0-yarn-berry
+
+A Docker image with all dependencies pre-installed, based on Debian Bookworm.
+
+NOTE: This image is intended for internal use with https://github.com/cypress-io/cypress. It contains a few differences from the factory, such as:
+
+#### Dependency Additions
+
+- xauth (to run xvfb inside system-tests)
+- build-essential to install `make` and other linux build packages
+- has yarn 4 to test yarn PnP dependencies with Cypress in order to verify the `@cypress/webpack-batteries-included-preprocessor` works with yarn PnP (without `node_modules`)
+
+#### Env variables
+
+- Does not contain the `CACHE_FOLDER` and `FACTORY_DEFAULT_NODE_VERSION` env variables to keep unit tests non environment specific

--- a/base-internal/releases/node-22/22.18.0-yarn-berry/build.sh
+++ b/base-internal/releases/node-22/22.18.0-yarn-berry/build.sh
@@ -1,0 +1,8 @@
+#!/bin/bash
+set e+x
+
+# build image with Cypress dependencies
+LOCAL_NAME=cypress/base-internal:22.18.0-yarn-berry
+
+echo "Building $LOCAL_NAME"
+docker build -t $LOCAL_NAME . --platform linux/amd64

--- a/base-internal/releases/node-22/22.18.0/Dockerfile
+++ b/base-internal/releases/node-22/22.18.0/Dockerfile
@@ -1,0 +1,56 @@
+# build it with command
+#   docker build -t cypress/base-internal:22.18.0 --platform linux/amd64 .
+#
+FROM node:22.18.0-bookworm-slim
+
+RUN apt-get update && \
+  apt-get install --no-install-recommends -y \
+  libgtk2.0-0 \
+  libgtk-3-0 \
+  libnotify-dev \
+  libgconf-2-4 \
+  libgbm-dev \
+  libnss3 \
+  libxss1 \
+  libasound2 \
+  libxtst6 \
+  procps \
+  xauth \
+  xvfb \
+  build-essential \
+  # install text editors
+  vim-tiny \
+  nano \
+  # install emoji font
+  fonts-noto-color-emoji \
+  # install Chinese fonts
+  # this list was copied from https://github.com/jim3ma/docker-leanote
+  fonts-arphic-bkai00mp \
+  fonts-arphic-bsmi00lp \
+  fonts-arphic-gbsn00lp \
+  fonts-arphic-gkai00mp \
+  fonts-arphic-ukai \
+  fonts-arphic-uming \
+  ttf-wqy-zenhei \
+  ttf-wqy-microhei \
+  xfonts-wqy \
+  # clean up
+  && rm -rf /var/lib/apt/lists/* \
+  && apt-get clean
+
+# a few environment variables to make NPM installs easier
+# good colors for most applications
+ENV TERM=xterm
+# avoid million NPM install messages
+ENV npm_config_loglevel=warn
+
+RUN npm --version \
+  && npm install -g yarn@latest --force \
+  && yarn --version \
+  && node -p process.versions \
+  && node -p 'module.paths' \
+  && echo  " node version:    $(node -v) \n" \
+    "npm version:     $(npm -v) \n" \
+    "yarn version:    $(yarn -v) \n" \
+    "debian version:  $(cat /etc/debian_version) \n" \
+    "user:            $(whoami) \n" 

--- a/base-internal/releases/node-22/22.18.0/README.md
+++ b/base-internal/releases/node-22/22.18.0/README.md
@@ -1,0 +1,14 @@
+# cypress/base-internal:22.18.0
+
+A Docker image with all dependencies pre-installed based on Debian Bookworm.
+
+NOTE: This image is intended for internal use with https://github.com/cypress-io/cypress. It contains a few differences from the factory, such as:
+
+#### Dependency Additions
+
+- xauth (to run xvfb inside system-tests)
+- build-essential to install `make` and other linux build packages
+
+#### Env variables
+
+- Does not contain the `CACHE_FOLDER` and `FACTORY_DEFAULT_NODE_VERSION` env variables to keep unit tests non environment specific

--- a/base-internal/releases/node-22/22.18.0/build.sh
+++ b/base-internal/releases/node-22/22.18.0/build.sh
@@ -1,0 +1,9 @@
+#!/bin/bash
+
+set -e+x
+
+# build image with Cypress dependencies
+LOCAL_NAME=cypress/base-internal:22.18.0
+
+echo "Building $LOCAL_NAME"
+docker build -t $LOCAL_NAME . --platform linux/amd64


### PR DESCRIPTION
For https://github.com/cypress-io/cypress/pull/32371

Mostly following this pattern: https://github.com/cypress-io/cypress-docker-images/pull/1379/files