### PR TITLE
fix(deps): update to Node.js 24.12.0

### DIFF
--- a/factory/.env
+++ b/factory/.env
@@ -11,14 +11,14 @@ BASE_IMAGE='debian:13.2-slim'
 # Node Versions: https://nodejs.org/en/download/releases/
 # master branch needs "Active LTS" version
 # use feature branch for "Maintenance LTS" or "Current" versions
-FACTORY_DEFAULT_NODE_VERSION='24.11.1'
+FACTORY_DEFAULT_NODE_VERSION='24.12.0'
 
 # Node Versions: https://nodejs.org/en/download/releases/
 NODE_VERSION="${FACTORY_DEFAULT_NODE_VERSION}"
 
 # Update the FACTORY_VERSION to deploy cypress/factory if you make changes to
 # BASE_IMAGE, FACTORY_DEFAULT_NODE_VERSION, YARN_VERSION, factory.Dockerfile or installScripts
-FACTORY_VERSION='7.1.0'
+FACTORY_VERSION='7.1.1'
 
 # Cypress officially supports the latest 3 major versions of Chrome, Firefox, and Edge only
 
@@ -37,11 +37,11 @@ CYPRESS_VERSION='15.7.1'
 
 # Edge versions: https://packages.microsoft.com/repos/edge/pool/main/m/microsoft-edge-stable/
 # Linux/amd64 only
-EDGE_VERSION='142.0.3595.94-1'
+EDGE_VERSION='143.0.3650.66-1'
 
 # Firefox versions: https://download-installer.cdn.mozilla.net/pub/firefox/releases/
 # Linux/amd64 for all versions, Linux/arm64 for versions 136.0 and above
-FIREFOX_VERSION='145.0.2'
+FIREFOX_VERSION='146.0'
 
 # Geckodriver versions: https://github.com/mozilla/geckodriver/releases
 # Geckodriver documentation: https://firefox-source-docs.mozilla.org/testing/geckodriver/index.html

--- a/factory/CHANGELOG.md
+++ b/factory/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Change log
 
+## 7.1.1
+
+- Updated `FACTORY_DEFAULT_NODE_VERSION` from `24.11.1` to `24.12.0`. Addressed in [#1457](https://github.com/cypress-io/cypress-docker-images/pull/1457).
+
 ## 7.1.0
 
 - Updated Debian `BASE_IMAGE` from `debian:13.1-slim` to `debian:13.2-slim` using [Debian 13.2 (trixie)](https://www.debian.org/releases/trixie/). Addressed in [#1452](https://github.com/cypress-io/cypress-docker-images/issues/1452).


### PR DESCRIPTION
## Situation

- Node.js released an update [Node.js v24.12.0 LTS](https://nodejs.org/en/blog/release/v24.12.0) on Dec 10, 2025.

## Change

In [factory/.env](https://github.com/cypress-io/cypress-docker-images/blob/master/factory/.env) make the following updates:

| Environment variable           | Before            | After             |
| ------------------------------ | ----------------- | ----------------- |
| `FACTORY_VERSION`              | `7.1.0`           | `7.1.1`           |
| `FACTORY_DEFAULT_NODE_VERSION` | `24.11.1`         | `24.12.0`         |
| `CHROME_VERSION`               | `143.0.7499.40-1` | no change         |
| `CHROME_FOR_TESTING_VERSION`   | `143.0.7499.40`   | no change         |
| `EDGE_VERSION`                 | `142.0.3595.94-1` | `143.0.3650.66-1` |
| `FIREFOX_VERSION`              | `145.0.2`         | `146.0`           |
