### PR TITLE
chore: add Renovate configuration

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -1,0 +1,22 @@
+{
+  "configMigration": true,
+  "dependencyDashboard": true,
+  "extends": ["config:recommended"],
+  "automerge": true,
+  "major": {
+    "automerge": false
+  },
+  "prConcurrentLimit": 3,
+  "prHourlyLimit": 2,
+  "rangeStrategy": "bump",
+  "lockFileMaintenance": {
+    "enabled": true
+  },
+  "labels": ["type: dependencies", "renovate"],
+  "packageRules": [
+    {
+      "matchPackageNames": ["/eslint/", "globals"],
+      "groupName": "eslint"
+    }
+  ]
+}


### PR DESCRIPTION
## Situation

This repo uses npm modules in `devDependencies` for linting. Increasing numbers of vulnerabilities being reported mean that dependency updates are needed more often to mitigate against vulnerabilities in the repo.

The same is true for `devDependencies` in the [examples](https://github.com/cypress-io/cypress-docker-images/tree/master/examples) directories.

Manual updates are labor-intensive and can cause delays.

Renovate is already used in several other Cypress repos to automate creating update PRs to keep dependencies up-to-date, to take advantage of fixes, vulnerability mitigations and added features.

https://developer.mend.io/github/cypress-io does not currently show this repo as enabled for Renovate.

## Change

Add a `renovate.json` configuration (see https://docs.renovatebot.com/config-overview/)

### Configuration Notes

Reference https://docs.renovatebot.com/config-overview/

- extend from [config:recommended](https://docs.renovatebot.com/presets-config/#configrecommended), note that this includes
[:ignoreModulesAndTests](https://docs.renovatebot.com/presets-default/#ignoremodulesandtests) with `ignorePaths` for `"**/examples/**"`. Path selection may be changed in a follow-on PR to include `examples`.

- allow [automerge](https://docs.renovatebot.com/configuration-options/#automerge) except for major version updates. Note that with branch protection rules, this still means that each PR needs to be manually approved before Renovate automerges. Major version updates require the extra step of being manually merged after having been approved.

- ci tests run in CircleCI using the [circle.yml](https://github.com/cypress-io/eslint-plugin-cypress/blob/master/circle.yml) configuration. These tests run multiple parallel versions of the full Cypress scaffolded tests and they are susceptible to rate-limiting on `cypress.io`. The [prConcurrentLimit](https://docs.renovatebot.com/configuration-options/#prconcurrentlimit) (default 10) is set to 3 for this reason, together with a [prHourlyLimit](https://docs.renovatebot.com/configuration-options/#prhourlylimit) setting using the default value of 2.

- [rangeStrategy](https://docs.renovatebot.com/configuration-options/#rangestrategy) set to `bump` will bump the range. For example `"eslint": "^10.0.2"` would be bumped to `"eslint": "^10.0.3"`.

- [lockfilemaintenance](https://docs.renovatebot.com/configuration-options/#lockfilemaintenance) runs by default once a week on Mondays

- [labels](https://docs.renovatebot.com/configuration-options/#labels) specified are `type: dependencies` and `renovate` as used in other Cypress repos. These labels do not currently exist in this repo and need to be added.

- ESlint-related dependencies are grouped together. Especially `eslint` and `@eslint/js` are often updated together, and this reduces the number of generated PRs. `globals` is also related to `eslint` and grouped together.

## Verification

```shell
npx --yes --package renovate -- renovate-config-validator
```

## Additional steps

The following tasks need to be carried out by the Cypress.io team in addition to this PR. They require corresponding write privileges:

- Enable Renovate and check the https://developer.mend.io/github/cypress-io dashboard.

- Add labels `type: dependencies` & `renovate` to the repo.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: adds only Renovate configuration with no runtime code changes; primary impact is increased automated dependency update PR activity.
> 
> **Overview**
> Adds `renovate.json` to enable Renovate with `config:recommended`, a dependency dashboard, and **automerge for non-major updates**.
> 
> Limits Renovate PR volume (`prConcurrentLimit`, `prHourlyLimit`), enables lockfile maintenance, applies dependency labels, and groups ESLint-related packages via `packageRules`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 5f9fddb803be99b6f9ecdc8b4069511265401d26. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->