### PR TITLE
test: update test-project to cypress 15.0.0

### DIFF
--- a/factory/test-project/cypress/e2e/2-advanced-examples/misc.cy.js
+++ b/factory/test-project/cypress/e2e/2-advanced-examples/misc.cy.js
@@ -49,7 +49,7 @@ context('Misc', () => {
         .its('stderr').should('be.empty')
 
       cy.log(`Cypress version ${Cypress.version}`)
-      if (Cypress.version.split('.').map(Number)[0] < 15 ) {
+      if (Cypress.version.split('.').map(Number)[0] < 15) {
         cy.exec('pwd')
           .its('code').should('eq', 0)
       }


### PR DESCRIPTION
## Situation

- PR https://github.com/cypress-io/cypress-docker-images/pull/1397 manually prepared the [factory/test-project](https://github.com/cypress-io/cypress-docker-images/tree/master/factory/test-project) for Cypress `15.0.0`

## Change

The [factory/test-project](https://github.com/cypress-io/cypress-docker-images/tree/master/factory/test-project) is aligned with scaffolded tests from Cypress 15.0.0, following the instructions in the [factory/test-project/README.MD](https://github.com/cypress-io/cypress-docker-images/blob/master/factory/test-project/README.MD) document.

This makes only a minor white-space linting change.