### PR TITLE
fix: prevent electron from attempting dbus connections

### DIFF
--- a/factory/.env
+++ b/factory/.env
@@ -18,7 +18,7 @@ NODE_VERSION="${FACTORY_DEFAULT_NODE_VERSION}"
 
 # Update the FACTORY_VERSION to deploy cypress/factory if you make changes to
 # BASE_IMAGE, FACTORY_DEFAULT_NODE_VERSION, YARN_VERSION, factory.Dockerfile or installScripts
-FACTORY_VERSION='6.1.0'
+FACTORY_VERSION='6.1.1'
 
 # Chrome versions: https://www.ubuntuupdates.org/package/google_chrome/stable/main/base/google-chrome-stable
 # Linux/amd64 only

--- a/factory/CHANGELOG.md
+++ b/factory/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Change log
 
+## 6.1.1
+
+- Set `DBUS_SESSION_BUS_ADDRESS` to `disabled:`, which prevents Electron from attempting to connect to dbus. Addressed in
+
 ## 6.1.0
 
 - Updated Debian `BASE_IMAGE` from `debian:13.0-slim` to `debian:13.1-slim` using [Debian 13.1 (trixie)](https://www.debian.org/releases/trixie/). Addresses [#1412](https://github.com/cypress-io/cypress-docker-images/issues/1412).

--- a/factory/CHANGELOG.md
+++ b/factory/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## 6.1.1
 
-- Set `DBUS_SESSION_BUS_ADDRESS` to `disabled:`, which prevents Electron from attempting to connect to dbus. Addressed in [#1415](https://github.com/cypress-io/cypress-docker-images/pull/1415).
+- Factory now defaults to setting `DBUS_SESSION_BUS_ADDRESS` to `disabled:`, which prevents Electron from attempting to connect to dbus. Addressed in [#1415](https://github.com/cypress-io/cypress-docker-images/pull/1415).
 
 ## 6.1.0
 

--- a/factory/CHANGELOG.md
+++ b/factory/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## 6.1.1
 
-- Set `DBUS_SESSION_BUS_ADDRESS` to `disabled:`, which prevents Electron from attempting to connect to dbus. Addressed in
+- Set `DBUS_SESSION_BUS_ADDRESS` to `disabled:`, which prevents Electron from attempting to connect to dbus. Addressed in [#1415](https://github.com/cypress-io/cypress-docker-images/pull/1415).
 
 ## 6.1.0
 

--- a/factory/factory.Dockerfile
+++ b/factory/factory.Dockerfile
@@ -73,9 +73,6 @@ ARG FACTORY_DEFAULT_NODE_VERSION
 # Set the default node version to an env to allow us to access it in the onbuild step.
 ENV CYPRESS_FACTORY_DEFAULT_NODE_VERSION=${FACTORY_DEFAULT_NODE_VERSION}
 
-# Inform Electron that it will not need to connect to dbus, and should not try
-ENV DBUS_SESSION_BUS_ADDRESS='disabled:'
-
 # Install Node: Node MUST be installed, so the default lives here
 ONBUILD ARG NODE_VERSION
 
@@ -145,3 +142,6 @@ ONBUILD RUN apt-get purge -y --auto-remove \
   && rm -rf /var/lib/apt/lists/* \
   # Remove cypress install scripts
   && rm -rf /opt/installScripts
+
+# Disable dbus connections
+ONBUILD ENV DBUS_SESSION_BUS_ADDRESS='disabled:'

--- a/factory/factory.Dockerfile
+++ b/factory/factory.Dockerfile
@@ -73,6 +73,9 @@ ARG FACTORY_DEFAULT_NODE_VERSION
 # Set the default node version to an env to allow us to access it in the onbuild step.
 ENV CYPRESS_FACTORY_DEFAULT_NODE_VERSION=${FACTORY_DEFAULT_NODE_VERSION}
 
+# Inform Electron that it will not need to connect to dbus, and should not try
+ENV DBUS_SESSION_BUS_ADDRESS='disabled:'
+
 # Install Node: Node MUST be installed, so the default lives here
 ONBUILD ARG NODE_VERSION
 

--- a/factory/factory.Dockerfile
+++ b/factory/factory.Dockerfile
@@ -144,4 +144,4 @@ ONBUILD RUN apt-get purge -y --auto-remove \
   && rm -rf /opt/installScripts
 
 # Disable dbus connections
-ONBUILD ENV DBUS_SESSION_BUS_ADDRESS='disabled:'
+ONBUILD ENV DBUS_SYSTEM_BUS_ADDRESS='disabled:'


### PR DESCRIPTION
When Electron tries to connect to `dbus` but cannot, it writes many errors to `stdout`.

By default, Electron attempts to connect to `dbus` in order to interact with systray, etc. In docker environments, there is no desktop environment, and thus no `dbus`. Setting the `DBUS_SESSION_BUS_ADDRESS` explicitly to `disabled:` prevents Electron from attempting to connect to `dbus`.

By preventing Electron from attempting to connect to `dbus`, the `dbus` error messages should no longer be emitted in docker environments that source the Cypress docker images unless that environment variable is modified.

There is a companion pull request in the main Cypress project that attempts to disable dbus when Cypress detects that it is not running in an interactive terminal: https://github.com/cypress-io/cypress/pull/32479