### PR TITLE
chore: exclude npm registry from link check

### DIFF
--- a/markdownLinkConfig.json
+++ b/markdownLinkConfig.json
@@ -1,7 +1,7 @@
 {
   "ignorePatterns": [
     {
-      "pattern": "^#S*"
+      "pattern": "^https://www.npmjs.com"
     }
   ]
 }


### PR DESCRIPTION
## Situation

Executing `npm run check:markdown` results in errors checking the [./factory/README.md](https://github.com/cypress-io/cypress-docker-images/blob/master/factory/README.md) document:

```text
  ERROR: 3 dead links found!
  [✖] https://www.npmjs.com/package/yarn → Status: 403
  [✖] https://www.npmjs.com/package/cypress → Status: 403
  [✖] https://www.npmjs.com/package/geckodriver → Status: 403
```

These are [HTTP 403 Forbidden](https://developer.mozilla.org/de/docs/Web/HTTP/Reference/Status/403) errors, resulting from the npm registry refusing to honor non-browser requests.

## Change

- Add `^https://www.npmjs.com` to `ignorePatterns` in [markdownLinkConfig.json](https://github.com/cypress-io/cypress-docker-images/blob/master/markdownLinkConfig.json)

- Remove the existing `"pattern": "^#S*"`. This is not necessary.

## Verification

```shell
npm ci
npm run check:markdown
```

Confirm that there are no link issues reported.

## Comment

Due to a bug in [markdown-link-check](https://github.com/tcort/markdown-link-check) the return code is always set to success. Once this is fixed, the `check:markdown` script could be added to CI to report on link issues.