### PR TITLE
fix(deps): update to Node.js 24.14.1

### DIFF
--- a/factory/.env
+++ b/factory/.env
@@ -11,14 +11,14 @@ BASE_IMAGE='debian:13.4-slim'
 # Node Versions: https://nodejs.org/en/download/releases/
 # master branch needs "Active LTS" version
 # use feature branch for "Maintenance LTS" or "Current" versions
-FACTORY_DEFAULT_NODE_VERSION='24.14.0'
+FACTORY_DEFAULT_NODE_VERSION='24.14.1'
 
 # Node Versions: https://nodejs.org/en/download/releases/
 NODE_VERSION="${FACTORY_DEFAULT_NODE_VERSION}"
 
 # Update the FACTORY_VERSION to deploy cypress/factory if you make changes to
 # BASE_IMAGE, FACTORY_DEFAULT_NODE_VERSION, YARN_VERSION, factory.Dockerfile or installScripts
-FACTORY_VERSION='7.3.0'
+FACTORY_VERSION='7.3.1'
 
 # Cypress officially supports the latest 3 major versions of Chrome, Firefox, and Edge only
 

--- a/factory/CHANGELOG.md
+++ b/factory/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Change log
 
+## 7.3.1
+
+- Updated `FACTORY_DEFAULT_NODE_VERSION` from `24.14.0` to `24.14.1`. Addressed in [#1486](https://github.com/cypress-io/cypress-docker-images/pull/1486).
+
 ## 7.3.0
 
 - Updated Debian `BASE_IMAGE` from `debian:13.3-slim` to `debian:13.4-slim` using [Debian 13.4 (trixie)](https://www.debian.org/releases/trixie/). Addressed in [#1483](https://github.com/cypress-io/cypress-docker-images/issues/1483).


### PR DESCRIPTION
## Situation

- Node.js released a security update [Node.js v24.14.1 LTS](https://github.com/nodejs/node/releases/tag/v24.14.1) on Mar 24, 2026.

## Change

In [factory/.env](https://github.com/cypress-io/cypress-docker-images/blob/master/factory/.env) make the following updates:

| Environment variable           | Before            | After              |
| ------------------------------ | ----------------- | ------------------ |
| `FACTORY_VERSION`              | `7.3.0`           | `7.3.1`            |
| `FACTORY_DEFAULT_NODE_VERSION` | `24.14.0`         | `24.14.1`          |

No change to browser versions

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk version bump limited to `factory/.env` and changelog updates; the main impact is a new `cypress/factory` release/tag and any downstream image rebuild behavior.
> 
> **Overview**
> Updates `cypress/factory` to use Node.js `24.14.1` by bumping `FACTORY_DEFAULT_NODE_VERSION` in `factory/.env` and increments `FACTORY_VERSION` to `7.3.1` to trigger a new factory image release.
> 
> Adds a `7.3.1` entry to `factory/CHANGELOG.md` documenting the Node.js update.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 932518f8a2ebb707583d459e2053dfe384e064d1. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->