### PR TITLE
fix(deps): update to Node.js 24.15.0

### DIFF
--- a/factory/.env
+++ b/factory/.env
@@ -11,33 +11,33 @@ BASE_IMAGE='debian:13.4-slim'
 # Node Versions: https://nodejs.org/en/download/releases/
 # master branch needs "Active LTS" version
 # use feature branch for "Maintenance LTS" or "Current" versions
-FACTORY_DEFAULT_NODE_VERSION='24.14.1'
+FACTORY_DEFAULT_NODE_VERSION='24.15.0'
 
 # Node Versions: https://nodejs.org/en/download/releases/
 NODE_VERSION="${FACTORY_DEFAULT_NODE_VERSION}"
 
 # Update the FACTORY_VERSION to deploy cypress/factory if you make changes to
 # BASE_IMAGE, FACTORY_DEFAULT_NODE_VERSION, YARN_VERSION, factory.Dockerfile or installScripts
-FACTORY_VERSION='8.0.0'
+FACTORY_VERSION='8.0.1'
 
 # Cypress officially supports the latest 3 major versions of Chrome, Firefox, and Edge only
 
 # Chrome versions: https://www.ubuntuupdates.org/package/google_chrome/stable/main/base/google-chrome-stable
 # Linux/amd64 only
 # Earlier versions of Google Chrome may no longer be available from http://dl.google.com
-CHROME_VERSION='146.0.7680.177-1'
+CHROME_VERSION='147.0.7727.101-1'
 
 # Chrome for Testing versions: https://googlechromelabs.github.io/chrome-for-testing/
 # not currently used for cypress/browsers and cypress/included images
 # Linux/amd64 only
-CHROME_FOR_TESTING_VERSION='147.0.7727.55'
+CHROME_FOR_TESTING_VERSION='147.0.7727.57'
 
 # Cypress versions: https://www.npmjs.com/package/cypress
 CYPRESS_VERSION='15.13.1'
 
 # Edge versions: https://packages.microsoft.com/repos/edge/pool/main/m/microsoft-edge-stable/
 # Linux/amd64 only
-EDGE_VERSION='146.0.3856.97-1'
+EDGE_VERSION='147.0.3912.60-1'
 
 # Firefox versions: https://download-installer.cdn.mozilla.net/pub/firefox/releases/
 # Linux/amd64 for all versions, Linux/arm64 for versions 136.0 and above

--- a/factory/CHANGELOG.md
+++ b/factory/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Change log
 
+## 8.0.1
+
+- Updated `FACTORY_DEFAULT_NODE_VERSION` from `24.14.1` to `24.15.0`. Addressed in [#1501](https://github.com/cypress-io/cypress-docker-images/pull/1501).
+
 ## 8.0.0
 
 - `YARN_VERSION` is disallowed when `NODE_VERSION` is set to `>=26`. Addresses [#1495](https://github.com/cypress-io/cypress-docker-images/pull/1495).


### PR DESCRIPTION
## Situation

- Node.js released an update [Node.js v24.15.0 LTS](https://github.com/nodejs/node/releases/tag/v24.15.0). This is tagged  Apr 15, 2026, however there was a delay in the actual release until Apr 16, 2026.

## Change

In [factory/.env](https://github.com/cypress-io/cypress-docker-images/blob/master/factory/.env) make the following updates:

| Environment variable         | Before           | After            |
| ---------------------------- | ---------------- | ---------------- |
| FACTORY_VERSION              | 8.0.0            | 8.0.1            |
| FACTORY_DEFAULT_NODE_VERSION | 24.14.1          | 24.15.0          |
| CHROME_VERSION               | 146.0.7680.177-1 | 147.0.7727.101-1 |
| CHROME_FOR_TESTING_VERSION   | 147.0.7727.55    | 147.0.7727.57    |
| EDGE_VERSION                 | 146.0.3856.97-1  | 147.0.3912.60-1  |
| FIREFOX_VERSION              | 149.0.2          | no change        |


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Version pin updates only (Node and browser package versions) with no functional code changes; primary risk is build/test compatibility regressions from the new runtime/browsers.
> 
> **Overview**
> Updates `factory/.env` to ship a new `cypress/factory` build by bumping `FACTORY_DEFAULT_NODE_VERSION` to `24.15.0`, incrementing `FACTORY_VERSION` to `8.0.1`, and refreshing the pinned `CHROME_VERSION`, `CHROME_FOR_TESTING_VERSION`, and `EDGE_VERSION`.
> 
> Adds a `factory/CHANGELOG.md` entry for `8.0.1` documenting the Node default version update.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 9610f40d82987889d1ff47d9e2c765aec32ba84d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->