### PR TITLE
fix(deps): update to Node.js 22.19.0

### DIFF
--- a/factory/.env
+++ b/factory/.env
@@ -11,34 +11,34 @@ BASE_IMAGE='debian:13.0-slim'
 # Node Versions: https://nodejs.org/en/download/releases/
 # master branch needs "Active LTS" version
 # use feature branch for "Maintenance LTS" or "Current" versions
-FACTORY_DEFAULT_NODE_VERSION='22.18.0'
+FACTORY_DEFAULT_NODE_VERSION='22.19.0'
 
 # Node Versions: https://nodejs.org/en/download/releases/
 NODE_VERSION="${FACTORY_DEFAULT_NODE_VERSION}"
 
 # Update the FACTORY_VERSION to deploy cypress/factory if you make changes to
 # BASE_IMAGE, FACTORY_DEFAULT_NODE_VERSION, YARN_VERSION, factory.Dockerfile or installScripts
-FACTORY_VERSION='6.0.0'
+FACTORY_VERSION='6.0.1'
 
 # Chrome versions: https://www.ubuntuupdates.org/package/google_chrome/stable/main/base/google-chrome-stable
 # Linux/amd64 only
-CHROME_VERSION='139.0.7258.138-1'
+CHROME_VERSION='139.0.7258.154-1'
 
 # Chrome for Testing versions: https://googlechromelabs.github.io/chrome-for-testing/
 # not currently used for cypress/browsers and cypress/included images
 # Linux/amd64 only
-CHROME_FOR_TESTING_VERSION='139.0.7258.138'
+CHROME_FOR_TESTING_VERSION='139.0.7258.154'
 
 # Cypress versions: https://www.npmjs.com/package/cypress
 CYPRESS_VERSION='15.0.0'
 
 # Edge versions: https://packages.microsoft.com/repos/edge/pool/main/m/microsoft-edge-stable/
 # Linux/amd64 only
-EDGE_VERSION='139.0.3405.102-1'
+EDGE_VERSION='139.0.3405.125-1'
 
 # Firefox versions: https://download-installer.cdn.mozilla.net/pub/firefox/releases/
 # Linux/amd64 for all versions, Linux/arm64 for versions 136.0 and above
-FIREFOX_VERSION='142.0'
+FIREFOX_VERSION='142.0.1'
 
 # Geckodriver versions: https://github.com/mozilla/geckodriver/releases
 # Geckodriver documentation: https://firefox-source-docs.mozilla.org/testing/geckodriver/index.html

--- a/factory/CHANGELOG.md
+++ b/factory/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Change log
 
+## 6.0.1
+
+- Updated `FACTORY_DEFAULT_NODE_VERSION` from `22.18.0` to `22.19.0`. Addressed in [#1408](https://github.com/cypress-io/cypress-docker-images/pull/1408).
+
 ## 6.0.0
 
 - Updated Debian base image from `debian:12.11-slim` to `debian:13.0-slim` using [Debian 13.0 (trixie)](https://www.debian.org/releases/trixie/). Addressed in [#1396](https://github.com/cypress-io/cypress-docker-images/pull/1396).


### PR DESCRIPTION
## Situation

- Node.js released an update [Node.js v22.19.0 LTS](https://nodejs.org/en/blog/release/v22.19.0) on Aug 28, 2025.

## Change

In [factory/.env](https://github.com/cypress-io/cypress-docker-images/blob/master/factory/.env) make the following updates:

| Environment variable           | Before             | After              |
| ------------------------------ | ------------------ | ------------------ |
| `FACTORY_VERSION`              | `6.0.0`            | `6.0.1`            |
| `FACTORY_DEFAULT_NODE_VERSION` | `22.18.0`          | `22.19.0`          |
| `CHROME_VERSION`               | `139.0.7258.138-1` | `139.0.7258.154-1` |
| `CHROME_FOR_TESTING_VERSION`   | `139.0.7258.138`   | `139.0.7258.154`   |
| `EDGE_VERSION`                 | `139.0.3405.102-1` | `139.0.3405.125-1` |
| `FIREFOX_VERSION`              | `142.0`            | `142.0.1`          |
