### PR TITLE
fix: Geckodriver installation script version string comparison

### DIFF
--- a/factory/.env
+++ b/factory/.env
@@ -18,7 +18,7 @@ NODE_VERSION="${FACTORY_DEFAULT_NODE_VERSION}"
 
 # Update the FACTORY_VERSION to deploy cypress/factory if you make changes to
 # BASE_IMAGE, FACTORY_DEFAULT_NODE_VERSION, YARN_VERSION, factory.Dockerfile or installScripts
-FACTORY_VERSION='7.0.1'
+FACTORY_VERSION='7.0.2'
 
 # Cypress officially supports the latest 3 major versions of Chrome, Firefox, and Edge only
 

--- a/factory/CHANGELOG.md
+++ b/factory/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Change log
 
+## 7.0.2
+
+- Fixed Geckodriver installation script logic for Geckodriver versions > `0.99.x`. Addresses [#1444](https://github.com/cypress-io/cypress-docker-images/issues/1444).
+
 ## 7.0.1
 
 - Fixed Firefox installation script logic for Firefox versions > `999.x`. Addresses [#1443](https://github.com/cypress-io/cypress-docker-images/issues/1443).

--- a/factory/installScripts/geckodriver/install-geckodriver-version.js
+++ b/factory/installScripts/geckodriver/install-geckodriver-version.js
@@ -10,10 +10,15 @@ if (!geckodriverVersion) {
 
 // See https://firefox-source-docs.mozilla.org/testing/geckodriver/Support.html for compatibility matrix
 // geckodriver < 0.34.0 only supports up to Firefox 120, which is no longer supported by Cypress
-const MIN_GECKO = '0.34.0'
+const MINIMUM_GECKO_MAJOR = 0
+const MINIMUM_GECKO_MINOR = 34
+const geckodriverMajorVersion = geckodriverVersion.split('.').map(Number)[0]
+const geckodriverMinorVersion = geckodriverVersion.split('.').map(Number)[1]
 
-if (geckodriverVersion < MIN_GECKO) {
-  console.log(`geckodriver version ${geckodriverVersion} provided, minimum version ${MIN_GECKO} required, skipping geckodriver install`)
+if (geckodriverMajorVersion < MINIMUM_GECKO_MAJOR
+  || (geckodriverMajorVersion === MINIMUM_GECKO_MAJOR && geckodriverMinorVersion < MINIMUM_GECKO_MINOR)
+) {
+  console.log(`geckodriver version ${geckodriverVersion} provided, minimum version ${MINIMUM_GECKO_MAJOR}.${MINIMUM_GECKO_MINOR}.x required, skipping geckodriver install`)
   process.exit(0)
 }
 


### PR DESCRIPTION
- closes https://github.com/cypress-io/cypress-docker-images/issues/1444

## Situation

The version string comparison in [factory/installScripts/geckodriver/install-geckodriver-version.js](https://github.com/cypress-io/cypress-docker-images/blob/master/factory/installScripts/geckodriver/install-geckodriver-version.js) against `MIN_GECKO = '0.34.0'` is flawed. It will fail if the version of Geckodriver exceeds `0.99.0`.

The installation script [factory/installScripts/geckodriver/install-geckodriver-version.js](https://github.com/cypress-io/cypress-docker-images/blob/master/factory/installScripts/geckodriver/install-geckodriver-version.js) ensures that a minimum version of Geckodriver `0.34.0` is used.

The compatibility matrix https://firefox-source-docs.mozilla.org/testing/geckodriver/Support.html lists the maximum version of Firefox `120` for Geckodriver versions `<0.34.0`. Firefox `120` is no longer supported by Cypress - currently Cypress supports Firefox `142`, `141` and `140` versions. This requires preventing installation of Geckodriver versions `<0.34.0`.

## Change

Instead of string comparisons, parse out the major and minor versions for Geckodriver and carry out numerical comparisons.

| Environment variable           | Before            | After             |
| ------------------------------ | ----------------- | ----------------- |
| `FACTORY_VERSION`              | `7.0.1`           | `7.0.2`           |

## Verification

 | `GECKODRIVER_VERSION` | Build message      |
 | --------------------- | ------------------ |
 | `0.36.0`              | Success            |
 | `0.34.0`              | Success            |
 | `0.33.0`              | Skip               |
 | `0.99.0`              | Fail 404 Not Found |
 | `0.100.0`             | Fail 404 Not Found |
 | `1.0.0`               | Fail 404 Not Found |
 | `1.33.0`              | Fail 404 Not Found |
 | `1.34.0`              | Fail 404 Not Found |

- use `--progress plain` to see skipped messages
- use `--no-cache` to repeat test

```shell
cd factory
docker compose build factory
docker compose build firefox

export GECKODRIVER_VERSION=0.36.0
docker compose --progress plain build firefox # expect success

export GECKODRIVER_VERSION=0.34.0
docker compose --progress plain build firefox # expect success

export GECKODRIVER_VERSION=0.33.0
docker compose --progress plain build firefox # expect skip message

export GECKODRIVER_VERSION=0.99.0
docker compose --progress plain build firefox # expect 404 error

export GECKODRIVER_VERSION=0.100.0
docker compose --progress plain build firefox # expect 404 error

export GECKODRIVER_VERSION=1.0.0
docker compose --progress plain build firefox # expect 404 error

export GECKODRIVER_VERSION=1.33.0
docker compose --progress plain build firefox # expect 404 error

export GECKODRIVER_VERSION=1.34.0
docker compose --progress plain build firefox # expect 404 error
cd ..
```

Skip message is similar to:

> geckodriver version 0.33.0 provided, minimum version 0.34.x required, skipping geckodriver install
