### PR TITLE
feat: update BASE_IMAGE to debian:13.4-slim (trixie)

### DIFF
--- a/factory/.env
+++ b/factory/.env
@@ -6,7 +6,7 @@
 
 # Use Debian stable release https://www.debian.org/releases/stable/
 # The Debian image cypress/factory is based on
-BASE_IMAGE='debian:13.3-slim'
+BASE_IMAGE='debian:13.4-slim'
 
 # Node Versions: https://nodejs.org/en/download/releases/
 # master branch needs "Active LTS" version
@@ -18,30 +18,30 @@ NODE_VERSION="${FACTORY_DEFAULT_NODE_VERSION}"
 
 # Update the FACTORY_VERSION to deploy cypress/factory if you make changes to
 # BASE_IMAGE, FACTORY_DEFAULT_NODE_VERSION, YARN_VERSION, factory.Dockerfile or installScripts
-FACTORY_VERSION='7.2.4'
+FACTORY_VERSION='7.3.0'
 
 # Cypress officially supports the latest 3 major versions of Chrome, Firefox, and Edge only
 
 # Chrome versions: https://www.ubuntuupdates.org/package/google_chrome/stable/main/base/google-chrome-stable
 # Linux/amd64 only
 # Earlier versions of Google Chrome may no longer be available from http://dl.google.com
-CHROME_VERSION='146.0.7680.75-1'
+CHROME_VERSION='146.0.7680.80-1'
 
 # Chrome for Testing versions: https://googlechromelabs.github.io/chrome-for-testing/
 # not currently used for cypress/browsers and cypress/included images
 # Linux/amd64 only
-CHROME_FOR_TESTING_VERSION='146.0.7680.76'
+CHROME_FOR_TESTING_VERSION='146.0.7680.80'
 
 # Cypress versions: https://www.npmjs.com/package/cypress
 CYPRESS_VERSION='15.12.0'
 
 # Edge versions: https://packages.microsoft.com/repos/edge/pool/main/m/microsoft-edge-stable/
 # Linux/amd64 only
-EDGE_VERSION='145.0.3800.70-1'
+EDGE_VERSION='146.0.3856.62-1'
 
 # Firefox versions: https://download-installer.cdn.mozilla.net/pub/firefox/releases/
 # Linux/amd64 for all versions, Linux/arm64 for versions 136.0 and above
-FIREFOX_VERSION='148.0'
+FIREFOX_VERSION='148.0.2'
 
 # Geckodriver versions: https://github.com/mozilla/geckodriver/releases
 # Geckodriver documentation: https://firefox-source-docs.mozilla.org/testing/geckodriver/index.html

--- a/factory/CHANGELOG.md
+++ b/factory/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Change log
 
+## 7.3.0
+
+- Updated Debian `BASE_IMAGE` from `debian:13.3-slim` to `debian:13.4-slim` using [Debian 13.4 (trixie)](https://www.debian.org/releases/trixie/). Addressed in [#1483](https://github.com/cypress-io/cypress-docker-images/issues/1483).
+
 ## 7.2.4
 
 - Updated `FACTORY_DEFAULT_NODE_VERSION` from `24.13.1` to `24.14.0`. Addressed in [#1476](https://github.com/cypress-io/cypress-docker-images/pull/1476).


### PR DESCRIPTION
## Situation

Cypress Docker images built from [factory/.env](https://github.com/cypress-io/cypress-docker-images/blob/master/factory/.env) currently use `BASE_IMAGE='debian:13.3-slim'`. [Debian 13.4 (trixie)](https://www.debian.org/releases/trixie/), which was [released](https://www.debian.org/News/2026/20260314) on Mar 14, 2026, supersedes Debian 13.3 (trixie).

## Change

Update the base image for `cypress/factory` to use [Debian 13.4 (trixie)](https://www.debian.org/releases/trixie/).

The environment variables in [factory/.env](https://github.com/cypress-io/cypress-docker-images/blob/master/factory/.env) that control the default build process, are updated as follows:

| Environment variable           | Before             | After              |
| ------------------------------ | ------------------ | ------------------ |
| `BASE_IMAGE`                   | `debian:13.3-slim` | `debian:13.4-slim` |
| `FACTORY_VERSION`              | `7.2.4`            | `7.3.0`            |
| `FACTORY_DEFAULT_NODE_VERSION` | `24.14.0`          | no change          |
| `CYPRESS_VERSION`              | `15.12.0`          | no change          |
| `CHROME_VERSION`               | `146.0.7680.75-1`  | `146.0.7680.80-1`  |
| `CHROME_FOR_TESTING_VERSION`   | `146.0.7680.76`    | `146.0.7680.80`    |
| `EDGE_VERSION`                 | `145.0.3800.70-1`  | `146.0.3856.62-1`  |
| `FIREFOX_VERSION`              | `148.0`            | `148.0.2`          |
| `GECKODRIVER_VERSION`          | `0.36.0`           | no change          |

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Medium risk because it changes the underlying OS and browser versions used to build `cypress/factory`, which can affect package availability and runtime behavior despite being a straightforward version bump.
> 
> **Overview**
> Updates `factory/.env` to build `cypress/factory` on **Debian `13.4-slim`** (from `13.3-slim`) and bumps `FACTORY_VERSION` to `7.3.0`.
> 
> Refreshes pinned browser versions used in derived images (`CHROME_VERSION`, `CHROME_FOR_TESTING_VERSION`, `EDGE_VERSION`, `FIREFOX_VERSION`) and records the release in `factory/CHANGELOG.md`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 6359479c96e77d183600292c378aafcdfd37520b. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->