### PR TITLE
chore: factory versions for Cypress 15.14.2

### DIFF
--- a/factory/.env
+++ b/factory/.env
@@ -25,23 +25,23 @@ FACTORY_VERSION='8.0.2'
 # Chrome versions: https://www.ubuntuupdates.org/package/google_chrome/stable/main/base/google-chrome-stable
 # Linux/amd64 only
 # Earlier versions of Google Chrome may no longer be available from http://dl.google.com
-CHROME_VERSION='147.0.7727.101-1'
+CHROME_VERSION='147.0.7727.137-1'
 
 # Chrome for Testing versions: https://googlechromelabs.github.io/chrome-for-testing/
 # not currently used for cypress/browsers and cypress/included images
 # Linux/amd64 only
-CHROME_FOR_TESTING_VERSION='147.0.7727.57'
+CHROME_FOR_TESTING_VERSION='147.0.7727.137'
 
 # Cypress versions: https://www.npmjs.com/package/cypress
-CYPRESS_VERSION='15.14.1'
+CYPRESS_VERSION='15.14.2'
 
 # Edge versions: https://packages.microsoft.com/repos/edge/pool/main/m/microsoft-edge-stable/
 # Linux/amd64 only
-EDGE_VERSION='147.0.3912.60-1'
+EDGE_VERSION='147.0.3912.86-1'
 
 # Firefox versions: https://download-installer.cdn.mozilla.net/pub/firefox/releases/
 # Linux/amd64 for all versions, Linux/arm64 for versions 136.0 and above
-FIREFOX_VERSION='150.0'
+FIREFOX_VERSION='150.0.1'
 
 # Geckodriver versions: https://github.com/mozilla/geckodriver/releases
 # Geckodriver documentation: https://firefox-source-docs.mozilla.org/testing/geckodriver/index.html


### PR DESCRIPTION
## Summary

Updates `factory/.env` for the Cypress **15.14.2** image line.

### Version bumps
| Component | From | To |
|-----------|------|-----|
| Cypress | 15.14.1 | **15.14.2** |
| Chrome (stable) | 147.0.7727.101 | 147.0.7727.137 |
| Chrome for Testing | 147.0.7727.57 | 147.0.7727.137 |
| Edge | 147.0.3912.60 | 147.0.3912.86 |
| Firefox | 150.0 | 150.0.1 |

Made with [Cursor](https://cursor.com)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: only updates pinned version numbers in `factory/.env`, affecting the next Docker image build inputs but not application logic.
> 
> **Overview**
> Updates `factory/.env` to build the Cypress 15.14.2 image line by bumping `CYPRESS_VERSION` and refreshing pinned browser versions (Chrome stable, Chrome for Testing, Edge, and Firefox) to newer patch releases.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 317ba6f1b8e429173976a1b9f099fd6fc9f75084. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->