### PR TITLE
chore(factory): bump Cypress 15.15.0 and browser pins

### DIFF
--- a/factory/.env
+++ b/factory/.env
@@ -25,23 +25,23 @@ FACTORY_VERSION='8.0.2'
 # Chrome versions: https://www.ubuntuupdates.org/package/google_chrome/stable/main/base/google-chrome-stable
 # Linux/amd64 only
 # Earlier versions of Google Chrome may no longer be available from http://dl.google.com
-CHROME_VERSION='147.0.7727.137-1'
+CHROME_VERSION='148.0.7778.96-1'
 
 # Chrome for Testing versions: https://googlechromelabs.github.io/chrome-for-testing/
 # not currently used for cypress/browsers and cypress/included images
 # Linux/amd64 only
-CHROME_FOR_TESTING_VERSION='147.0.7727.137'
+CHROME_FOR_TESTING_VERSION='148.0.7778.96'
 
 # Cypress versions: https://www.npmjs.com/package/cypress
-CYPRESS_VERSION='15.14.2'
+CYPRESS_VERSION='15.15.0'
 
 # Edge versions: https://packages.microsoft.com/repos/edge/pool/main/m/microsoft-edge-stable/
 # Linux/amd64 only
-EDGE_VERSION='147.0.3912.86-1'
+EDGE_VERSION='148.0.3967.54-1'
 
 # Firefox versions: https://download-installer.cdn.mozilla.net/pub/firefox/releases/
 # Linux/amd64 for all versions, Linux/arm64 for versions 136.0 and above
-FIREFOX_VERSION='150.0.1'
+FIREFOX_VERSION='150.0.3'
 
 # Geckodriver versions: https://github.com/mozilla/geckodriver/releases
 # Geckodriver documentation: https://firefox-source-docs.mozilla.org/testing/geckodriver/index.html


### PR DESCRIPTION
## Summary

Updates `factory/.env` so the Docker factory builds images with:

- **Cypress** `15.15.0`
- **Chrome** / **Chrome for Testing** `148.0.7778.96`
- **Edge** `148.0.3967.54`
- **Firefox** `150.0.3`

## Notes

Aligns factory defaults with the 15.15.0 release line and current stable browser versions for Linux/amd64 builds.

Made with [Cursor](https://cursor.com)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Moderate risk because it changes the versions baked into released Docker images, which can affect CI stability and browser/Cypress compatibility even though it’s configuration-only.
> 
> **Overview**
> Bumps the `factory/.env` pins used to build Docker images: **Cypress** to `15.15.0` and the default Linux/amd64 browser versions to **Chrome/Chrome for Testing** `148.0.7778.96`, **Edge** `148.0.3967.54`, and **Firefox** `150.0.3`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 72d87cc32c8507e68ad8b74eb0b19409ad65a7b1. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->