### PR TITLE
fix(deps): pin typescript to v5 for cypress install

### DIFF
--- a/factory/.env
+++ b/factory/.env
@@ -18,26 +18,26 @@ NODE_VERSION="${FACTORY_DEFAULT_NODE_VERSION}"
 
 # Update the FACTORY_VERSION to deploy cypress/factory if you make changes to
 # BASE_IMAGE, FACTORY_DEFAULT_NODE_VERSION, YARN_VERSION, factory.Dockerfile or installScripts
-FACTORY_VERSION='7.3.1'
+FACTORY_VERSION='7.4.1'
 
 # Cypress officially supports the latest 3 major versions of Chrome, Firefox, and Edge only
 
 # Chrome versions: https://www.ubuntuupdates.org/package/google_chrome/stable/main/base/google-chrome-stable
 # Linux/amd64 only
 # Earlier versions of Google Chrome may no longer be available from http://dl.google.com
-CHROME_VERSION='146.0.7680.164-1'
+CHROME_VERSION='146.0.7680.177-1'
 
 # Chrome for Testing versions: https://googlechromelabs.github.io/chrome-for-testing/
 # not currently used for cypress/browsers and cypress/included images
 # Linux/amd64 only
-CHROME_FOR_TESTING_VERSION='146.0.7680.165'
+CHROME_FOR_TESTING_VERSION='147.0.7727.50'
 
 # Cypress versions: https://www.npmjs.com/package/cypress
 CYPRESS_VERSION='15.13.0'
 
 # Edge versions: https://packages.microsoft.com/repos/edge/pool/main/m/microsoft-edge-stable/
 # Linux/amd64 only
-EDGE_VERSION='146.0.3856.72-1'
+EDGE_VERSION='146.0.3856.97-1'
 
 # Firefox versions: https://download-installer.cdn.mozilla.net/pub/firefox/releases/
 # Linux/amd64 for all versions, Linux/arm64 for versions 136.0 and above

--- a/factory/CHANGELOG.md
+++ b/factory/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Change log
 
+## 7.4.1
+
+- Modified Cypress installation script to install typescript@5 instead of typescript@latest. Addresses [#1491](https://github.com/cypress-io/cypress-docker-images/issues/1491).
+
 ## 7.3.1
 
 - Updated `FACTORY_DEFAULT_NODE_VERSION` from `24.14.0` to `24.14.1`. Addressed in [#1486](https://github.com/cypress-io/cypress-docker-images/pull/1486).

--- a/factory/README.md
+++ b/factory/README.md
@@ -61,11 +61,15 @@ They are not currently published to the npm registry and require the experimenta
 
 ### CYPRESS_VERSION
 
-The version of Cypress to install (via npm). If the `ARG` variable is unset or an empty string, Cypress is not installed.
+The version of Cypress to install (globally via npm). If the `ARG` variable is unset or an empty string, Cypress is not installed.
 
 Example: `CYPRESS_VERSION='15.1.0'`
 
 [Cypress versions](https://www.npmjs.com/package/cypress)
+
+If the `ARG` variable is set, then
+[typescript@5](https://www.npmjs.com/package/typescript) is also installed (globally via npm)
+to allow running tests written in TypeScript (see [Cypress TypeScript Support](https://on.cypress.io/typescript)).
 
 ### CHROME_VERSION
 

--- a/factory/installScripts/cypress/install.sh
+++ b/factory/installScripts/cypress/install.sh
@@ -1,17 +1,18 @@
 #! /bin/bash
 set -e
-# TODO: should typescript be versioned? Should it have it's own ARG for the factory?
+# TODO: Should typescript have its own ARG for the factory?
 # Typescript is installed to allow testing of .ts spec files.
 if [[ -n "$1" ]]; then
-  npm install -g "cypress@$1" typescript
+  npm install -g "cypress@$1" typescript@5
+  echo "Installed TypeScript $(tsc --version)"
 
-  # Loosen file priveleges for the cypress cache. The first time that cypress runs it will create a
+  # Loosen file privileges for the cypress cache. The first time that cypress runs it will create a
   # binary_state.json file if it hasn't already been created. This was causing issues with non-root
-  # users, they do not have access to write to this directory. Since this is a develompent docker container
-  # and to lower barriers as much as possible, we are loosening privs to allow the binary_state.json file
+  # users who do not have access to write to this directory. Since this is a development docker container
+  # and to lower barriers as much as possible, we are loosening privileges to allow the binary_state.json file
   # to be created. Previously this file was created by root when cypress verify was called, but this would
   # apply to amd processors since cypress verify was not called on arm processors.
   chmod -R 777 /root/.cache
 else
-  echo 'No Cypress version provided; skipping install.' 
+  echo 'No Cypress version provided, skipping Cypress install'
 fi


### PR DESCRIPTION
- closes https://github.com/cypress-io/cypress-docker-images/issues/1491

## Situation

- The Cypress installation script [factory/installScripts/cypress/install.sh](https://github.com/cypress-io/cypress-docker-images/blob/master/factory/installScripts/cypress/install.sh) installs also the latest version of [typescript](https://www.npmjs.com/package/typescript), which is currently `6.0.2`
- The installation script is used to build `cypress/included` images and for custom images
- At this time, Cypress is compatible with only TypeScript 5.x (see https://docs.cypress.io/app/tooling/typescript-support#Install-TypeScript) and https://github.com/cypress-io/cypress/issues/33511

## Change

In [factory/installScripts/cypress/install.sh](https://github.com/cypress-io/cypress-docker-images/blob/master/factory/installScripts/cypress/install.sh)

- pin to `typescript@5`
- add log for version of TypeScript installed
- correct typos
- align message text to other installation scripts

Update browsers to latest

| Environment variable           | Before           | After            |
| ------------------------------ | ---------------- | ---------------- |
| `FACTORY_VERSION`              | ???              | 7.4.1            |
| `FACTORY_DEFAULT_NODE_VERSION` | 24.14.1          | no change        |
| `CYPRESS_VERSION`              | 15.13.0          | no change        |
| `CHROME_VERSION`               | 146.0.7680.164-1 | 146.0.7680.177-1 |
| `CHROME_FOR_TESTING_VERSION`   | 146.0.7680.165   | 147.0.7727.50    |
| `EDGE_VERSION`                 | 146.0.3856.72-1  | 146.0.3856.97-1  |
| `FIREFOX_VERSION`              | 149.0            | no change        |
| `GECKODRIVER_VERSION`          | 0.36.0           | no change        |

## Verification

```shell
cd factory
docker compose build factory
docker compose build included
docker run --rm --entrypoint bash cypress/included -c "npm ls -g"
```

TypeScript should be listed as 5.x, not 6, for example [typescript@5.9.3](https://github.com/microsoft/TypeScript/releases/tag/v5.9.3), released Oct 1, 2025. See [typescript releases](https://github.com/microsoft/TypeScript/releases)

In CirclceCI, check job `test-image-medium-included-test-included-electron`, step `building docker image`.

Confirm log:

> Installed TypeScript Version 5.9.3

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes the global dependency versions baked into built Docker images (TypeScript and browser versions), which could affect downstream builds and runtime behavior, but is limited in scope to image/version configuration.
> 
> **Overview**
> Pins the Cypress factory install script to globally install `typescript@5` (instead of the latest) and logs the installed TypeScript version, along with minor message/typo cleanup.
> 
> Bumps the factory release to `7.4.1` and updates bundled browser version pins (Chrome/Chrome-for-Testing/Edge), and records the change in `CHANGELOG.md`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 5a3d7ee1d806bf41827dace504ff818b0b776fb7. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->