### PR TITLE
chore: bump browser versions to latest

### DIFF
--- a/factory/.env
+++ b/factory/.env
@@ -25,23 +25,23 @@ FACTORY_VERSION='6.1.1'
 # Chrome versions: https://www.ubuntuupdates.org/package/google_chrome/stable/main/base/google-chrome-stable
 # Linux/amd64 only
 # Earlier versions of Google Chrome may no longer be available from http://dl.google.com
-CHROME_VERSION='141.0.7390.54-1'
+CHROME_VERSION='141.0.7390.107-1'
 
 # Chrome for Testing versions: https://googlechromelabs.github.io/chrome-for-testing/
 # not currently used for cypress/browsers and cypress/included images
 # Linux/amd64 only
-CHROME_FOR_TESTING_VERSION='141.0.7390.54'
+CHROME_FOR_TESTING_VERSION='141.0.7390.78'
 
 # Cypress versions: https://www.npmjs.com/package/cypress
 CYPRESS_VERSION='15.4.0'
 
 # Edge versions: https://packages.microsoft.com/repos/edge/pool/main/m/microsoft-edge-stable/
 # Linux/amd64 only
-EDGE_VERSION='141.0.3537.57-1'
+EDGE_VERSION='141.0.3537.71-1'
 
 # Firefox versions: https://download-installer.cdn.mozilla.net/pub/firefox/releases/
 # Linux/amd64 for all versions, Linux/arm64 for versions 136.0 and above
-FIREFOX_VERSION='143.0.4'
+FIREFOX_VERSION='144.0'
 
 # Geckodriver versions: https://github.com/mozilla/geckodriver/releases
 # Geckodriver documentation: https://firefox-source-docs.mozilla.org/testing/geckodriver/index.html


### PR DESCRIPTION
| Environment variable           | Before            | After              |
| ------------------------------ | ----------------- | ------------------ |
| `FACTORY_VERSION`              | `6.1.1`           | no change          |
| `FACTORY_DEFAULT_NODE_VERSION` | `22.20.0`         | no change          |
| `CYPRESS_VERSION`              | `15.4.0`          | no change          |
| `CHROME_VERSION`               | `141.0.7390.54-1` | `141.0.7390.107-1` |
| `CHROME_FOR_TESTING_VERSION`   | `141.0.7390.54`   | `141.0.7390.78`    |
| `EDGE_VERSION`                 | `141.0.3537.57-1` | `141.0.3537.71-1`  |
| `FIREFOX_VERSION`              | `143.0.4`         | `144.0`            |
| `GECKODRIVER_VERSION`          | `0.36.0`          | no change          |

Incidentally corrects an issue with `cypress/included:15.4.0` built on Node.js `25.0.0`.
This reverts to using Node.js `22.20.0` and at the same time updates each browser to its latest available released version.