### PR TITLE
fix: make Yarn v1 GPG signing key retrieval more robust

### DIFF
--- a/factory/.env
+++ b/factory/.env
@@ -18,7 +18,7 @@ NODE_VERSION="${FACTORY_DEFAULT_NODE_VERSION}"
 
 # Update the FACTORY_VERSION to deploy cypress/factory if you make changes to
 # BASE_IMAGE, FACTORY_DEFAULT_NODE_VERSION, YARN_VERSION, factory.Dockerfile or installScripts
-FACTORY_VERSION='7.2.1'
+FACTORY_VERSION='7.2.2'
 
 # Cypress officially supports the latest 3 major versions of Chrome, Firefox, and Edge only
 

--- a/factory/CHANGELOG.md
+++ b/factory/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Change log
 
+## 7.2.2
+
+- Updated Yarn v1 Classic PGP signing key retrieval to avoid failure. Addresses [#1469](https://github.com/cypress-io/cypress-docker-images/pull/1469).
+
 ## 7.2.1
 
 - Updated `FACTORY_DEFAULT_NODE_VERSION` from `24.12.0` to `24.13.0`. Addressed in [#1463](https://github.com/cypress-io/cypress-docker-images/pull/1463).

--- a/factory/installScripts/yarn/default.sh
+++ b/factory/installScripts/yarn/default.sh
@@ -10,8 +10,8 @@ set -ex \
   && for key in \
     6A010C5166006599AA17F08146C2130DFD2497F5 \
   ; do \
-    gpg --batch --keyserver hkps://keys.openpgp.org $keyserverOptions --recv-keys "$key" || \
-    gpg --batch --keyserver keyserver.ubuntu.com --recv-keys "$key" ; \
+    { gpg --batch --keyserver hkps://keys.openpgp.org $keyserverOptions --recv-keys "$key" && gpg --batch --fingerprint "$key"; } || \
+    { gpg --batch --keyserver keyserver.ubuntu.com --recv-keys "$key" && gpg --batch --fingerprint "$key"; } ; \
   done \
   && curl -fsSLO --compressed "https://yarnpkg.com/downloads/$1/yarn-v$1.tar.gz" \
   && curl -fsSLO --compressed "https://yarnpkg.com/downloads/$1/yarn-v$1.tar.gz.asc" \


### PR DESCRIPTION
- closes https://github.com/cypress-io/cypress-docker-images/issues/1469

## Situation

Yarn v1 Classic package signing issues described in https://github.com/yarnpkg/yarn/issues/9216 have caused Yarn v1 to replace their signing keys.

Attempts to build a Cypress Docker image with Yarn v1 fails with the message

> gpg:                using RSA key 72ECF46A56B4AD39C907BBB71646B01B86E50310
> gpg: Can't check signature: No public key

## Change

In [factory/installScripts/yarn/default.sh](https://github.com/cypress-io/cypress-docker-images/blob/master/factory/installScripts/yarn/default.sh) make key retrieval more robust, as is already implemented in https://github.com/nodejs/docker-node/blob/main/Dockerfile-slim.template. Similar to PR https://github.com/cypress-io/cypress-docker-images/pull/1380.

Update:

| Environment variable | Before  | After   |
| -------------------- | ------- | ------- |
| `FACTORY_VERSION`    | `7.2.1` | `7.2.2` |

## Verification

```shell
cd factory
docker compose build factory --no-cache
docker compose build --progress plain base --no-cache
cd test-project
set -a && . ../.env && set +a
docker compose run --build --rm test-factory-all-included
cd ../..
```
