### PR TITLE
ci: update circleci to ubuntu-2404:2025.09.1 (latest) machine image

### DIFF
--- a/circle.yml
+++ b/circle.yml
@@ -52,7 +52,7 @@ commands:
 jobs:
   lint:
     machine:
-      image: ubuntu-2204:2024.11.1
+      image: ubuntu-2404:2025.09.1
     steps:
       - checkout
       - run: npm ci
@@ -60,7 +60,7 @@ jobs:
       - run: npm run format:check
   check-factory-versions:
     machine:
-      image: ubuntu-2204:2024.11.1
+      image: ubuntu-2404:2025.09.1
     steps:
       - checkout
       - expand-env-file
@@ -154,7 +154,7 @@ jobs:
           working_directory: factory/test-project
   check-node-override-version:
     machine:
-      image: ubuntu-2204:2024.11.1
+      image: ubuntu-2404:2025.09.1
     steps:
       - checkout
       - expand-env-file
@@ -180,7 +180,7 @@ jobs:
           working_directory: factory/test-project
   test-image:
     machine:
-      image: ubuntu-2204:2024.11.1
+      image: ubuntu-2404:2025.09.1
     parameters:
       target:
         type: string
@@ -210,7 +210,7 @@ jobs:
 
   push:
     machine:
-      image: ubuntu-2204:2024.11.1
+      image: ubuntu-2404:2025.09.1
     parameters:
       target:
         type: string


### PR DESCRIPTION
## Situation

The currently used [CircleCI machine image](https://circleci.com/developer/images?imageType=machine) [ubuntu-2204:2024.11.1](https://circleci.com/developer/machine/image/ubuntu-2204) is based on the older Ubuntu `22.04` LTS, released in Apr 2022. The current Ubuntu LTS release is `24.04`, released in Apr 2024. (See [Ubuntu release cycle](https://ubuntu.com/about/release-cycle).)

The Docker versions in the CircleCI images are quite outdated, especially Docker `buildx` is at `0.17.1` compared to the current [buildx release](https://docs.docker.com/build/release-notes/) `0.28.0`.

CircleCI has now [announced a new set of machine images](https://discuss.circleci.com/t/ubuntu-22-04-24-04-q3-edge-release-including-cuda/54106):

- `ubuntu-2204:2025.09.1`
- `ubuntu-2404:2025.09.1`

## Change

Migrate the machine image used in [circle.yml](https://github.com/cypress-io/cypress-docker-images/blob/master/circle.yml) using
[ubuntu-2404:2025.09.1](https://discuss.circleci.com/t/ubuntu-22-04-24-04-q3-edge-release-including-cuda/54106) which updates the components as follows:

| Image tag               | Node.js   | Docker Engine                                                   | buildx                                                           | Status  |
| ----------------------- | --------- | --------------------------------------------------------------- | ---------------------------------------------------------------- | ------- |
| `ubuntu-2204:2024.11.1` | `22.11.0` | [27.3.1](https://docs.docker.com/engine/release-notes/27/#2731) | [v0.17.1](https://github.com/docker/buildx/releases/tag/v0.17.1) | current |
| `ubuntu-2404:2025.09.1` | `22.19.0` | [28.4.0](https://docs.docker.com/engine/release-notes/28/#2840) | [v0.28.0](https://github.com/docker/buildx/releases/tag/v0.28.0) | future  |

This is a minor version update for Node.js from `22.x` LTS. It is a major version update for Docker Engine from `27.x` to `28.x` and a major functional update from Docker Buildx [v0.17.1](https://github.com/docker/buildx/releases/tag/v0.17.1) to [v0.28.0](https://github.com/docker/buildx/releases/tag/v0.28.0).
