### PR TITLE
fix(deps): update to Node.js 24.13.0

### DIFF
--- a/factory/.env
+++ b/factory/.env
@@ -11,37 +11,37 @@ BASE_IMAGE='debian:13.3-slim'
 # Node Versions: https://nodejs.org/en/download/releases/
 # master branch needs "Active LTS" version
 # use feature branch for "Maintenance LTS" or "Current" versions
-FACTORY_DEFAULT_NODE_VERSION='24.12.0'
+FACTORY_DEFAULT_NODE_VERSION='24.13.0'
 
 # Node Versions: https://nodejs.org/en/download/releases/
 NODE_VERSION="${FACTORY_DEFAULT_NODE_VERSION}"
 
 # Update the FACTORY_VERSION to deploy cypress/factory if you make changes to
 # BASE_IMAGE, FACTORY_DEFAULT_NODE_VERSION, YARN_VERSION, factory.Dockerfile or installScripts
-FACTORY_VERSION='7.2.0'
+FACTORY_VERSION='7.2.1'
 
 # Cypress officially supports the latest 3 major versions of Chrome, Firefox, and Edge only
 
 # Chrome versions: https://www.ubuntuupdates.org/package/google_chrome/stable/main/base/google-chrome-stable
 # Linux/amd64 only
 # Earlier versions of Google Chrome may no longer be available from http://dl.google.com
-CHROME_VERSION='143.0.7499.169-1'
+CHROME_VERSION='143.0.7499.192-1'
 
 # Chrome for Testing versions: https://googlechromelabs.github.io/chrome-for-testing/
 # not currently used for cypress/browsers and cypress/included images
 # Linux/amd64 only
-CHROME_FOR_TESTING_VERSION='143.0.7499.169'
+CHROME_FOR_TESTING_VERSION='143.0.7499.192'
 
 # Cypress versions: https://www.npmjs.com/package/cypress
 CYPRESS_VERSION='15.8.2'
 
 # Edge versions: https://packages.microsoft.com/repos/edge/pool/main/m/microsoft-edge-stable/
 # Linux/amd64 only
-EDGE_VERSION='143.0.3650.96-1'
+EDGE_VERSION='143.0.3650.139-1'
 
 # Firefox versions: https://download-installer.cdn.mozilla.net/pub/firefox/releases/
 # Linux/amd64 for all versions, Linux/arm64 for versions 136.0 and above
-FIREFOX_VERSION='146.0.1'
+FIREFOX_VERSION='147.0'
 
 # Geckodriver versions: https://github.com/mozilla/geckodriver/releases
 # Geckodriver documentation: https://firefox-source-docs.mozilla.org/testing/geckodriver/index.html

--- a/factory/CHANGELOG.md
+++ b/factory/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Change log
 
+## 7.2.1
+
+- Updated `FACTORY_DEFAULT_NODE_VERSION` from `24.12.0` to `24.13.0`. Addressed in [#1463](https://github.com/cypress-io/cypress-docker-images/pull/1463).
+
 ## 7.2.0
 
 - Updated Debian `BASE_IMAGE` from `debian:13.2-slim` to `debian:13.3-slim` using [Debian 13.3 (trixie)](https://www.debian.org/releases/trixie/). Addressed in [#1462](https://github.com/cypress-io/cypress-docker-images/issues/1462).


### PR DESCRIPTION
## Situation

- Node.js released a security update [Node.js v24.13.0 LTS](https://nodejs.org/en/blog/release/v24.13.0) on Jan 13, 2026.

## Change

In [factory/.env](https://github.com/cypress-io/cypress-docker-images/blob/master/factory/.env) make the following updates:

| Environment variable           | Before             | After              |
| ------------------------------ | ------------------ | ------------------ |
| `FACTORY_VERSION`              | `7.2.0`            | `7.2.1`            |
| `FACTORY_DEFAULT_NODE_VERSION` | `24.12.0`          | `24.13.0`          |
| `CHROME_VERSION`               | `143.0.7499.169-1` | `143.0.7499.192-1` |
| `CHROME_FOR_TESTING_VERSION`   | `143.0.7499.169`   | `143.0.7499.192`   |
| `EDGE_VERSION`                 | `143.0.3650.96-1`  | `143.0.3650.139-1` |
| `FIREFOX_VERSION`              | `146.0.1`          | `147.0`         |
