### PR TITLE
chore: release images for Node.js 26.0.0 (current)

### DIFF
--- a/circle.yml
+++ b/circle.yml
@@ -374,7 +374,7 @@ workflows:
                 # change to a feature branch such as <cypress-version>-node-<node.js version>-publish
                 # if publishing an alternate (non-primary) version
                 # This job must run because the base, browsers and included jobs depend on it
-                - master
+                - 15.14.2-node-26.0.0-publish
           requires:
             - factory
             - factory-arm
@@ -390,7 +390,7 @@ workflows:
                 # Only branches matching the below regex filters will run
                 # Change to a feature branch such as <cypress-version>-node-<node.js version>-publish
                 # if publishing an alternate version
-                - master
+                - 15.14.2-node-26.0.0-publish
           requires:
             - 'Push Factory Image'
             - base
@@ -405,7 +405,7 @@ workflows:
                 # Only branches matching the below regex filters will run
                 # Change to a feature branch such as <cypress-version>-node-<node.js version>-publish
                 # if publishing an alternate version
-                - master
+                - 15.14.2-node-26.0.0-publish
           requires:
             - 'Push Factory Image'
             - browsers
@@ -420,7 +420,7 @@ workflows:
                 # Only branches matching the below regex filters will run
                 # Change to a feature branch such as <cypress-version>-node-<node.js version>-publish
                 # if publishing an alternate version
-                - master
+                - 15.14.2-node-26.0.0-publish
           requires:
             - 'Push Factory Image'
             - included

--- a/factory/.env
+++ b/factory/.env
@@ -25,7 +25,7 @@ FACTORY_VERSION='8.0.2'
 # Chrome versions: https://www.ubuntuupdates.org/package/google_chrome/stable/main/base/google-chrome-stable
 # Linux/amd64 only
 # Earlier versions of Google Chrome may no longer be available from http://dl.google.com
-CHROME_VERSION='147.0.7727.137-1'
+CHROME_VERSION='148.0.7778.96-1'
 
 # Chrome for Testing versions: https://googlechromelabs.github.io/chrome-for-testing/
 # not currently used for cypress/browsers and cypress/included images

--- a/factory/.env
+++ b/factory/.env
@@ -14,7 +14,7 @@ BASE_IMAGE='debian:13.4-slim'
 FACTORY_DEFAULT_NODE_VERSION='24.15.0'
 
 # Node Versions: https://nodejs.org/en/download/releases/
-NODE_VERSION="${FACTORY_DEFAULT_NODE_VERSION}"
+NODE_VERSION='26.0.0'
 
 # Update the FACTORY_VERSION to deploy cypress/factory if you make changes to
 # BASE_IMAGE, FACTORY_DEFAULT_NODE_VERSION, YARN_VERSION, factory.Dockerfile or installScripts
@@ -30,14 +30,14 @@ CHROME_VERSION='147.0.7727.137-1'
 # Chrome for Testing versions: https://googlechromelabs.github.io/chrome-for-testing/
 # not currently used for cypress/browsers and cypress/included images
 # Linux/amd64 only
-CHROME_FOR_TESTING_VERSION='147.0.7727.137'
+CHROME_FOR_TESTING_VERSION='148.0.7778.97'
 
 # Cypress versions: https://www.npmjs.com/package/cypress
 CYPRESS_VERSION='15.14.2'
 
 # Edge versions: https://packages.microsoft.com/repos/edge/pool/main/m/microsoft-edge-stable/
 # Linux/amd64 only
-EDGE_VERSION='147.0.3912.86-1'
+EDGE_VERSION='147.0.3912.98-1'
 
 # Firefox versions: https://download-installer.cdn.mozilla.net/pub/firefox/releases/
 # Linux/amd64 for all versions, Linux/arm64 for versions 136.0 and above
@@ -58,7 +58,7 @@ GECKODRIVER_VERSION='0.36.0'
 # - with NODE_VERSION 26.0.0 or higher is disallowed
 #
 # Yarn versions >= 2 are not supported
-YARN_VERSION='1.22.22'
+# YARN_VERSION='1.22.22'
 
 # Webkit versions: https://www.npmjs.com/package/playwright-webkit
 # TODO: Globally installed webkit currently isn't found, see issue https://github.com/cypress-io/cypress/issues/25344

--- a/factory/docker-compose.yml
+++ b/factory/docker-compose.yml
@@ -16,7 +16,7 @@ services:
         BASE_IMAGE: ${BASE_IMAGE}
         FACTORY_DEFAULT_NODE_VERSION: ${FACTORY_DEFAULT_NODE_VERSION}
       tags:
-        - ${REPO_PREFIX-}cypress/factory:latest # comment out for release of alternate version
+        # - ${REPO_PREFIX-}cypress/factory:latest # comment out for release of alternate version
         - ${REPO_PREFIX-}cypress/factory:${FACTORY_VERSION}
     command: node -v
 
@@ -36,8 +36,8 @@ services:
         YARN_VERSION: ${YARN_VERSION:-}
         # WEBKIT_VERSION: ${WEBKIT_VERSION}
       tags:
-        - ${REPO_PREFIX-}cypress/included:latest # comment out for release of alternate version
-        - ${REPO_PREFIX-}cypress/included:${INCLUDED_IMAGE_SHORT_TAG} # comment out for release of alternate version
+        # - ${REPO_PREFIX-}cypress/included:latest # comment out for release of alternate version
+        # - ${REPO_PREFIX-}cypress/included:${INCLUDED_IMAGE_SHORT_TAG} # comment out for release of alternate version
         - ${REPO_PREFIX-}cypress/included:${INCLUDED_IMAGE_TAG}
     command: node -v
 
@@ -55,7 +55,7 @@ services:
         GECKODRIVER_VERSION: ${GECKODRIVER_VERSION}
         EDGE_VERSION: ${EDGE_VERSION}
       tags:
-        - ${REPO_PREFIX-}cypress/browsers:latest # comment out for release of alternate version
+        # - ${REPO_PREFIX-}cypress/browsers:latest # comment out for release of alternate version
         - ${REPO_PREFIX-}cypress/browsers:${BROWSERS_IMAGE_SHORT_TAG}
         - ${REPO_PREFIX-}cypress/browsers:${BROWSERS_IMAGE_TAG}
     command: node -v
@@ -70,7 +70,7 @@ services:
         FACTORY_VERSION: ${FACTORY_VERSION}
         YARN_VERSION: ${YARN_VERSION:-}
       tags:
-        - ${REPO_PREFIX-}cypress/base:latest # comment out for release of alternate version
+        # - ${REPO_PREFIX-}cypress/base:latest # comment out for release of alternate version
         - ${REPO_PREFIX-}cypress/base:${BASE_IMAGE_TAG}
     command: node -v
 


### PR DESCRIPTION
## Situation

[Node.js 26.0.0](https://nodejs.org/en/blog/release/v26.0.0) was released on May 5, 2026. This is the "Current" version of Node.js that is planned to be promoted to LTS (Long Term Support) on Oct 28, 2026.

In the meantime, Node.js 24 remains as the Active LTS release line (see [Node.js releases](https://github.com/nodejs/release#readme)).

## Content

Using the feature branch

[15.14.2-node-26.0.0-publish](https://github.com/cypress-io/cypress-docker-images/tree/15.14.2-node-26.0.0-publish)

and following the process described in [Alternate versions](https://github.com/cypress-io/cypress-docker-images/blob/master/CONTRIBUTING.md#alternate-versions), generate and publish images based on `NODE_VERSION='26.0.0'`.

The set of Docker images is:

| Image type       | Short tag | Long tag                                                                           |
| ---------------- | --------- | ---------------------------------------------------------------------------------- |
| cypress/base     | 26.0.0    | -                                                                                  |
| cypress/browsers | 26.0.0    | node-26.0.0-chrome-148.0.7778.96-1-ff-150.0.1-edge-147.0.3912.98-1                 |
| cypress/included | -         | cypress-15.14.2-node-26.0.0-chrome-148.0.7778.96-1-ff-150.0.1-edge-147.0.3912.98-1 |

No new version of cypress/factory is built. None of the `latest` tags are changed, which remain pointing to images based on Node.js 24 (Active LTS).

| Environment variable         | Value           | Comment           |
| ---------------------------- | --------------- | ----------------- |
| FACTORY_VERSION              | 8.0.2           | no change         |
| YARN_VERSION                 | not set         | not installed     |
| FACTORY_DEFAULT_NODE_VERSION | 24.15.0         | no change         |
| NODE_VERSION                 | 26.0.0          | alternate version |
| CYPRESS_VERSION              | 15.14.2         | no change         |
| CHROME_VERSION               | 148.0.7778.96-1 | updated           |
| CHROME_FOR_TESTING_VERSION   | 148.0.7778.97   | updated           |
| EDGE_VERSION                 | 147.0.3912.98-1 | updated           |
| FIREFOX_VERSION              | 150.0.1         | no change         |
| GECKODRIVER_VERSION          | 0.36.0          | no change         |

Edit: compared to the original PR, `CHROME_VERSION` is now updated to 148.0.7778.96-1

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Medium risk because it changes CI publish branch filters and bumps runtime/tool versions used to build and tag Docker images, which can affect release artifacts and downstream consumers if mis-tagged or incompatible.
> 
> **Overview**
> Enables publishing of an *alternate* Cypress Docker image set based on **Node.js `26.0.0`** by switching CircleCI `push` workflows to run only on branch `15.14.2-node-26.0.0-publish`.
> 
> Updates `factory/.env` to target Node 26, bump `CHROME_FOR_TESTING_VERSION` and `EDGE_VERSION`, and disables Yarn installation by commenting out `YARN_VERSION` (per Node 26 restriction).
> 
> Adjusts `factory/docker-compose.yml` to prevent updating `latest` (and `included` short-tag) by commenting out those tag entries during the alternate-version release.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 4b1c92bcedb1ba4950e1b73dd0857b178d8da58c. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->