### PR TITLE
docs: fix broken Docker multi-architecture link

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,7 +15,10 @@ We build four images: click on the image name to see the available tags with ver
 
 ## Platforms
 
-Cypress Docker images are Linux based, using the Docker image [debian:13-slim](https://hub.docker.com/_/debian) as the default base image. Each of the above listed Cypress Docker images is published with [multi-architecture](https://docs.docker.com/contribute/style/terminology/#multi-architecture--multi-arch) support for `Linux/amd64` and `Linux/arm64` platforms.
+Cypress Docker images are Linux based, using the Docker image [debian:13-slim](https://hub.docker.com/_/debian) as the default base image.
+Each of the above listed Cypress Docker images is published with
+[multi-platform](https://docs.docker.com/build/building/multi-platform/)
+support for `Linux/amd64` and `Linux/arm64` platforms.
 
 Cypress Docker images can be run as containers on Continuous Integration (CI) systems which support Docker. Cypress Docker images can also be run locally under [Docker Desktop](https://docs.docker.com/desktop/) for Mac, Linux or Windows environments.
 


### PR DESCRIPTION
## Situation

The [README > Platforms](https://github.com/cypress-io/cypress-docker-images/blob/master/README.md#platforms) documentation section contains a dead link to https://docs.docker.com/contribute/style/terminology/#multi-architecture--multi-arch

This causes `npm run check:markdown` to fail.

## Change

In the [README > Platforms](https://github.com/cypress-io/cypress-docker-images/blob/master/README.md#platforms) documentation section, change the link to https://docs.docker.com/build/building/multi-platform/ which describes "Multi-platform builds".

## Verification

```shell
npm ci
npm run check:markdown
```

No errors should be reported.
