### PR TITLE
docs: remove pull statistics from README

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,12 +6,12 @@ These images provide all of the required dependencies for running Cypress in [Do
 
 We build four images: click on the image name to see the available tags with versions, and refer to the [Tags](#tags) section below. These allow you to target specific combinations you need.
 
-| Image Name                                                     | Description                                                                        | Monthly pulls                                                                                                                         |
-| -------------------------------------------------------------- | ---------------------------------------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------- |
-| [cypress/factory](https://hub.docker.com/r/cypress/factory/)   | A base image template which can be used with ARGs to create a custom docker image. | [![Docker Pulls](https://img.shields.io/docker/pulls/cypress/factory.svg?maxAge=604800)](https://hub.docker.com/r/cypress/factory/)   |
-| [cypress/base](https://hub.docker.com/r/cypress/base/)         | All operating system dependencies, no Cypress, and no browsers.                    | [![Docker Pulls](https://img.shields.io/docker/pulls/cypress/base.svg?maxAge=604800)](https://hub.docker.com/r/cypress/base/)         |
-| [cypress/browsers](https://hub.docker.com/r/cypress/browsers/) | All operating system dependencies, no Cypress, and some browsers.                  | [![Docker Pulls](https://img.shields.io/docker/pulls/cypress/browsers.svg?maxAge=604800)](https://hub.docker.com/r/cypress/browsers/) |
-| [cypress/included](https://hub.docker.com/r/cypress/included/) | All operating system dependencies, Cypress, and some browsers installed globally.  | [![Docker Pulls](https://img.shields.io/docker/pulls/cypress/included.svg?maxAge=604800)](https://hub.docker.com/r/cypress/included/) |
+| Image Name                                                     | Description                                                                        |
+| -------------------------------------------------------------- | ---------------------------------------------------------------------------------- |
+| [cypress/factory](https://hub.docker.com/r/cypress/factory/)   | A base image template which can be used with ARGs to create a custom docker image. |
+| [cypress/base](https://hub.docker.com/r/cypress/base/)         | All operating system dependencies, no Cypress, and no browsers.                    |
+| [cypress/browsers](https://hub.docker.com/r/cypress/browsers/) | All operating system dependencies, no Cypress, and some browsers.                  |
+| [cypress/included](https://hub.docker.com/r/cypress/included/) | All operating system dependencies, Cypress, and some browsers, installed globally. |
 
 ## Platforms
 


### PR DESCRIPTION
- closes https://github.com/cypress-io/cypress-docker-images/issues/1393

## Situation

In the table at the top of the [README](https://github.com/cypress-io/cypress-docker-images/blob/master/README.md) document, the column "Monthly pulls" is incorrectly labeled as "Monthly". It's the total since first publication:

<img width="1042" height="423" alt="image" src="https://github.com/user-attachments/assets/d2c0350c-34ae-4ab6-ae22-4d0e82c94b39" />

---

The [Cypress organization on Docker Hub](https://hub.docker.com/u/cypress) shows the equivalent pull figures as the total number of pulls over all time, not a monthly figure.

<img width="1700" height="566" alt="image" src="https://github.com/user-attachments/assets/44100c54-9c5d-480d-99aa-2b60170cf0a6" />

---

Cypress Docker images are now in a mature phase of their life cycle and there is no sign that the presentation of download statistics has any influence on user's download choices.

Additionally, the picture is incomplete, since the statistics only refer to:

- [Docker Hub](https://hub.docker.com/u/cypress) and not to
- [Amazon ECR (Elastic Container Registry) Public Gallery](https://gallery.ecr.aws/cypress-io) pulls

In summary, the statistics are incorrectly presented and there is no value to display them in the README.

## Change

Remove the column "Monthly pulls" from the [README](https://github.com/cypress-io/cypress-docker-images/blob/master/README.md) document.