### PR TITLE
docs: put PATH at end of build CLI examples

### DIFF
--- a/base/README.md
+++ b/base/README.md
@@ -59,6 +59,6 @@ We build the new image, run the container from the image and execute the Cypress
 ```shell
 cd examples/basic         # Use a pre-configured simple Cypress E2E project
 npm ci                    # Install Cypress
-docker build . -f Dockerfile.base -t test-base  # Build a new image
+docker build -f Dockerfile.base -t test-base . # Build a new image
 docker run -it --rm --entrypoint bash test-base -c "npx cypress run" # Run Cypress test in container
 ```

--- a/browsers/README.md
+++ b/browsers/README.md
@@ -68,6 +68,6 @@ We build the new image, run the container from the image and execute the Cypress
 ```shell
 cd examples/basic         # Use a pre-configured simple Cypress E2E project
 npm ci                    # Install Cypress
-docker build . -f Dockerfile.browsers -t test-browsers  # Build a new image
+docker build -f Dockerfile.browsers -t test-browsers . # Build a new image
 docker run -it --rm --entrypoint bash test-browsers -c "npx cypress run -b chrome" # Run Cypress test in container using Chrome
 ```

--- a/examples/chromium/README.md
+++ b/examples/chromium/README.md
@@ -60,6 +60,6 @@ We build the new image, run the container from the image and execute the Cypress
 ```shell
 cd examples/chromium             # Use a pre-configured simple Cypress E2E project
 npm ci                           # Install all dependencies
-docker build . -t test-chromium  # Build a new image
+docker build -t test-chromium . # Build a new image
 docker run -it --rm --entrypoint bash test-chromium -c "npx cypress run --browser chromium" # Run Cypress test using Chromium
 ```

--- a/examples/firefox-esr/README.md
+++ b/examples/firefox-esr/README.md
@@ -62,6 +62,6 @@ We build the new image, run the container from the image and execute the Cypress
 ```shell
 cd examples/firefox-esr             # Use a pre-configured simple Cypress E2E project
 npm ci                              # Install all dependencies
-docker build . -t test-firefox-esr  # Build a new image
+docker build -t test-firefox-esr . # Build a new image
 docker run -it --rm --entrypoint bash test-firefox-esr -c "npx cypress run --browser firefox" # Run Cypress test using Firefox ESR
 ```

--- a/factory/README.md
+++ b/factory/README.md
@@ -180,7 +180,7 @@ RUN npx cypress install
 Then, in the same directory as the `Dockerfile`, run the following commands to build the Docker image and run Cypress against the Chrome browser.
 
 ```bash
-docker build . -t test
+docker build -t test .
 docker run -it --rm test npx cypress run -b chrome
 ```
 
@@ -202,7 +202,7 @@ RUN npx cypress install
 Run the Docker commands:
 
 ```bash
-docker build . --build-arg CHROME_VERSION='139.0.7258.154-1' --build-arg EDGE_VERSION='139.0.3405.125-1' --build-arg FIREFOX_VERSION='142.0.1' -t test
+docker build --build-arg CHROME_VERSION='139.0.7258.154-1' --build-arg EDGE_VERSION='139.0.3405.125-1' --build-arg FIREFOX_VERSION='142.0.1' -t test .
 docker run -it --rm test npx cypress run -b chrome
 ```
 
@@ -264,7 +264,7 @@ RUN npx cypress install
 Then, in the same directory as the `Dockerfile`, run the following commands to build the Docker image and run Cypress against the Chrome browser.
 
 ```bash
-docker build . -t test
+docker build -t test .
 docker run -it --rm test npx cypress run -b chrome
 ```
 
@@ -277,7 +277,7 @@ To build a custom image behind a corporate proxy, it is possible to set the opti
 Example with the `--build-arg` flag :
 
 ```bash
-docker build . --build-arg HTTP_PROXY=http://my-corporate-proxy.com:3128 -t test
+docker build --build-arg HTTP_PROXY=http://my-corporate-proxy.com:3128 -t test .
 ```
 
 ## Version Testing


### PR DESCRIPTION
## Situation

Build examples, such as the following in the [factory/README > In the Dockerfile](https://github.com/cypress-io/cypress-docker-images/blob/master/factory/README.md#in-the-dockerfile) document section:

```shell
docker build . -t test
```

do not correspond to the official `docker build` documentation [docker buildx build](https://docs.docker.com/reference/cli/docker/buildx/build/) which shows the following as the `docker` CLI syntax:

`docker buildx build [OPTIONS] PATH | URL | -`

In the official documentation examples, the `PATH` parameter `.`, indicating the current directory, is always shown at the end of the command line.

## Change

Align all `docker build` examples to show the `PATH` parameter `.` at the end of the CLI command line.

## Notes

The `test.sh` scripts in [examples](https://github.com/cypress-io/cypress-docker-images/tree/master/examples) sub-directories are already aligned to the official Docker documentation syntax.

`docker build` is an alias for `docker buildx build` (but see also [Difference between docker build and docker buildx build](https://docs.docker.com/build/builders/#difference-between-docker-build-and-docker-buildx-build)).