### PR TITLE
feat: update BASE_IMAGE to debian:13.3-slim (trixie)

### DIFF
--- a/factory/.env
+++ b/factory/.env
@@ -6,7 +6,7 @@
 
 # Use Debian stable release https://www.debian.org/releases/stable/
 # The Debian image cypress/factory is based on
-BASE_IMAGE='debian:13.2-slim'
+BASE_IMAGE='debian:13.3-slim'
 
 # Node Versions: https://nodejs.org/en/download/releases/
 # master branch needs "Active LTS" version
@@ -18,7 +18,7 @@ NODE_VERSION="${FACTORY_DEFAULT_NODE_VERSION}"
 
 # Update the FACTORY_VERSION to deploy cypress/factory if you make changes to
 # BASE_IMAGE, FACTORY_DEFAULT_NODE_VERSION, YARN_VERSION, factory.Dockerfile or installScripts
-FACTORY_VERSION='7.1.1'
+FACTORY_VERSION='7.2.0'
 
 # Cypress officially supports the latest 3 major versions of Chrome, Firefox, and Edge only
 

--- a/factory/CHANGELOG.md
+++ b/factory/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Change log
 
+## 7.2.0
+
+- Updated Debian `BASE_IMAGE` from `debian:13.2-slim` to `debian:13.3-slim` using [Debian 13.3 (trixie)](https://www.debian.org/releases/trixie/). Addressed in [#1462](https://github.com/cypress-io/cypress-docker-images/issues/1462).
+
 ## 7.1.1
 
 - Updated `FACTORY_DEFAULT_NODE_VERSION` from `24.11.1` to `24.12.0`. Addressed in [#1457](https://github.com/cypress-io/cypress-docker-images/pull/1457).


### PR DESCRIPTION
## Situation

Cypress Docker images built from [factory/.env](https://github.com/cypress-io/cypress-docker-images/blob/master/factory/.env) currently use `BASE_IMAGE='debian:13.2-slim'`. [Debian 13.3 (trixie)](https://www.debian.org/releases/trixie/), which was [released](https://www.debian.org/News/2026/20260110) on Jan 10, 2026, supersedes Debian 13.2 (trixie).

## Change

Update the base image for `cypress/factory` to use [Debian 13.3 (trixie)](https://www.debian.org/releases/trixie/).

The environment variables in [factory/.env](https://github.com/cypress-io/cypress-docker-images/blob/master/factory/.env) that control the default build process, are updated as follows:

| Environment variable           | Before             | After              |
| ------------------------------ | ------------------ | ------------------ |
| `BASE_IMAGE`                   | `debian:13.2-slim` | `debian:13.3-slim` |
| `FACTORY_VERSION`              | `7.1.1`            | `7.2.0`            |
| `FACTORY_DEFAULT_NODE_VERSION` | `24.12.0`          | no change          |

no browser version changes
