### PR TITLE
chore: update engines to Node.js 20.18.1 min

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -17,7 +17,7 @@
         "prettier": "^3.6.2"
       },
       "engines": {
-        "node": ">=18.17"
+        "node": ">=20.18.1"
       }
     },
     "node_modules/@eslint-community/eslint-utils": {

--- a/package.json
+++ b/package.json
@@ -13,7 +13,7 @@
     "lint": "eslint"
   },
   "engines": {
-    "node": ">=18.17"
+    "node": ">=20.18.1"
   },
   "repository": {
     "type": "git",


### PR DESCRIPTION
## Situation

[package.json](https://github.com/cypress-io/cypress-docker-images/blob/master/package.json) includes https://github.com/cypress-io/cypress-docker-images/blob/8e68c65a076fcc9e02674a5d2d6a37299c715e7f/package.json#L15-L17

Node.js `18.17` is not compatible with:

- [markdown-link-check@3.13.7](https://github.com/tcort/markdown-link-check/releases/tag/v3.13.7) which requires Node.js `>=20.18.1`
- [cypress@15.2.0](https://github.com/cypress-io/cypress/releases/tag/v15.2.0) which requires Node.js `^20.0.0`

Node.js 18 reached [end-of-life](https://github.com/nodejs/Release/blob/main/README.md#end-of-life-releases) on Apr 30, 2025.

## Change

Update [package.json](https://github.com/cypress-io/cypress-docker-images/blob/master/package.json) `engines` field to `>=20.18.1`.

This does not affect building images with Node.js as this is containerized and independent from the Node.js version installed in the Docker host system.

## Verification

With Node.js `20.18.1`, execute

```shell
git clean -xfd
npm ci
```

and confirm that no `EBADENGINE` warnings are output.