### PR TITLE
test: scaffold test-project using Cypress 15.14.2

### DIFF
--- a/factory/test-project/cypress.config.js
+++ b/factory/test-project/cypress.config.js
@@ -1,6 +1,8 @@
 const { defineConfig } = require("cypress");
 
 module.exports = defineConfig({
+  allowCypressEnv: false,
+
   e2e: {
     setupNodeEvents(on, config) {
       // implement node event listeners here

--- a/factory/test-project/cypress/e2e/2-advanced-examples/cypress_api.cy.js
+++ b/factory/test-project/cypress/e2e/2-advanced-examples/cypress_api.cy.js
@@ -109,32 +109,32 @@ context('Cypress APIs', () => {
     })
   })
 
-  context('Cypress.env()', () => {
+  context('Cypress.expose()', () => {
     beforeEach(() => {
       cy.visit('https://example.cypress.io/cypress-api')
     })
 
-    // We can set environment variables for highly dynamic values
+    // We can publicly expose values
 
     // https://on.cypress.io/environment-variables
     it('Get environment variables', () => {
     // https://on.cypress.io/env
     // set multiple environment variables
-      Cypress.env({
+      Cypress.expose({
         host: 'veronica.dev.local',
         api_server: 'http://localhost:8888/v1/',
       })
 
       // get environment variable
-      expect(Cypress.env('host')).to.eq('veronica.dev.local')
+      expect(Cypress.expose('host')).to.eq('veronica.dev.local')
 
       // set environment variable
-      Cypress.env('api_server', 'http://localhost:8888/v2/')
-      expect(Cypress.env('api_server')).to.eq('http://localhost:8888/v2/')
+      Cypress.expose('api_server', 'http://localhost:8888/v2/')
+      expect(Cypress.expose('api_server')).to.eq('http://localhost:8888/v2/')
 
       // get all environment variable
-      expect(Cypress.env()).to.have.property('host', 'veronica.dev.local')
-      expect(Cypress.env()).to.have.property('api_server', 'http://localhost:8888/v2/')
+      expect(Cypress.expose()).to.have.property('host', 'veronica.dev.local')
+      expect(Cypress.expose()).to.have.property('api_server', 'http://localhost:8888/v2/')
     })
   })
 

--- a/factory/test-project/cypress/e2e/2-advanced-examples/misc.cy.js
+++ b/factory/test-project/cypress/e2e/2-advanced-examples/misc.cy.js
@@ -18,8 +18,8 @@ context('Misc', () => {
 
     // on CircleCI Windows build machines we have a failure to run bash shell
     // https://github.com/cypress-io/cypress/issues/5169
-    // so skip some of the tests by passing flag "--env circle=true"
-    const isCircleOnWindows = Cypress.platform === 'win32' && Cypress.env('circle')
+    // so skip some of the tests by passing flag "--expose circle=true"
+    const isCircleOnWindows = Cypress.platform === 'win32' && Cypress.expose('circle')
 
     if (isCircleOnWindows) {
       cy.log('Skipping test on CircleCI')
@@ -29,7 +29,7 @@ context('Misc', () => {
 
     // cy.exec problem on Shippable CI
     // https://github.com/cypress-io/cypress/issues/6718
-    const isShippable = Cypress.platform === 'linux' && Cypress.env('shippable')
+    const isShippable = Cypress.platform === 'linux' && Cypress.expose('shippable')
 
     if (isShippable) {
       cy.log('Skipping test on ShippableCI')


### PR DESCRIPTION
## Situation

- The [test-project](https://github.com/cypress-io/cypress-docker-images/tree/master/factory/test-project) is scaffolded using Cypress `15.0.0`.

- The release [cypress@15.10.0](https://docs.cypress.io/app/references/changelog#15-10-0) deprecated [Cypress.env()](https://docs.cypress.io/api/cypress-api/env) and it is expected that this API call will be removed in Cypress 16 when it is released, which would cause test failures.

## Change

- The [factory/test-project](https://github.com/cypress-io/cypress-docker-images/tree/master/factory/test-project) is aligned with scaffolded tests from Cypress 15.14.2 (current `latest`), following the instructions in the [factory/test-project/README.MD](https://github.com/cypress-io/cypress-docker-images/blob/master/factory/test-project/README.MD) document.

- `Cypress.env()` is replaced with `Cypress.expose()`
- `allowCypressEnv: false` which suppresses warnings in Cypress `>=15.10.0` `<16.0.0`

This prepares the test-project for the removal of `Cypress.env()` in the planned Cypress 16 release.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk test-only changes that update deprecated Cypress APIs and tweak config to suppress warnings; main risk is minor CI behavior differences if `--env` flags were relied on instead of `--expose`.
> 
> **Overview**
> Updates the `factory/test-project` Cypress scaffold to avoid deprecated `Cypress.env()` usage.
> 
> Adds `allowCypressEnv: false` to `cypress.config.js` and replaces `Cypress.env()` calls with `Cypress.expose()` in the sample specs (including CI skip flags), aligning the project with newer Cypress 15 behavior ahead of Cypress 16 removals.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 6ddd99e9b53e093dd76e3af3a9911e061c1ab847. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->