### PR TITLE
fix(deps): update to Node.js 24.14.0

### DIFF
--- a/factory/.env
+++ b/factory/.env
@@ -11,37 +11,37 @@ BASE_IMAGE='debian:13.3-slim'
 # Node Versions: https://nodejs.org/en/download/releases/
 # master branch needs "Active LTS" version
 # use feature branch for "Maintenance LTS" or "Current" versions
-FACTORY_DEFAULT_NODE_VERSION='24.13.1'
+FACTORY_DEFAULT_NODE_VERSION='24.14.0'
 
 # Node Versions: https://nodejs.org/en/download/releases/
 NODE_VERSION="${FACTORY_DEFAULT_NODE_VERSION}"
 
 # Update the FACTORY_VERSION to deploy cypress/factory if you make changes to
 # BASE_IMAGE, FACTORY_DEFAULT_NODE_VERSION, YARN_VERSION, factory.Dockerfile or installScripts
-FACTORY_VERSION='7.2.3'
+FACTORY_VERSION='7.2.4'
 
 # Cypress officially supports the latest 3 major versions of Chrome, Firefox, and Edge only
 
 # Chrome versions: https://www.ubuntuupdates.org/package/google_chrome/stable/main/base/google-chrome-stable
 # Linux/amd64 only
 # Earlier versions of Google Chrome may no longer be available from http://dl.google.com
-CHROME_VERSION='144.0.7559.132-1'
+CHROME_VERSION='145.0.7632.116-1'
 
 # Chrome for Testing versions: https://googlechromelabs.github.io/chrome-for-testing/
 # not currently used for cypress/browsers and cypress/included images
 # Linux/amd64 only
-CHROME_FOR_TESTING_VERSION='145.0.7632.46'
+CHROME_FOR_TESTING_VERSION='145.0.7632.117'
 
 # Cypress versions: https://www.npmjs.com/package/cypress
 CYPRESS_VERSION='15.10.0'
 
 # Edge versions: https://packages.microsoft.com/repos/edge/pool/main/m/microsoft-edge-stable/
 # Linux/amd64 only
-EDGE_VERSION='144.0.3719.115-1'
+EDGE_VERSION='145.0.3800.70-1'
 
 # Firefox versions: https://download-installer.cdn.mozilla.net/pub/firefox/releases/
 # Linux/amd64 for all versions, Linux/arm64 for versions 136.0 and above
-FIREFOX_VERSION='147.0.3'
+FIREFOX_VERSION='148.0'
 
 # Geckodriver versions: https://github.com/mozilla/geckodriver/releases
 # Geckodriver documentation: https://firefox-source-docs.mozilla.org/testing/geckodriver/index.html

--- a/factory/CHANGELOG.md
+++ b/factory/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Change log
 
+## 7.2.4
+
+- Updated `FACTORY_DEFAULT_NODE_VERSION` from `24.13.1` to `24.14.0`. Addressed in [#1476](https://github.com/cypress-io/cypress-docker-images/pull/1476).
+
 ## 7.2.3
 
 - Updated `FACTORY_DEFAULT_NODE_VERSION` from `24.13.0` to `24.13.1`. Addressed in [#1473](https://github.com/cypress-io/cypress-docker-images/pull/1473).


### PR DESCRIPTION
## Situation

- Node.js released an update [Node.js v24.14.0 LTS](https://github.com/nodejs/node/releases/tag/v24.14.0) on Feb 24, 2026.

## Change

In [factory/.env](https://github.com/cypress-io/cypress-docker-images/blob/master/factory/.env) make the following updates:

| Environment variable           | Before             | After              |
| ------------------------------ | ------------------ | ------------------ |
| `FACTORY_VERSION`              | `7.2.3`            | `7.2.4`            |
| `FACTORY_DEFAULT_NODE_VERSION` | `24.13.1`          | `24.14.0`          |
| `CHROME_VERSION`               | `144.0.7559.132-1` | `145.0.7632.116-1` |
| `CHROME_FOR_TESTING_VERSION`   | `145.0.7632.46`    | `145.0.7632.117`   |
| `EDGE_VERSION`                 | `144.0.3719.115-1` | `145.0.3800.70-1`  |
| `FIREFOX_VERSION`              | `147.0.3`          | `148.0`            |
