### PR TITLE
fix(deps): update to Node.js 22.20.0

### DIFF
--- a/factory/.env
+++ b/factory/.env
@@ -11,14 +11,14 @@ BASE_IMAGE='debian:13.1-slim'
 # Node Versions: https://nodejs.org/en/download/releases/
 # master branch needs "Active LTS" version
 # use feature branch for "Maintenance LTS" or "Current" versions
-FACTORY_DEFAULT_NODE_VERSION='22.19.0'
+FACTORY_DEFAULT_NODE_VERSION='22.20.0'
 
 # Node Versions: https://nodejs.org/en/download/releases/
 NODE_VERSION="${FACTORY_DEFAULT_NODE_VERSION}"
 
 # Update the FACTORY_VERSION to deploy cypress/factory if you make changes to
 # BASE_IMAGE, FACTORY_DEFAULT_NODE_VERSION, YARN_VERSION, factory.Dockerfile or installScripts
-FACTORY_VERSION='6.1.0'
+FACTORY_VERSION='6.1.1'
 
 # Chrome versions: https://www.ubuntuupdates.org/package/google_chrome/stable/main/base/google-chrome-stable
 # Linux/amd64 only

--- a/factory/CHANGELOG.md
+++ b/factory/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Change log
 
+## 6.1.1
+
+- Updated `FACTORY_DEFAULT_NODE_VERSION` from `22.19.0` to `22.20.0`. Addressed in [#1425](https://github.com/cypress-io/cypress-docker-images/pull/1425)
+
 ## 6.1.0
 
 - Updated Debian `BASE_IMAGE` from `debian:13.0-slim` to `debian:13.1-slim` using [Debian 13.1 (trixie)](https://www.debian.org/releases/trixie/). Addresses [#1412](https://github.com/cypress-io/cypress-docker-images/issues/1412).


### PR DESCRIPTION
## Situation

- Node.js released an update [Node.js v22.20.0 LTS](https://nodejs.org/en/blog/release/v22.20.0) on Sep 24, 2025.

## Change

In [factory/.env](https://github.com/cypress-io/cypress-docker-images/blob/master/factory/.env) make the following updates:

| Environment variable           | Before    | After     |
| ------------------------------ | --------- | --------- |
| `FACTORY_VERSION`              | `6.1.0`   | `6.1.1`   |
| `FACTORY_DEFAULT_NODE_VERSION` | `22.19.0` | `22.20.0` |

No browser version changes
