### PR TITLE
chore: update factory to cypress 15.7.0

### DIFF
--- a/factory/.env
+++ b/factory/.env
@@ -25,23 +25,23 @@ FACTORY_VERSION='7.1.0'
 # Chrome versions: https://www.ubuntuupdates.org/package/google_chrome/stable/main/base/google-chrome-stable
 # Linux/amd64 only
 # Earlier versions of Google Chrome may no longer be available from http://dl.google.com
-CHROME_VERSION='142.0.7444.162-1'
+CHROME_VERSION='142.0.7444.175-1'
 
 # Chrome for Testing versions: https://googlechromelabs.github.io/chrome-for-testing/
 # not currently used for cypress/browsers and cypress/included images
 # Linux/amd64 only
-CHROME_FOR_TESTING_VERSION='142.0.7444.162'
+CHROME_FOR_TESTING_VERSION='142.0.7444.175'
 
 # Cypress versions: https://www.npmjs.com/package/cypress
-CYPRESS_VERSION='15.6.0'
+CYPRESS_VERSION='15.7.0'
 
 # Edge versions: https://packages.microsoft.com/repos/edge/pool/main/m/microsoft-edge-stable/
 # Linux/amd64 only
-EDGE_VERSION='142.0.3595.65-1'
+EDGE_VERSION='142.0.3595.90-1'
 
 # Firefox versions: https://download-installer.cdn.mozilla.net/pub/firefox/releases/
 # Linux/amd64 for all versions, Linux/arm64 for versions 136.0 and above
-FIREFOX_VERSION='145.0'
+FIREFOX_VERSION='145.0.1'
 
 # Geckodriver versions: https://github.com/mozilla/geckodriver/releases
 # Geckodriver documentation: https://firefox-source-docs.mozilla.org/testing/geckodriver/index.html


### PR DESCRIPTION
updates browsers to latest and Cypress to `15.7.0`