### PR TITLE
chore: release v15.13.0

### DIFF
--- a/factory/.env
+++ b/factory/.env
@@ -25,23 +25,23 @@ FACTORY_VERSION='7.3.0'
 # Chrome versions: https://www.ubuntuupdates.org/package/google_chrome/stable/main/base/google-chrome-stable
 # Linux/amd64 only
 # Earlier versions of Google Chrome may no longer be available from http://dl.google.com
-CHROME_VERSION='146.0.7680.80-1'
+CHROME_VERSION='146.0.7680.164-1'
 
 # Chrome for Testing versions: https://googlechromelabs.github.io/chrome-for-testing/
 # not currently used for cypress/browsers and cypress/included images
 # Linux/amd64 only
-CHROME_FOR_TESTING_VERSION='146.0.7680.80'
+CHROME_FOR_TESTING_VERSION='146.0.7680.165'
 
 # Cypress versions: https://www.npmjs.com/package/cypress
-CYPRESS_VERSION='15.12.0'
+CYPRESS_VERSION='15.13.0'
 
 # Edge versions: https://packages.microsoft.com/repos/edge/pool/main/m/microsoft-edge-stable/
 # Linux/amd64 only
-EDGE_VERSION='146.0.3856.62-1'
+EDGE_VERSION='146.0.3856.72-1'
 
 # Firefox versions: https://download-installer.cdn.mozilla.net/pub/firefox/releases/
 # Linux/amd64 for all versions, Linux/arm64 for versions 136.0 and above
-FIREFOX_VERSION='148.0.2'
+FIREFOX_VERSION='149.0'
 
 # Geckodriver versions: https://github.com/mozilla/geckodriver/releases
 # Geckodriver documentation: https://firefox-source-docs.mozilla.org/testing/geckodriver/index.html


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Low risk: only updates pinned version strings for Cypress and bundled browsers in `factory/.env`, with no code or logic changes. Main risk is CI/Docker image behavior shifting due to upstream browser/Cypress version changes.
> 
> **Overview**
> Updates `factory/.env` to release Cypress `15.13.0` and refresh pinned browser versions (Chrome/Chrome-for-Testing, Edge, Firefox) used by the `cypress/factory`-derived Docker images.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit c318c6aea49a2f82f6f222d3c41754799fc4d5d2. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->