### PR TITLE
fix(deps): update to Node.js 24.13.1

### DIFF
--- a/factory/.env
+++ b/factory/.env
@@ -11,14 +11,14 @@ BASE_IMAGE='debian:13.3-slim'
 # Node Versions: https://nodejs.org/en/download/releases/
 # master branch needs "Active LTS" version
 # use feature branch for "Maintenance LTS" or "Current" versions
-FACTORY_DEFAULT_NODE_VERSION='24.13.0'
+FACTORY_DEFAULT_NODE_VERSION='24.13.1'
 
 # Node Versions: https://nodejs.org/en/download/releases/
 NODE_VERSION="${FACTORY_DEFAULT_NODE_VERSION}"
 
 # Update the FACTORY_VERSION to deploy cypress/factory if you make changes to
 # BASE_IMAGE, FACTORY_DEFAULT_NODE_VERSION, YARN_VERSION, factory.Dockerfile or installScripts
-FACTORY_VERSION='7.2.2'
+FACTORY_VERSION='7.2.3'
 
 # Cypress officially supports the latest 3 major versions of Chrome, Firefox, and Edge only
 
@@ -30,14 +30,14 @@ CHROME_VERSION='144.0.7559.132-1'
 # Chrome for Testing versions: https://googlechromelabs.github.io/chrome-for-testing/
 # not currently used for cypress/browsers and cypress/included images
 # Linux/amd64 only
-CHROME_FOR_TESTING_VERSION='144.0.7559.133'
+CHROME_FOR_TESTING_VERSION='145.0.7632.46'
 
 # Cypress versions: https://www.npmjs.com/package/cypress
 CYPRESS_VERSION='15.10.0'
 
 # Edge versions: https://packages.microsoft.com/repos/edge/pool/main/m/microsoft-edge-stable/
 # Linux/amd64 only
-EDGE_VERSION='144.0.3719.104-1'
+EDGE_VERSION='144.0.3719.115-1'
 
 # Firefox versions: https://download-installer.cdn.mozilla.net/pub/firefox/releases/
 # Linux/amd64 for all versions, Linux/arm64 for versions 136.0 and above

--- a/factory/CHANGELOG.md
+++ b/factory/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Change log
 
+## 7.2.3
+
+- Updated `FACTORY_DEFAULT_NODE_VERSION` from `24.13.0` to `24.13.1`. Addressed in [#1473](https://github.com/cypress-io/cypress-docker-images/pull/1473).
+
 ## 7.2.2
 
 - Updated Yarn v1 Classic PGP signing key retrieval to avoid failure. Addresses [#1469](https://github.com/cypress-io/cypress-docker-images/pull/1469).


### PR DESCRIPTION
## Situation

- Node.js released an update [Node.js v24.13.1 LTS](https://nodejs.org/en/blog/release/v24.13.1) on Feb 10, 2026.

## Change

In [factory/.env](https://github.com/cypress-io/cypress-docker-images/blob/master/factory/.env) make the following updates:

| Environment variable           | Before             | After              |
| ------------------------------ | ------------------ | ------------------ |
| `FACTORY_VERSION`              | `7.2.2`            | `7.2.3`            |
| `FACTORY_DEFAULT_NODE_VERSION` | `24.13.0`          | `24.13.1`          |
| `CHROME_VERSION`               | `144.0.7559.132-1` | no change          |
| `CHROME_FOR_TESTING_VERSION`   | `144.0.7559.133`   | `145.0.7632.46`    |
| `EDGE_VERSION`                 | `144.0.3719.104-1` | `144.0.3719.115-1` |
| `FIREFOX_VERSION`              | `147.0.3`          | no change          |
