### PR TITLE
chore: update cypress to 15.14.0

### DIFF
--- a/factory/.env
+++ b/factory/.env
@@ -33,7 +33,7 @@ CHROME_VERSION='147.0.7727.101-1'
 CHROME_FOR_TESTING_VERSION='147.0.7727.57'
 
 # Cypress versions: https://www.npmjs.com/package/cypress
-CYPRESS_VERSION='15.13.1'
+CYPRESS_VERSION='15.14.0'
 
 # Edge versions: https://packages.microsoft.com/repos/edge/pool/main/m/microsoft-edge-stable/
 # Linux/amd64 only


### PR DESCRIPTION
updates Cypress to `15.14.0`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Simple version bump in `factory/.env` that only affects which Cypress release is baked into images; minimal code-path risk but may surface upstream Cypress regressions.
> 
> **Overview**
> Updates the `factory` image configuration to use Cypress `15.14.0` (from `15.13.1`), which will change the Cypress version baked into generated `cypress/included` images and related tags.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit cd906436c538eaa75014ac265f62740c39122c91. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->