### PR TITLE
feat: deprecate YARN_VERSION usage in cypress/factory

### DIFF
--- a/factory/.env
+++ b/factory/.env
@@ -18,7 +18,7 @@ NODE_VERSION="${FACTORY_DEFAULT_NODE_VERSION}"
 
 # Update the FACTORY_VERSION to deploy cypress/factory if you make changes to
 # BASE_IMAGE, FACTORY_DEFAULT_NODE_VERSION, YARN_VERSION, factory.Dockerfile or installScripts
-FACTORY_VERSION='7.3.1'
+FACTORY_VERSION='7.4.0'
 
 # Cypress officially supports the latest 3 major versions of Chrome, Firefox, and Edge only
 
@@ -49,9 +49,13 @@ FIREFOX_VERSION='149.0'
 # Minimum version is 0.34.0
 GECKODRIVER_VERSION='0.36.0'
 
-# Yarn versions: https://www.npmjs.com/package/yarn and
-# Yarn v1 Classic only https://classic.yarnpkg.com/latest-version
-# Yarn Modern (versions 2 and above) are not supported https://yarnpkg.com/
+# Yarn v1 Classic:
+# https://classic.yarnpkg.com/latest-version
+# https://www.npmjs.com/package/yarn
+# is frozen and unsupported since January 2020 https://github.com/yarnpkg/yarn
+# Using YARN_VERSION for custom builds of Cypress Docker images is deprecated
+#
+# Yarn versions >= 2 are not supported
 YARN_VERSION='1.22.22'
 
 # Webkit versions: https://www.npmjs.com/package/playwright-webkit

--- a/factory/CHANGELOG.md
+++ b/factory/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Change log
 
+## 7.4.0
+
+- Yarn v1 Classic was [frozen](https://github.com/yarnpkg/yarn) in January 2020 with no further support or plans for new releases.
+  Use of the parameter `YARN_VERSION` to include Yarn v1 Classic in custom Docker images
+  is deprecated and support will be removed in a future [cypress/factory](../factory/README.md) major release.
+  Addressed in [#1490](https://github.com/cypress-io/cypress-docker-images/pull/1490).
+
 ## 7.3.1
 
 - Updated `FACTORY_DEFAULT_NODE_VERSION` from `24.14.0` to `24.14.1`. Addressed in [#1486](https://github.com/cypress-io/cypress-docker-images/pull/1486).

--- a/factory/README.md
+++ b/factory/README.md
@@ -50,7 +50,7 @@ Example: `NODE_VERSION='20.14.0'`
 
 ### YARN_VERSION
 
-The version of Yarn v1 Classic to install (via npm). If the `ARG` variable is unset or an empty string, Yarn is not installed.
+The version of Yarn v1 Classic to install. If the `ARG` variable is unset or an empty string, Yarn is not installed.
 
 Example: `YARN_VERSION='1.22.22'`
 

--- a/factory/README.md
+++ b/factory/README.md
@@ -3,7 +3,7 @@
 [`cypress/factory`](https://hub.docker.com/r/cypress/factory) is a Docker image that can be used with [`ARG`](https://docs.docker.com/reference/dockerfile/#arg) instructions in a custom-built [`Dockerfile`](https://docs.docker.com/reference/dockerfile/) to generate a new Docker image with specific versions of:
 
 - Node.js
-- Yarn v1 Classic
+- Yarn v1 Classic (deprecated)
 - Chrome
 - Chrome for Testing
 - Firefox
@@ -54,10 +54,16 @@ The version of Yarn v1 Classic to install (via npm). If the `ARG` variable is un
 
 Example: `YARN_VERSION='1.22.22'`
 
-[Yarn v1 versions](https://www.npmjs.com/package/yarn)
+[Yarn v1 Classic](https://classic.yarnpkg.com/) is
+[frozen and unsupported](https://github.com/yarnpkg/yarn).
+Use of `YARN_VERSION` to add Yarn v1 Classic to Cypress Docker images is deprecated.
+Support will be removed in a future `cypress/factory` major release.
 
 [Yarn Modern](https://yarnpkg.com/) (versions 2 and above) are not supported.
-They are not currently published to the npm registry and require the experimental [Corepack](https://yarnpkg.com/corepack) to [install](https://yarnpkg.com/getting-started/install).
+They are not currently published to the
+[npm registry](https://www.npmjs.com/) and require the experimental
+[Corepack](https://yarnpkg.com/corepack) to
+[install](https://yarnpkg.com/getting-started/install).
 
 ### CYPRESS_VERSION
 

--- a/factory/factory.Dockerfile
+++ b/factory/factory.Dockerfile
@@ -85,10 +85,6 @@ ONBUILD RUN bash /opt/installScripts/node/install-node-version.sh ${APPLIED_FACT
 # Install Yarn: Optional
 ONBUILD ARG YARN_VERSION
 
-# DEPRECATED: Yarn v1 Classic
-ONBUILD ENV YARN_DEPRECATION=${YARN_VERSION:+'**Build support for YARN_VERSION is DEPRECATED and will be removed in a future cypress/factory major release**'}
-ONBUILD RUN echo ${YARN_DEPRECATION}
-
 # Installed using a node script to handle conditionals since we all know javascript
 ONBUILD RUN node /opt/installScripts/yarn/install-yarn-version.js ${YARN_VERSION}
 

--- a/factory/factory.Dockerfile
+++ b/factory/factory.Dockerfile
@@ -85,6 +85,10 @@ ONBUILD RUN bash /opt/installScripts/node/install-node-version.sh ${APPLIED_FACT
 # Install Yarn: Optional
 ONBUILD ARG YARN_VERSION
 
+# DEPRECATED: Yarn v1 Classic
+ONBUILD ENV YARN_DEPRECATION=${YARN_VERSION:+'**Build support for YARN_VERSION is DEPRECATED and will be removed in a future cypress/factory major release**'}
+ONBUILD RUN echo ${YARN_DEPRECATION}
+
 # Installed using a node script to handle conditionals since we all know javascript
 ONBUILD RUN node /opt/installScripts/yarn/install-yarn-version.js ${YARN_VERSION}
 

--- a/factory/installScripts/yarn/install-yarn-version.js
+++ b/factory/installScripts/yarn/install-yarn-version.js
@@ -13,6 +13,11 @@ if (yarnVersion >= '2') {
   process.exit(1)
 }
 
+console.log(
+  'WARNING: Build support for YARN_VERSION in custom Cypress Docker images is DEPRECATED\n'
+  + 'Support will be removed in a future major release of cypress/factory\n'
+  + 'Proceeding with installation...',
+)
 console.log('Installing Yarn version: ', yarnVersion)
 
 // Insert logic here if needed to run a different install script based on version.


### PR DESCRIPTION
- relates to issue https://github.com/cypress-io/cypress-docker-images/issues/1438

## Situation

- The [cypress/factory](https://github.com/cypress-io/cypress-docker-images/tree/master/factory) image allows the selection of any Yarn v1 Classic version using `YARN_VERSION` for custom Cypress image building.

- Yarn v1 Classic was [frozen](https://github.com/yarnpkg/yarn) in Jan 2020 with no further support or plans for new releases. It is untested in currently supported Node.js versions `>=20`.

- The PGP signing key [6A010C5166006599AA17F08146C2130DFD2497F5](https://keyserver.ubuntu.com/pks/lookup?search=6A010C5166006599AA17F08146C2130DFD2497F5&fingerprint=on&op=index) expires in January 2030 and will cause installation to then fail. There is no expectation that this key will be renewed. By this date, Yarn v1 Classic will have been unsupported for a full 10 years.

- Remaining legacy needs for Yarn v1 Classic can be met by using `npm install --global yarn` as described in https://classic.yarnpkg.com/en/docs/install

## Change

- Mark `YARN_VERSION` as deprecated in the [factory/README.md](https://github.com/cypress-io/cypress-docker-images/blob/master/factory/README.md) document.
- Add a build-time deprecation notice for Yarn v1 addressed to users of `cypress/factory` who are continuing to build custom images using `YARN_VERSION`.

| Environment variable           | Before             | After              |
| ------------------------------ | ------------------ | ------------------ |
| `FACTORY_VERSION`              | `7.3.1`            | `7.4.0`            |

## User impact

This is a runtime deprecation only. Apart from deprecation warnings in Docker build log files, no other change in usage.
## Verification

Execute:

```shell
cd factory
docker compose build factory
unset YARN_VERSION # for repeat testing
docker compose --progress plain build base --no-cache # no cache, also for repeats
cd ..
```

Logs include output similar to the following:

```text
#7 [default_image  3/21] ONBUILD RUN node /opt/installScripts/yarn/install-yarn-version.js 1.22.22
#7 0.195 WARNING: Build support for YARN_VERSION in custom Cypress Docker images is DEPRECATED
#7 0.195 Support will be removed in a future major release of cypress/factory
#7 0.195 Proceeding with installation...
#7 0.196 Installing Yarn version:  1.22.22
```

Execute:

```shell
cd factory
export YARN_VERSION=""
docker compose --progress plain build base --no-cache # # no cache, also for repeats
cd ..
```

and confirm that Yarn installation is skipped with no related deprecation warning:

```text
#7 [default_image  3/21] ONBUILD RUN node /opt/installScripts/yarn/install-yarn-version.js
#7 0.264 No Yarn version provided, skipping Yarn install
#7 DONE 0.3s
```

## Next steps

Submit PR to propose disallowing use of `YARN_VERSION` with `NODE_VERSION` set to `>=26`, effectively removing Yarn v1 Classic from custom and regular builds with Node.js 26 and above. Node.js 26.0.0 is planned for release on 2026-04-22.


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: changes are limited to documentation/version metadata and a build-time warning during Yarn v1 installation, with no change to the actual install path beyond added logging.
> 
> **Overview**
> Marks `YARN_VERSION` (Yarn v1 Classic) as **deprecated** for `cypress/factory` custom builds and documents the upcoming removal of support.
> 
> Adds a build-time deprecation warning in `install-yarn-version.js` when a Yarn version is provided, updates `.env` commentary around Yarn, bumps `FACTORY_VERSION` to `7.4.0`, and records the change in `factory/CHANGELOG.md`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 9301f304f8a18e765caa4f65c6381002da604e11. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->