### PR TITLE
chore: bump cypress to 15.13.1 and bump browsers to latest

### DIFF
--- a/factory/.env
+++ b/factory/.env
@@ -25,23 +25,23 @@ FACTORY_VERSION='7.3.1'
 # Chrome versions: https://www.ubuntuupdates.org/package/google_chrome/stable/main/base/google-chrome-stable
 # Linux/amd64 only
 # Earlier versions of Google Chrome may no longer be available from http://dl.google.com
-CHROME_VERSION='146.0.7680.164-1'
+CHROME_VERSION='146.0.7680.177-1'
 
 # Chrome for Testing versions: https://googlechromelabs.github.io/chrome-for-testing/
 # not currently used for cypress/browsers and cypress/included images
 # Linux/amd64 only
-CHROME_FOR_TESTING_VERSION='146.0.7680.165'
+CHROME_FOR_TESTING_VERSION='147.0.7727.55'
 
 # Cypress versions: https://www.npmjs.com/package/cypress
-CYPRESS_VERSION='15.13.0'
+CYPRESS_VERSION='15.13.1'
 
 # Edge versions: https://packages.microsoft.com/repos/edge/pool/main/m/microsoft-edge-stable/
 # Linux/amd64 only
-EDGE_VERSION='146.0.3856.72-1'
+EDGE_VERSION='146.0.3856.97-1'
 
 # Firefox versions: https://download-installer.cdn.mozilla.net/pub/firefox/releases/
 # Linux/amd64 for all versions, Linux/arm64 for versions 136.0 and above
-FIREFOX_VERSION='149.0'
+FIREFOX_VERSION='149.0.2'
 
 # Geckodriver versions: https://github.com/mozilla/geckodriver/releases
 # Geckodriver documentation: https://firefox-source-docs.mozilla.org/testing/geckodriver/index.html


### PR DESCRIPTION
Bumps browsers to latest and Cypress to `15.13.1`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk version bumps in `factory/.env`, but may change Docker image build outputs and browser/Cypress compatibility in CI.
> 
> **Overview**
> Updates `factory/.env` to bump pinned runtime versions: Cypress to `15.13.1`, Chrome/Chrome-for-Testing, Edge, and Firefox to their latest stable patch releases.
> 
> No logic changes; this primarily affects the versions baked into the `cypress/factory`-derived Docker images and therefore the test environment in CI.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 01e5ea9f4a2ff0470da4ca6402d8a8c9d1f30710. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->