### PR TITLE
ci: update circleci to ubuntu-2404:2026.02.20 (latest) machine image

### DIFF
--- a/circle.yml
+++ b/circle.yml
@@ -55,16 +55,13 @@ commands:
 # https://circleci.com/developer/machine/image/ubuntu-2404
 # New releases are generally announced in https://discuss.circleci.com/c/ecosystem/63
 #
-# The currently used image ubuntu-2404:2025.09.1 is described in
-# https://discuss.circleci.com/t/ubuntu-22-04-24-04-q3-edge-release-including-cuda/54106
-#
 # When updating the machine image, update also .node-version and .nvmrc to the same version of Node.js
 # used by the new machine image.
 
 jobs:
   lint:
     machine:
-      image: ubuntu-2404:2025.09.1
+      image: ubuntu-2404:2026.02.20
     steps:
       - checkout
       - run: npm ci
@@ -72,7 +69,7 @@ jobs:
       - run: npm run format:check
   check-factory-versions:
     machine:
-      image: ubuntu-2404:2025.09.1
+      image: ubuntu-2404:2026.02.20
     steps:
       - checkout
       - expand-env-file
@@ -166,7 +163,7 @@ jobs:
           working_directory: factory/test-project
   check-node-override-version:
     machine:
-      image: ubuntu-2404:2025.09.1
+      image: ubuntu-2404:2026.02.20
     steps:
       - checkout
       - expand-env-file
@@ -192,7 +189,7 @@ jobs:
           working_directory: factory/test-project
   test-image:
     machine:
-      image: ubuntu-2404:2025.09.1
+      image: ubuntu-2404:2026.02.20
     parameters:
       target:
         type: string
@@ -224,7 +221,7 @@ jobs:
 
   push:
     machine:
-      image: ubuntu-2404:2025.09.1
+      image: ubuntu-2404:2026.02.20
     parameters:
       target:
         type: string


### PR DESCRIPTION
## Situation

The currently used [CircleCI machine image](https://circleci.com/developer/images?imageType=machine) [ubuntu-2404:2025.09.1](https://circleci.com/developer/machine/image/ubuntu-2404) is based on the slightly older Ubuntu `24.04.3` LTS patch level.

The Docker version in the CircleCI image is one major version behind (`28.x` instead of `29.x`).

CircleCI provides a later image according to the list on [ubuntu-2404](https://circleci.com/developer/machine/image/ubuntu-2404)

- `ubuntu-2404:2026.02.20`

## Change

Migrate the machine image used in [circle.yml](https://github.com/cypress-io/cypress-docker-images/blob/master/circle.yml) using `ubuntu-2404:2026.02.20` which updates the components as follows:

| Image tag               | Node.js   | Docker Engine                                                   | buildx                                                           | Status  |
| ----------------------- | --------- | --------------------------------------------------------------- | ---------------------------------------------------------------- | ------- |
| `ubuntu-2404:2025.09.1` | `22.19.0` | [28.4.0](https://docs.docker.com/engine/release-notes/28/#2840) | [v0.28.0](https://github.com/docker/buildx/releases/tag/v0.28.0) | current |
| `ubuntu-2404:2026.02.20` | `22.19.0` | [29.0.0](https://docs.docker.com/engine/release-notes/29/#2900) | [v0.31.1](https://github.com/docker/buildx/releases/tag/v0.31.1) | future |

Ubuntu is updated to `24.04.4` LTS (Noble Numbat). Node.js remains unchanged at `v22.19.0`. It is a major version update for Docker Engine from `28.x` to `29.x` and a functional update from Docker Buildx [v0.28.0](https://github.com/docker/buildx/releases/tag/v0.28.0) to [v0.31.1](https://github.com/docker/buildx/releases/tag/v0.31.1).

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> CI runtime is updated to a newer CircleCI machine image (including newer Docker/buildx), which can change build/push behavior or introduce environment-specific regressions even though no application logic changes.
> 
> **Overview**
> Updates CircleCI `machine` executor image across all jobs in `circle.yml` from `ubuntu-2404:2025.09.1` to `ubuntu-2404:2026.02.20`.
> 
> This effectively refreshes the CI build environment (notably Docker Engine/buildx versions) for linting, test-image builds, and Docker publish workflows.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 5cf7825a67a53a4cfe9fa2f71433423af911586a. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->