### PR TITLE
docs: update example versions

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -77,7 +77,7 @@ Once the PR is merged into the `master` branch, the corresponding images will be
 
 If you need to release alternate versions that do not qualify to be primary versions, do not modify the contents of the [factory/.env](./factory/.env) file in the `master` branch. An example would be to publish images including updated [Node.js releases](https://nodejs.org/en/about/previous-releases) in the category "Maintenance LTS" or "Current". Instead, carry out the following steps:
 
-1. Create a feature branch in the form `<cypress-version>-node-<node.js version>-publish`, for example `13.11.0-node-18.20.3-publish`, branched from the `master` branch. If you are not a member of the Cypress org, make a request via a new issue to create a feature branch.
+1. Create a feature branch in the form `<cypress-version>-node-<node.js version>-publish`, for example `15.1.0-node-20.19.4-publish`, branched from the `master` branch. If you are not a member of the Cypress org, make a request via a new issue to create a feature branch.
 2. Modify [factory/.env](./factory/.env) with the desired versions. Do not modify the `FACTORY_VERSION`. No new `cypress/factory` image should be published with this process.
 3. Modify [factory/docker-compose.yml](./factory/docker-compose.yml) to comment out the creation of `latest` tags. Comment out the `cypress/included` `INCLUDED_IMAGE_SHORT_TAG` to also prevent this tag from being created. This step is essential to avoid the related tags of any existing released images being moved to point to non-primary images.
 4. Modify [circle.yml](circle.yml) to push releases from the feature branch.

--- a/README.md
+++ b/README.md
@@ -93,17 +93,17 @@ For each of the `REPOSITORY` image types, see the `Tags` section of each `README
 
 | Image Type README                                    | Example Tag |
 | ---------------------------------------------------- | ----------- |
-| [cypress/factory README](./factory/README.md#tags)   | `5.1.0`     |
-| [cypress/base README](./base/README.md#tags)         | `22.11.0`   |
-| [cypress/browsers README](./browsers/README.md#tags) | `22.11.0`   |
-| [cypress/included README](./included/README.md#tags) | `13.16.0`   |
+| [cypress/factory README](./factory/README.md#tags)   | `6.0.1`     |
+| [cypress/base README](./base/README.md#tags)         | `22.19.0`   |
+| [cypress/browsers README](./browsers/README.md#tags) | `22.19.0`   |
+| [cypress/included README](./included/README.md#tags) | `15.1.0`    |
 
-Images with a specific version tag for `cypress/factory` and `cypress/base` (for example: `cypress/factory:5.1.0` and `cypress/base:22.11.0`) are frozen once they have been published. The same is true for images linked to full browser version tags for `cypress/browsers` and `cypress/included` (for example: `cypress/browsers:node-22.11.0-chrome-131.0.6778.69-1-ff-132.0.2-edge-131.0.2903.51-1` and `cypress/included:cypress-13.16.0-node-22.11.0-chrome-131.0.6778.69-1-ff-132.0.2-edge-131.0.2903.51-1`).
+Images with a specific version tag for `cypress/factory` and `cypress/base` (for example: `cypress/factory:6.0.1` and `cypress/base:22.19.0`) are frozen once they have been published. The same is true for images linked to full browser version tags for `cypress/browsers` and `cypress/included` (for example: `cypress/browsers:node-22.19.0-chrome-139.0.7258.154-1-ff-142.0.1-edge-139.0.3405.125-1` and `cypress/included:cypress-15.1.0-node-22.19.0-chrome-139.0.7258.154-1-ff-142.0.1-edge-139.0.3405.125-1`).
 
 The version tags for Chrome and Edge for `Linux/arm64` images, as well as Firefox version tags below `ff-136.x`, do not carry any meaning due to browser unavailability for this platform.
 With the tag scheme used by Cypress Docker images, all tags are required to be in place to allow use of Docker's [multi-platform images](https://docs.docker.com/build/building/multi-platform/), irrespective of whether the browser is actually available or not.
 
-`cypress/browsers` and `cypress/included` images are also offered with short-form convenience tags that do not include browser version details (example: `cypress/browsers:22.11.0` and `cypress/included:13.16.0`). The tags that these images refer to can change without notice if browser updates are made.
+`cypress/browsers` and `cypress/included` images are also offered with short-form convenience tags that do not include browser version details (example: `cypress/browsers:22.19.0` and `cypress/included:15.1.0`). The tags that these images refer to can change without notice if browser updates are made.
 
 Similarly, the convenience tag `latest`, for each of the image types, changes without notice.
 

--- a/base/README.md
+++ b/base/README.md
@@ -13,7 +13,7 @@
 
 for example:
 
-- `cypress/base:20.14.0`
+- `cypress/base:22.19.0`
 - `cypress/base:latest`
 
 To avoid unplanned breaking changes, specify a fixed `<node version>` tag, not the `latest` tag.

--- a/browsers/README.md
+++ b/browsers/README.md
@@ -19,8 +19,8 @@
 
 for example:
 
-- `cypress/browsers:node-20.14.0-chrome-125.0.6422.141-1-ff-126.0.1-edge-125.0.2535.85-1`
-- `cypress/browsers:22.11.0`
+- `cypress/browsers:node-22.19.0-chrome-139.0.7258.154-1-ff-142.0.1-edge-139.0.3405.125-1`
+- `cypress/browsers:22.19.0`
 - `cypress/browsers:latest`
 
 To avoid unplanned breaking changes, specify a fixed `<node version>` & `<browser version>` combination tag.

--- a/factory/README.md
+++ b/factory/README.md
@@ -63,7 +63,7 @@ They are not currently published to the npm registry and require the experimenta
 
 The version of Cypress to install (via npm). If the `ARG` variable is unset or an empty string, Cypress is not installed.
 
-Example: `CYPRESS_VERSION='13.11.0'`
+Example: `CYPRESS_VERSION='15.1.0'`
 
 [Cypress versions](https://www.npmjs.com/package/cypress)
 
@@ -71,7 +71,7 @@ Example: `CYPRESS_VERSION='13.11.0'`
 
 The version of Google Chrome to install. If the `ARG` variable is unset or an empty string, Chrome is not installed. The exact version must be used, no wildcards or shorthands are supported.
 
-Example: `CHROME_VERSION='131.0.6778.264-1'`
+Example: `CHROME_VERSION='139.0.7258.154-1'`
 
 [Chrome versions](https://www.ubuntuupdates.org/package/google_chrome/stable/main/base/google-chrome-stable)
 
@@ -81,7 +81,7 @@ This browser is currently available only for the `Linux/amd64` platform.
 
 The version of [Google Chrome for Testing](https://developer.chrome.com/blog/chrome-for-testing/) to install. If the `ARG` variable is unset or an empty string, Chrome for Testing is not installed.
 
-Example: `CHROME_FOR_TESTING_VERSION='137.0.7151.70'`
+Example: `CHROME_FOR_TESTING_VERSION='139.0.7258.154'`
 
 Refer to [Chrome for Testing availability](https://googlechromelabs.github.io/chrome-for-testing/) for current versions or [available downloads](https://googlechromelabs.github.io/chrome-for-testing/files) for other versions.
 
@@ -91,7 +91,7 @@ The parameter `CHROME_FOR_TESTING_VERSION` can be used for custom-built images b
 
 The version of Mozilla Firefox to install. If the `ARG` variable is unset or an empty string, Firefox is not installed. The exact version must be used, no wildcards or shorthands are supported.
 
-Example: `FIREFOX_VERSION='134.0'`
+Example: `FIREFOX_VERSION='142.0.1'`
 
 [Firefox versions](https://download-installer.cdn.mozilla.net/pub/firefox/releases/)
 
@@ -109,7 +109,7 @@ Example: `GECKODRIVER_VERSION='0.36.0'`
 
 The version of Microsoft Edge to install. If the `ARG` variable is unset or an empty string, Edge is not installed. The exact version must be used, no wildcards or shorthands are supported.
 
-Example: `EDGE_VERSION='131.0.2903.112-1'`
+Example: `EDGE_VERSION='139.0.3405.125-1'`
 
 [Edge versions](https://packages.microsoft.com/repos/edge/pool/main/m/microsoft-edge-stable/)
 
@@ -165,9 +165,9 @@ Create a `Dockerfile` with the following content:
 # Args are defined in the Dockerfile before the FROM command.
 # Using these args will cause an image to be created with
 # Node.js (default version from .env file), Chrome, Firefox and Edge.
-ARG CHROME_VERSION='131.0.6778.264-1'
-ARG EDGE_VERSION='131.0.2903.112-1'
-ARG FIREFOX_VERSION='134.0'
+ARG CHROME_VERSION='139.0.7258.154-1'
+ARG EDGE_VERSION='139.0.3405.125'
+ARG FIREFOX_VERSION='142.0.1'
 
 FROM cypress/factory
 
@@ -202,7 +202,7 @@ RUN npx cypress install
 Run the Docker commands:
 
 ```bash
-docker build . --build-arg CHROME_VERSION='131.0.6778.264-1' --build-arg EDGE_VERSION='131.0.2903.112-1' --build-arg FIREFOX_VERSION='134.0' -t test
+docker build . --build-arg CHROME_VERSION='139.0.7258.154-1' --build-arg EDGE_VERSION='139.0.3405.125-1' --build-arg FIREFOX_VERSION='142.0.1' -t test
 docker run -it --rm test npx cypress run -b chrome
 ```
 
@@ -218,9 +218,9 @@ services:
     build:
       context: .
       args:
-        CHROME_VERSION: '125.0.6422.141-1'
-        EDGE_VERSION: '125.0.2535.85-1'
-        FIREFOX_VERSION: '126.0.1'
+        CHROME_VERSION: '139.0.7258.154-1'
+        EDGE_VERSION: '139.0.3405.125-1'
+        FIREFOX_VERSION: '142.0.1'
     command: npx cypress run
 ```
 
@@ -251,7 +251,7 @@ Since this example only uses Chrome, removing Edge and Firefox is as simple as n
 Create a `Dockerfile` with the following content:
 
 ```dockerfile
-ARG CHROME_VERSION='131.0.6778.264-1'
+ARG CHROME_VERSION='139.0.7258.154-1'
 
 FROM cypress/factory
 
@@ -282,8 +282,6 @@ docker build . --build-arg HTTP_PROXY=http://my-corporate-proxy.com:3128 -t test
 
 ## Version Testing
 
-Due to the large amount of possible version combinations, we're not able to exhaustively test each combination of versions, nor do we block versions that are incompatible. For example, Cypress 12 removed support for Node.js version 12.0.0. You are still able to generate a container with node 12.0.0 and Cypress 12, but Cypress will fail to run. This is because the factory supports earlier versions of Cypress and must support earlier versions of node.
+Due to the large amount of possible version combinations, we're not able to exhaustively test each combination of versions, nor do we block versions that are incompatible. For example, Cypress 12 removed support for Node.js version 12.0.0. You are still able to generate a container with Node.js 12.0.0 and Cypress 12, but Cypress will fail to run. This is because the factory supports earlier versions of Cypress and must support earlier versions of Node.js.
 
-If you run across a combination that should reasonably work, but doesn't, log an issue and we will take a look at supporting it.
-
-Additionally this docker image and containers generated from it are intended for test use only, and are not intended for hosting services in a production environment.
+Additionally, Cypress Docker images and containers generated from them are intended for test use only, and are not intended for hosting services in a production environment.

--- a/included/README.md
+++ b/included/README.md
@@ -19,8 +19,8 @@
 
 for example:
 
-- `cypress/included:cypress-13.15.1-node-22.11.0-chrome-130.0.6723.69-1-ff-132.0-edge-130.0.2849.56-1`
-- `cypress/included:13.15.1`
+- `cypress/included:cypress-15.1.0-node-22.19.0-chrome-139.0.7258.154-1-ff-142.0.1-edge-139.0.3405.125-1`
+- `cypress/included:15.1.0`
 - `cypress/included:latest`
 
 To avoid unplanned breaking changes, specify a fixed `<cypress version>`, `<node version>` & `<browser version>` combination tag.
@@ -111,7 +111,7 @@ docker run -it --rm --entrypoint cypress cypress/included info
 ```
 
 ```text
-DevTools listening on ws://127.0.0.1:36243/devtools/browser/eb85524a-6459-41d6-b855-94c10cd2b242
+DevTools listening on ws://127.0.0.1:37627/devtools/browser/0db3d002-dc65-49b3-83a9-471ea4920af4
 Displaying Cypress info...
 
 Detected 3 browsers installed:
@@ -119,41 +119,41 @@ Detected 3 browsers installed:
 1. Chrome
   - Name: chrome
   - Channel: stable
-  - Version: 130.0.6723.69
+  - Version: 139.0.7258.154
   - Executable: google-chrome
 
 2. Edge
   - Name: edge
   - Channel: stable
-  - Version: 130.0.2849.56
+  - Version: 139.0.3405.125
   - Executable: edge
 
 3. Firefox
   - Name: firefox
   - Channel: stable
-  - Version: 132.0
+  - Version: 142.0.1
   - Executable: firefox
 
 Note: to run these browsers, pass <name>:<channel> to the '--browser' field
 
 Examples:
-- cypress run --browser firefox
 - cypress run --browser chrome
+- cypress run --browser edge
 
 Learn More: https://on.cypress.io/launching-browsers
 
 Proxy Settings: none detected
 Environment Variables:
 CYPRESS_CACHE_FOLDER: /root/.cache/Cypress
-CYPRESS_FACTORY_DEFAULT_NODE_VERSION: 22.11.0
+CYPRESS_FACTORY_DEFAULT_NODE_VERSION: 22.19.0
 
 Application Data: /root/.config/cypress/cy/development
 Browser Profiles: /root/.config/cypress/cy/development/browsers
 Binary Caches: /root/.cache/Cypress
 
-Cypress Version: 13.15.1 (stable)
-System Platform: linux (Debian - 12.7)
-System Memory: 5.16 GB free 4.12 GB
+Cypress Version: 15.1.0 (stable)
+System Platform: linux (Debian - 13.0)
+System Memory: 5.16 GB free 3.79 GB
 ```
 
 ## User


### PR DESCRIPTION
## Situation

Cypress versions and browser versions used in text examples in README and CONTRIBUTING documents are outdated.

Cypress 13 references are made, where the current version is Cypress 15.

Cypress officially supports the latest 3 major versions of Chrome, Firefox, and Edge and so it is better to ensure that any examples show browser versions within the supported range. This means currently:

- Chrome 140, 139, 138
- Edge 139, 138, 137
- Firefox 142, 141, 140

## Change

Considering current releases, update versions used in documentation:

| Component                  | Current major release | Release example                                                                        |
| -------------------------- | --------------------- | -------------------------------------------------------------------------------------- |
| Cypress                    | 15                    | `15.1.0`                                                                               |
| Geckodriver                | 0                     | `0.36.0`                                                                               |
| Google Chrome              | 139                   | `139.0.7258.154`                                                                       |
| Microsoft Edge             | 139                   | `139.0.3405.125`                                                                       |
| Mozilla Firefox            | 142                   | `142.0.1`                                                                              |
| Node.js                    | 22 (Active LTS)       | `22.19.0`                                                                              |
| Node.js                    | 20 (Maintenance LTS)  | `20.19.4`                                                                              |
| `cypress/factory`          | 6                     | `6.0.1`                                                                                |
| `cypress/base`             |                       | `22.19.0`                                                                              |
| `cypress/browsers` (short) |                       | `22.19.0`                                                                              |
| `cypress/browsers` (long)  |                       | `node-22.19.0-chrome-139.0.7258.154-1-ff-142.0.1-edge-139.0.3405.125-1`                |
| `cypress/included` (short) |                       | `15.1.0`                                                                               |
| `cypress/included` (long)  |                       | `cypress-15.1.0-node-22.19.0-chrome-139.0.7258.154-1-ff-142.0.1-edge-139.0.3405.125-1` |
