### PR TITLE
chore: release 15.12.0

### DIFF
--- a/factory/.env
+++ b/factory/.env
@@ -25,15 +25,15 @@ FACTORY_VERSION='7.2.4'
 # Chrome versions: https://www.ubuntuupdates.org/package/google_chrome/stable/main/base/google-chrome-stable
 # Linux/amd64 only
 # Earlier versions of Google Chrome may no longer be available from http://dl.google.com
-CHROME_VERSION='145.0.7632.116-1'
+CHROME_VERSION='146.0.7680.75-1'
 
 # Chrome for Testing versions: https://googlechromelabs.github.io/chrome-for-testing/
 # not currently used for cypress/browsers and cypress/included images
 # Linux/amd64 only
-CHROME_FOR_TESTING_VERSION='145.0.7632.117'
+CHROME_FOR_TESTING_VERSION='146.0.7680.76'
 
 # Cypress versions: https://www.npmjs.com/package/cypress
-CYPRESS_VERSION='15.11.0'
+CYPRESS_VERSION='15.12.0'
 
 # Edge versions: https://packages.microsoft.com/repos/edge/pool/main/m/microsoft-edge-stable/
 # Linux/amd64 only


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Low risk: this is a version bump in `factory/.env` that affects which Cypress/Chrome binaries get baked into images, with no code logic changes.
> 
> **Overview**
> Bumps the pinned browser/tooling versions used by `cypress/factory` images: **Cypress** `15.11.0` → `15.12.0`, **Chrome** `145.x` → `146.x`, and **Chrome for Testing** `145.x` → `146.x`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit dd90eb3264cf94239f681142f5a919b7e3023104. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->