### PR TITLE
fix(deps): update to Node.js 22.21.0

### DIFF
--- a/factory/.env
+++ b/factory/.env
@@ -11,14 +11,14 @@ BASE_IMAGE='debian:13.1-slim'
 # Node Versions: https://nodejs.org/en/download/releases/
 # master branch needs "Active LTS" version
 # use feature branch for "Maintenance LTS" or "Current" versions
-FACTORY_DEFAULT_NODE_VERSION='22.20.0'
+FACTORY_DEFAULT_NODE_VERSION='22.21.0'
 
 # Node Versions: https://nodejs.org/en/download/releases/
 NODE_VERSION="${FACTORY_DEFAULT_NODE_VERSION}"
 
 # Update the FACTORY_VERSION to deploy cypress/factory if you make changes to
 # BASE_IMAGE, FACTORY_DEFAULT_NODE_VERSION, YARN_VERSION, factory.Dockerfile or installScripts
-FACTORY_VERSION='6.1.1'
+FACTORY_VERSION='6.1.2'
 
 # Cypress officially supports the latest 3 major versions of Chrome, Firefox, and Edge only
 
@@ -37,7 +37,7 @@ CYPRESS_VERSION='15.5.0'
 
 # Edge versions: https://packages.microsoft.com/repos/edge/pool/main/m/microsoft-edge-stable/
 # Linux/amd64 only
-EDGE_VERSION='141.0.3537.85-1'
+EDGE_VERSION='141.0.3537.92-1'
 
 # Firefox versions: https://download-installer.cdn.mozilla.net/pub/firefox/releases/
 # Linux/amd64 for all versions, Linux/arm64 for versions 136.0 and above

--- a/factory/CHANGELOG.md
+++ b/factory/CHANGELOG.md
@@ -1,8 +1,12 @@
 # Change log
 
+## 6.1.2
+
+- Updated `FACTORY_DEFAULT_NODE_VERSION` from `22.20.0` to `22.21.0`. Addressed in [#1437](https://github.com/cypress-io/cypress-docker-images/pull/1437).
+
 ## 6.1.1
 
-- Updated `FACTORY_DEFAULT_NODE_VERSION` from `22.19.0` to `22.20.0`. Addressed in [#1425](https://github.com/cypress-io/cypress-docker-images/pull/1425)
+- Updated `FACTORY_DEFAULT_NODE_VERSION` from `22.19.0` to `22.20.0`. Addressed in [#1425](https://github.com/cypress-io/cypress-docker-images/pull/1425).
 
 ## 6.1.0
 


### PR DESCRIPTION
## Situation

- Node.js released an update [Node.js v22.21.0 LTS](https://nodejs.org/en/blog/release/v22.21.0) on Oct 20, 2025.

## Change

In [factory/.env](https://github.com/cypress-io/cypress-docker-images/blob/master/factory/.env) make the following updates:

| Environment variable           | Before             | After             |
| ------------------------------ | ------------------ | ----------------- |
| `FACTORY_VERSION`              | `6.1.1`            | `6.1.2`           |
| `FACTORY_DEFAULT_NODE_VERSION` | `22.20.0`          | `22.21.0`         |
| `CHROME_VERSION`               | `141.0.7390.107-1` | no change         |
| `CHROME_FOR_TESTING_VERSION`   | `141.0.7390.78`    | no change         |
| `EDGE_VERSION`                 | `141.0.3537.85-1`  | `141.0.3537.92-1` |
| `FIREFOX_VERSION`              | `144.0`            | no change         |
