### PR TITLE
chore: bump cypress version to 15.14.1

### DIFF
--- a/factory/.env
+++ b/factory/.env
@@ -41,7 +41,7 @@ EDGE_VERSION='147.0.3912.60-1'
 
 # Firefox versions: https://download-installer.cdn.mozilla.net/pub/firefox/releases/
 # Linux/amd64 for all versions, Linux/arm64 for versions 136.0 and above
-FIREFOX_VERSION='149.0.2'
+FIREFOX_VERSION='150.0'
 
 # Geckodriver versions: https://github.com/mozilla/geckodriver/releases
 # Geckodriver documentation: https://firefox-source-docs.mozilla.org/testing/geckodriver/index.html

--- a/factory/.env
+++ b/factory/.env
@@ -33,7 +33,7 @@ CHROME_VERSION='147.0.7727.101-1'
 CHROME_FOR_TESTING_VERSION='147.0.7727.57'
 
 # Cypress versions: https://www.npmjs.com/package/cypress
-CYPRESS_VERSION='15.14.0'
+CYPRESS_VERSION='15.14.1'
 
 # Edge versions: https://packages.microsoft.com/repos/edge/pool/main/m/microsoft-edge-stable/
 # Linux/amd64 only


### PR DESCRIPTION
## Summary

- Bumps `CYPRESS_VERSION` in `factory/.env` from `15.14.0` to `15.14.1`


Made with [Cursor](https://cursor.com)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk version bumps in `factory/.env` that only affect the Docker image build matrix and bundled browser/runtime versions.
> 
> **Overview**
> Bumps the pinned versions in `factory/.env` used to build Cypress Docker images: **Cypress** `15.14.0` → `15.14.1` and **Firefox** `149.0.2` → `150.0`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit dd3ddcc14ecd957e44023e9de65bd9ee791331f7. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->