### PR TITLE
chore(deps): migrate to ESLint extends config structure

### DIFF
--- a/.prettierignore
+++ b/.prettierignore
@@ -6,3 +6,4 @@
 /factory/test-project
 
 **/*.js
+**/*.?js

--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -1,20 +1,26 @@
+import { defineConfig, globalIgnores } from 'eslint/config'
 import globals from 'globals'
-import pluginJs from '@eslint/js'
+import js from '@eslint/js'
 import pluginCypress from 'eslint-plugin-cypress'
 import stylistic from '@stylistic/eslint-plugin'
 
-export default [
-  { languageOptions: { globals: globals.node } },
-  pluginJs.configs.recommended,
-  pluginCypress.configs.recommended,
-  stylistic.configs.recommended,
-  { ignores: ['factory/test-project/**/*.js'] },
+export default defineConfig([
+  globalIgnores(['factory/test-project/**/*.js']),
   {
+    files: ['**/*.{,m}js'],
+    extends: [
+      js.configs.recommended,
+      pluginCypress.configs.recommended,
+      stylistic.configs.recommended,
+    ],
     rules: {
       '@stylistic/indent': ['error', 2],
       '@stylistic/comma-dangle': ['error', 'always-multiline'],
       '@stylistic/quotes': ['error', 'single'],
       '@stylistic/semi': ['error', 'never'],
     },
+    languageOptions: {
+      globals: globals.node,
+    },
   },
-]
+])


### PR DESCRIPTION
## Situation

The ESLint [9.22.0](https://eslint.org/blog/2025/03/eslint-v9.22.0-released/) release provided a new config feature described in the blog article [Evolving flat config with extends](https://eslint.org/blog/2025/03/flat-config-extends-define-config-global-ignores/) and which is now the documented way to construct ESLint [Configuration Files](https://eslint.org/docs/latest/use/configure/configuration-files).

The ESLint configuration [eslint.config.mjs](https://github.com/cypress-io/cypress-docker-images/blob/master/eslint.config.mjs) does not yet use this feature, so it is no longer in sync with the main ESLint documentation. The [eslint-plugin-cypress > README](https://github.com/cypress-io/eslint-plugin-cypress/blob/master/README.md) has also now been updated to describe using the `defineConfig()` helper function.

## Change

- Update the ESLint configuration [eslint.config.mjs](https://github.com/cypress-io/cypress-docker-images/blob/master/eslint.config.mjs) to use the `defineConfig()` function, imported from the `eslint/config` entrypoint according to the [Configuration Files](https://eslint.org/docs/latest/use/configure/configuration-files) documentation.

- Align import naming for best agreement with [ESLint](https://eslint.org/docs/latest/use/getting-started) and [eslint-plugin-cypress](https://github.com/cypress-io/eslint-plugin-cypress) documentation

- Exclude `*.?js` files from Prettier formatting. They are covered by the [@stylistic/eslint-plugin](https://eslint.style/) linter.

## Verification

```shell
git clean -xfd
npm ci
npm run format
npm run lint
```

Confirm no errors reported and no changes made.