### PR TITLE
fix(deps): pin typescript to v6 for cypress install

### DIFF
--- a/factory/.env
+++ b/factory/.env
@@ -18,7 +18,7 @@ NODE_VERSION="${FACTORY_DEFAULT_NODE_VERSION}"
 
 # Update the FACTORY_VERSION to deploy cypress/factory if you make changes to
 # BASE_IMAGE, FACTORY_DEFAULT_NODE_VERSION, YARN_VERSION, factory.Dockerfile or installScripts
-FACTORY_VERSION='8.0.1'
+FACTORY_VERSION='8.0.2'
 
 # Cypress officially supports the latest 3 major versions of Chrome, Firefox, and Edge only
 

--- a/factory/CHANGELOG.md
+++ b/factory/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Change log
 
+## 8.0.2
+
+- Modified Cypress installation script to pin installation to `typescript@6` instead of `typescript@latest`. Addresses [#1491](https://github.com/cypress-io/cypress-docker-images/issues/1491).
+
 ## 8.0.1
 
 - Updated `FACTORY_DEFAULT_NODE_VERSION` from `24.14.1` to `24.15.0`. Addressed in [#1501](https://github.com/cypress-io/cypress-docker-images/pull/1501).

--- a/factory/README.md
+++ b/factory/README.md
@@ -68,11 +68,15 @@ They are not currently published to the
 
 ### CYPRESS_VERSION
 
-The version of Cypress to install (via npm). If the `ARG` variable is unset or an empty string, Cypress is not installed.
+The version of Cypress to install (globally via npm). If the `ARG` variable is unset or an empty string, Cypress is not installed.
 
 Example: `CYPRESS_VERSION='15.1.0'`
 
 [Cypress versions](https://www.npmjs.com/package/cypress)
+
+If the `ARG` variable is set, then
+[typescript@6](https://www.npmjs.com/package/typescript) is also installed (globally via npm)
+to allow running tests written in TypeScript (see [Cypress TypeScript Support](https://on.cypress.io/typescript)).
 
 ### CHROME_VERSION
 

--- a/factory/installScripts/cypress/install.sh
+++ b/factory/installScripts/cypress/install.sh
@@ -1,17 +1,18 @@
 #! /bin/bash
 set -e
-# TODO: should typescript be versioned? Should it have it's own ARG for the factory?
+# TODO: Should typescript have its own ARG for the factory?
 # Typescript is installed to allow testing of .ts spec files.
 if [[ -n "$1" ]]; then
-  npm install -g "cypress@$1" typescript
+  npm install -g "cypress@$1" typescript@6
+  echo "Installed TypeScript $(tsc --version)"
 
-  # Loosen file priveleges for the cypress cache. The first time that cypress runs it will create a
-  # binary_state.json file if it hasn't already been created. This was causing issues with non-root
-  # users, they do not have access to write to this directory. Since this is a develompent docker container
-  # and to lower barriers as much as possible, we are loosening privs to allow the binary_state.json file
+  # Loosen file privileges for the cypress cache. The first time that cypress runs, it will create a
+  # binary_state.json file, if it hasn't already been created. This was causing issues with non-root
+  # users who do not have access to write to this directory. Since this is a development docker container
+  # and to lower barriers as much as possible, privileges are loosened to allow the binary_state.json file
   # to be created. Previously this file was created by root when cypress verify was called, but this would
   # apply to amd processors since cypress verify was not called on arm processors.
   chmod -R 777 /root/.cache
 else
-  echo 'No Cypress version provided; skipping install.' 
+  echo 'No Cypress version provided, skipping Cypress install'
 fi


### PR DESCRIPTION
- closes https://github.com/cypress-io/cypress-docker-images/issues/1491

## Situation

- The Cypress installation script [factory/installScripts/cypress/install.sh](https://github.com/cypress-io/cypress-docker-images/blob/master/factory/installScripts/cypress/install.sh) installs both Cypress and the latest version of [typescript](https://www.npmjs.com/package/typescript)
- The installation script is used to build `cypress/included` images and for custom images
- Although Cypress 15.14.0 added TypeScript 6 compatibility to the existing TypeScript 5 compatibility, this does not guard against any future TypeScript 7 release (see https://docs.cypress.io/app/tooling/typescript-support#Install-TypeScript for current list of supported TypeScript version) that may not be compatible with Cypress when it is released.

## Change

In [factory/installScripts/cypress/install.sh](https://github.com/cypress-io/cypress-docker-images/blob/master/factory/installScripts/cypress/install.sh)

- pin to `typescript@6`
- add log for version of TypeScript installed
- correct typos
- align message text to other installation scripts

| Environment variable | Before | After |
| -------------------- | ------ | ----- |
| FACTORY_VERSION      | 8.0.1  | 8.0.2 |

## Verification

```shell
cd factory
docker compose build factory
docker compose build included
docker run --rm --entrypoint bash cypress/included -c "npm ls -g"
cd ..
```

In the `npm ls -g` output, TypeScript should show as 6.x, for example [typescript@6.0.2](https://github.com/microsoft/TypeScript/releases/tag/v6.0.2). See [typescript versions](https://www.npmjs.com/package/typescript?activeTab=versions)

In CircleCI, check job `test-image-medium-included-test-included-electron`, step `building docker image`.

Confirm log, for example:

> Installed TypeScript Version 6.0.2

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes the `cypress/factory` build output by pinning globally installed TypeScript to major v6, which can affect downstream images and user expectations during Cypress installs, though the change is small and deterministic.
> 
> **Overview**
> Pins the Cypress install script used by `cypress/factory` (and downstream images) to install `typescript@6` instead of `typescript@latest`, and logs the installed TypeScript version during image build.
> 
> Bumps `FACTORY_VERSION` to `8.0.2` and updates docs/changelog to reflect the new TypeScript pin and the global install behavior for `CYPRESS_VERSION`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit b744e11ed861addb437ba58aafc4a00132418330. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->