### PR TITLE
test(deps): test example-cypress-github-action when changed

### DIFF
--- a/.github/workflows/example-cypress-github-action.yml
+++ b/.github/workflows/example-cypress-github-action.yml
@@ -4,12 +4,20 @@ name: Example Cypress GitHub Actions
 # Cypress JavaScript GitHub Action (https://github.com/cypress-io/github-action) with
 # Cypress Docker images (https://github.com/cypress-io/cypress-docker-images)
 
-# The workflow is triggered manually on demand, see
-# https://docs.github.com/en/actions/using-workflows/manually-running-a-workflow
 # To automatically trigger a workflow, for instance on a push event, see
 # https://docs.github.com/en/actions/using-workflows/triggering-a-workflow
+# for options and examples.
+# The workflow can be triggered manually on demand, see
+# https://docs.github.com/en/actions/using-workflows/manually-running-a-workflow
 
-on: workflow_dispatch
+on:
+  push:
+    paths:
+      - '.github/workflows/example-cypress-github-action.yml'
+  pull_request:
+    paths:
+      - '.github/workflows/example-cypress-github-action.yml'
+  workflow_dispatch:
 
 jobs:
   docker-base:


### PR DESCRIPTION
## Situation

[example-cypress-github-action.yml](https://github.com/cypress-io/cypress-docker-images/blob/master/.github/workflows/example-cypress-github-action.yml) contains only an event trigger for `workflow_dispatch` and is therefore only ever tested manually

## Change

Add the following event trigger to [example-cypress-github-action.yml](https://github.com/cypress-io/cypress-docker-images/blob/master/.github/workflows/example-cypress-github-action.yml)

```yml
  push:
    paths:
      - '.github/workflows/example-cypress-github-action.yml'
  pull_request:
    paths:
      - '.github/workflows/example-cypress-github-action.yml'
```

The Cypress Docker images are already tested extensively in [CircleCI](https://github.com/cypress-io/cypress-docker-images/blob/master/circle.yml) and in [example-tests.yml](https://github.com/cypress-io/cypress-docker-images/blob/master/.github/workflows/example-tests.yml), so the workflow only needs to be tested if it is changed.