### PR TITLE
chore: update cypress to 15.6.0

### DIFF
--- a/factory/.env
+++ b/factory/.env
@@ -33,11 +33,11 @@ CHROME_VERSION='142.0.7444.59-1'
 CHROME_FOR_TESTING_VERSION='142.0.7444.59'
 
 # Cypress versions: https://www.npmjs.com/package/cypress
-CYPRESS_VERSION='15.5.0'
+CYPRESS_VERSION='15.6.0'
 
 # Edge versions: https://packages.microsoft.com/repos/edge/pool/main/m/microsoft-edge-stable/
 # Linux/amd64 only
-EDGE_VERSION='141.0.3537.99-1'
+EDGE_VERSION='142.0.3595.53-1'
 
 # Firefox versions: https://download-installer.cdn.mozilla.net/pub/firefox/releases/
 # Linux/amd64 for all versions, Linux/arm64 for versions 136.0 and above


### PR DESCRIPTION
updates Edge to latest and Cypress to 15.6.0