### PR TITLE
feat: update BASE_IMAGE to debian:13.2-slim (trixie)

### DIFF
--- a/factory/.env
+++ b/factory/.env
@@ -6,7 +6,7 @@
 
 # Use Debian stable release https://www.debian.org/releases/stable/
 # The Debian image cypress/factory is based on
-BASE_IMAGE='debian:13.1-slim'
+BASE_IMAGE='debian:13.2-slim'
 
 # Node Versions: https://nodejs.org/en/download/releases/
 # master branch needs "Active LTS" version
@@ -18,7 +18,7 @@ NODE_VERSION="${FACTORY_DEFAULT_NODE_VERSION}"
 
 # Update the FACTORY_VERSION to deploy cypress/factory if you make changes to
 # BASE_IMAGE, FACTORY_DEFAULT_NODE_VERSION, YARN_VERSION, factory.Dockerfile or installScripts
-FACTORY_VERSION='7.0.3'
+FACTORY_VERSION='7.1.0'
 
 # Cypress officially supports the latest 3 major versions of Chrome, Firefox, and Edge only
 

--- a/factory/CHANGELOG.md
+++ b/factory/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Change log
 
+## 7.1.0
+
+- Updated Debian `BASE_IMAGE` from `debian:13.1-slim` to `debian:13.2-slim` using [Debian 13.2 (trixie)](https://www.debian.org/releases/trixie/). Addressed in [#1452](https://github.com/cypress-io/cypress-docker-images/issues/1452).
+
 ## 7.0.3
 
 - Updated `FACTORY_DEFAULT_NODE_VERSION` from `24.11.0` to `24.11.1`. Addressed in [#1451](https://github.com/cypress-io/cypress-docker-images/pull/1451).


### PR DESCRIPTION
## Situation

Cypress Docker images built from [factory/.env](https://github.com/cypress-io/cypress-docker-images/blob/master/factory/.env) currently use `BASE_IMAGE='debian:13.1-slim'`. [Debian 13.2 (trixie)](https://www.debian.org/releases/trixie/), which was [released](https://www.debian.org/News/2025/20251115) on Nov 15, 2025, supersedes Debian 13.1 (trixie).

## Change

Update the base image for `cypress/factory` to use [Debian 13.2 (trixie)](https://www.debian.org/releases/trixie/).

The environment variables in [factory/.env](https://github.com/cypress-io/cypress-docker-images/blob/master/factory/.env) that control the default build process, are updated as follows:

| Environment variable           | Before             | After              |
| ------------------------------ | ------------------ | ------------------ |
| `BASE_IMAGE`                   | `debian:13.1-slim` | `debian:13.2-slim` |
| `FACTORY_VERSION`              | `7.0.3`            | `7.1.0`            |
| `FACTORY_DEFAULT_NODE_VERSION` | `24.11.1`          | no change          |

no browser version changes
