### PR TITLE
chore: add Cypress 15.5.0 factory images

### DIFF
--- a/factory/.env
+++ b/factory/.env
@@ -33,11 +33,11 @@ CHROME_VERSION='141.0.7390.107-1'
 CHROME_FOR_TESTING_VERSION='141.0.7390.78'
 
 # Cypress versions: https://www.npmjs.com/package/cypress
-CYPRESS_VERSION='15.4.0'
+CYPRESS_VERSION='15.5.0'
 
 # Edge versions: https://packages.microsoft.com/repos/edge/pool/main/m/microsoft-edge-stable/
 # Linux/amd64 only
-EDGE_VERSION='141.0.3537.71-1'
+EDGE_VERSION='141.0.3537.85-1'
 
 # Firefox versions: https://download-installer.cdn.mozilla.net/pub/firefox/releases/
 # Linux/amd64 for all versions, Linux/arm64 for versions 136.0 and above


### PR DESCRIPTION
Updates cypress to `15.5.0`