### PR TITLE
docs: add browser version support and Chrome version availability

### DIFF
--- a/factory/.env
+++ b/factory/.env
@@ -20,8 +20,11 @@ NODE_VERSION="${FACTORY_DEFAULT_NODE_VERSION}"
 # BASE_IMAGE, FACTORY_DEFAULT_NODE_VERSION, YARN_VERSION, factory.Dockerfile or installScripts
 FACTORY_VERSION='6.1.1'
 
+# Cypress officially supports the latest 3 major versions of Chrome, Firefox, and Edge only
+
 # Chrome versions: https://www.ubuntuupdates.org/package/google_chrome/stable/main/base/google-chrome-stable
 # Linux/amd64 only
+# Earlier versions of Google Chrome may no longer be available from http://dl.google.com
 CHROME_VERSION='141.0.7390.54-1'
 
 # Chrome for Testing versions: https://googlechromelabs.github.io/chrome-for-testing/

--- a/factory/README.md
+++ b/factory/README.md
@@ -285,3 +285,5 @@ docker build --build-arg HTTP_PROXY=http://my-corporate-proxy.com:3128 -t test .
 Due to the large amount of possible version combinations, we're not able to exhaustively test each combination of versions, nor do we block versions that are incompatible. For example, Cypress 12 removed support for Node.js version 12.0.0. You are still able to generate a container with Node.js 12.0.0 and Cypress 12, but Cypress will fail to run. This is because the factory supports earlier versions of Cypress and must support earlier versions of Node.js.
 
 Additionally, Cypress Docker images and containers generated from them are intended for test use only, and are not intended for hosting services in a production environment.
+
+Refer to Cypress [System requirements](https://docs.cypress.io/app/get-started/install-cypress#System-requirements) for details of currently supported environments, including [Node.js](https://docs.cypress.io/app/get-started/install-cypress#Nodejs) and [Browsers](https://docs.cypress.io/app/get-started/install-cypress#Browsers) support.


### PR DESCRIPTION
- Closes https://github.com/cypress-io/cypress-docker-images/issues/1431

## Situation

- Google Chrome purges older browser versions, so they are no longer available for building into a Cypress Docker image

- Cypress officially supports the latest 3 major versions of Chrome, Firefox, and Edge only - see https://docs.cypress.io/app/references/launching-browsers#Browser-versions-supported

This information is missing from the [factory README](https://github.com/cypress-io/cypress-docker-images/blob/master/factory/README.md).

## Change

- Add the information that Cypress officially supports the latest 3 major versions of Chrome, Firefox, and Edge only to
  - the [factory README](https://github.com/cypress-io/cypress-docker-images/blob/master/factory/README.md) by referring to Cypress [System requirement](https://docs.cypress.io/app/get-started/install-cypress#System-requirements) for details of currently supported environments, including [Node.js](https://docs.cypress.io/app/get-started/install-cypress#Nodejs) and [Browsers](https://docs.cypress.io/app/get-started/install-cypress#Browsers) support.
  - the [factory/.env](https://github.com/cypress-io/cypress-docker-images/blob/master/factory/.env) and note the availability of earlier Google Chrome versions.
