### PR TITLE
feat: disallow YARN_VERSION with NODE_VERSION 26 and above

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,6 +24,14 @@ Cypress Docker images can be run as containers on Continuous Integration (CI) sy
 
 In the case of Windows environments, see [Docker Desktop for Windows](https://docs.docker.com/desktop/install/windows-install/) and Cypress documentation [Windows Subsystem for Linux](https://on.cypress.io/guides/references/advanced-installation#Windows-Subsystem-for-Linux) for additional information regarding Microsoft's `WSL2` and `WSLg` subsystems. The documentation and scripts in this repository assume that Docker Desktop for Windows runs in a virtual Linux environment.
 
+## Component bundles
+
+`cypress/base`, `cypress/browsers` and `cypress/included` include the following components:
+
+- Node.js (see [Node.js distribution policy](https://github.com/nodejs/node/blob/main/doc/contributing/distribution.md) for bundled components)
+- [corepack](https://github.com/nodejs/corepack) through Node.js - dropped in Node.js 25 and above
+- [Yarn v1 Classic](https://github.com/yarnpkg/yarn) installed globally with npm - dropped in Node.js 26 and above
+
 ## Browsers
 
 Cypress Docker images [cypress/browsers](./browsers/) include browsers for the `Linux/amd64` and the `Linux/arm64` platform according to browser availability as shown in the following table.

--- a/factory/.env
+++ b/factory/.env
@@ -18,7 +18,7 @@ NODE_VERSION="${FACTORY_DEFAULT_NODE_VERSION}"
 
 # Update the FACTORY_VERSION to deploy cypress/factory if you make changes to
 # BASE_IMAGE, FACTORY_DEFAULT_NODE_VERSION, YARN_VERSION, factory.Dockerfile or installScripts
-FACTORY_VERSION='7.4.0'
+FACTORY_VERSION='8.0.0'
 
 # Cypress officially supports the latest 3 major versions of Chrome, Firefox, and Edge only
 
@@ -53,7 +53,9 @@ GECKODRIVER_VERSION='0.36.0'
 # https://classic.yarnpkg.com/latest-version
 # https://www.npmjs.com/package/yarn
 # is frozen and unsupported since January 2020 https://github.com/yarnpkg/yarn
-# Using YARN_VERSION for custom builds of Cypress Docker images is deprecated
+# Using YARN_VERSION
+# - for custom builds of Cypress Docker images is deprecated
+# - with NODE_VERSION 26.0.0 or higher is disallowed
 #
 # Yarn versions >= 2 are not supported
 YARN_VERSION='1.22.22'

--- a/factory/CHANGELOG.md
+++ b/factory/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Change log
 
+## 8.0.0
+
+- `YARN_VERSION` is disallowed when `NODE_VERSION` is set to `>=26`. Addresses [#1495](https://github.com/cypress-io/cypress-docker-images/pull/1495).
+
 ## 7.4.0
 
 - Yarn v1 Classic was [frozen](https://github.com/yarnpkg/yarn) in January 2020 with no further support or plans for new releases.

--- a/factory/README.md
+++ b/factory/README.md
@@ -56,7 +56,8 @@ Example: `YARN_VERSION='1.22.22'`
 
 [Yarn v1 Classic](https://classic.yarnpkg.com/) is
 [frozen and unsupported](https://github.com/yarnpkg/yarn).
-Use of `YARN_VERSION` to add Yarn v1 Classic to Cypress Docker images is deprecated.
+Use of `YARN_VERSION` to add Yarn v1 Classic to Cypress Docker images is deprecated
+for `NODE_VERSION<26` and disallowed for `NODE_VERSION>=26`.
 Support will be removed in a future `cypress/factory` major release.
 
 [Yarn Modern](https://yarnpkg.com/) (versions 2 and above) are not supported.

--- a/factory/installScripts/yarn/install-yarn-version.js
+++ b/factory/installScripts/yarn/install-yarn-version.js
@@ -8,8 +8,19 @@ if (!yarnVersion) {
   process.exit(0)
 }
 
-if (yarnVersion >= '2') {
+const yarnMajorVersion = parseInt(yarnVersion.split('.')[0])
+if (yarnMajorVersion >= 2) {
   console.log(`Yarn ${yarnVersion} is not supported, Yarn installation failed`)
+  process.exit(1)
+}
+
+const YARN_DISALLOW_NODE_VERSION = 26
+const nodeMajorVersion = parseInt(process.versions.node.split('.')[0])
+if (nodeMajorVersion >= YARN_DISALLOW_NODE_VERSION) {
+  console.log(
+    `Yarn ${yarnVersion} is not supported for installation in Node.js ${nodeMajorVersion} and above,
+Yarn installation failed`,
+  )
   process.exit(1)
 }
 
@@ -18,6 +29,7 @@ console.log(
   + 'Support will be removed in a future major release of cypress/factory\n'
   + 'Proceeding with installation...',
 )
+
 console.log('Installing Yarn version: ', yarnVersion)
 
 // Insert logic here if needed to run a different install script based on version.

--- a/factory/installScripts/yarn/install-yarn-version.js
+++ b/factory/installScripts/yarn/install-yarn-version.js
@@ -18,7 +18,7 @@ const YARN_DISALLOW_NODE_VERSION = 26
 const nodeMajorVersion = parseInt(process.versions.node.split('.')[0])
 if (nodeMajorVersion >= YARN_DISALLOW_NODE_VERSION) {
   console.log(
-    `Yarn ${yarnVersion} is not supported for installation in Node.js ${nodeMajorVersion} and above,
+    `Yarn ${yarnVersion} is not supported for installation in Node.js ${YARN_DISALLOW_NODE_VERSION} and above,
 Yarn installation failed`,
   )
   process.exit(1)


### PR DESCRIPTION
- closes https://github.com/cypress-io/cypress-docker-images/issues/1495

BREAKING CHANGE:

Disallow setting YARN_VERSION for NODE_VERSION 26 and above

## Situation

- PR https://github.com/cypress-io/cypress-docker-images/pull/1490 deprecated the use of `YARN_VERSION` in custom builds of Cypress Docker images and established a deprecation message to appear in detailed logs of builds where `YARN_VERSION` is specified. This was released in `cypress/factory@7.4.0` (see also the [factory > YARN_VERSION](https://github.com/cypress-io/cypress-docker-images/blob/master/factory/README.md#yarn_version) document section).

- The release line Node.js 26 begins with v26.0.0 Current version [planned](https://github.com/nodejs/release#readme) for 2026-04-22 and LTS transition planned for 2026-10-28, six months later.

## Strategy

Align with removal of Yarn v1 Classic from [Node.js official images](https://github.com/nodejs/docker-node/blob/main/README.md#yarn-v1-classic-bundling) for Node.js 26.

## Change

For `cypress/base`, `cypress/browsers` & `cypress/included` standard images and custom images with respect to `YARN_VERSION` usage:

| Node.js      | `YARN_VERSION` Usage |
| ------------ | -------------------- |
| 25 and below | deprecation warning  |
| 26 and above | disallow             |


| Environment variable           | Before             | After              |
| ------------------------------ | ------------------ | ------------------ |
| `FACTORY_VERSION`              | `7.4.0`            | `8.0.0`            |

## Verification

To test before Node.js 26 is released, change `const YARN_DISALLOW_NODE_VERSION = 26` in `factory/installScripts/yarn/install-yarn-version.js` from 26 to 22.

Execute:

```shell
cd factory
docker compose build factory
unset YARN_VERSION # if re-testing
docker compose build base
cd ..
```

Confirm that `build base` fails with:

```text
 => ERROR [default_image  4/23] ONBUILD RUN node /opt/installScripts/yarn/install-yarn-version.js 1.22.22
------
 > [default_image  4/23] ONBUILD RUN node /opt/installScripts/yarn/install-yarn-version.js 1.22.22:
0.314 Yarn 1.22.22 is not supported for installation in Node.js 22 and above,
0.314 Yarn installation failed
------
```

```shell
cd factory
export YARN_VERSION=""
docker compose build factory
docker compose build base
docker compose build browsers
docker compose build included
cd ..
```

Confirm that builds complete successfully.

```shell
cd factory
docker compose build factory
cd test-project
set -a && . ../.env && set +a
export YARN_VERSION=""
docker compose run --build --rm test-factory-all-included
cd ../..
```

Confirm that Cypress tests are successful.


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Introduces a breaking change for custom image builds: specifying `YARN_VERSION` will now fail when building with Node.js 26+, which could break existing Docker build pipelines that relied on Yarn v1 installation.
> 
> **Overview**
> Custom builds using `cypress/factory` now **fail the build** if `YARN_VERSION` is provided while `NODE_VERSION` is `>=26`, aligning with Node.js dropping Yarn v1 bundling.
> 
> This bumps `FACTORY_VERSION` to `8.0.0` and updates the factory changelog/readmes and root `README` to document the new constraint and component-bundle expectations (Yarn v1 dropped in Node 26+).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 164e5b48eccae6adf5aaa59258a9e5df4e887741. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->