### PR TITLE
chore: tighten CI hygiene

### DIFF
--- a/.github/workflows/example-cypress-github-action.yml
+++ b/.github/workflows/example-cypress-github-action.yml
@@ -19,6 +19,9 @@ on:
       - '.github/workflows/example-cypress-github-action.yml'
   workflow_dispatch:
 
+permissions:
+  contents: read
+
 jobs:
   docker-base:
     runs-on: ubuntu-24.04

--- a/.github/workflows/example-tests.yml
+++ b/.github/workflows/example-tests.yml
@@ -8,6 +8,9 @@ on:
   pull_request:
   workflow_dispatch:
 
+permissions:
+  contents: read
+
 jobs:
   example:
     strategy:

--- a/circle.yml
+++ b/circle.yml
@@ -248,15 +248,15 @@ jobs:
             echo $(docker buildx version)
 
             ## see https://docs.docker.com/desktop/multi-arch/
-            docker run --privileged --rm tonistiigi/binfmt --install linux/amd64,linux/arm64
+            docker run --privileged --rm tonistiigi/binfmt:latest@sha256:d3b963f787999e6c0219a48dba02978769286ff61a5f4d26245cb6a6e5567ea3 --install linux/amd64,linux/arm64
             docker buildx create --name builder --use
 
-            docker login -u "$DOCKERHUB_USERNAME" --password "$DOCKERHUB_PASS"
+            echo "$DOCKERHUB_PASS" | docker login -u "$DOCKERHUB_USERNAME" --password-stdin
             docker buildx bake -f ./docker-compose.yml --progress plain --set *.platform=linux/arm64,linux/amd64 --push << parameters.target >>
 
             ## now, let's re-build those same images for Amazon ECR this is basically a re-tag and push because of the cache from the previous build.
             ## see https://docs.aws.amazon.com/AmazonECR/latest/userguide/docker-push-ecr-image.html
-            docker login --username AWS --password "$(aws ecr-public get-login-password --region $AWS_ECR_REGION)" $AWS_ECR_PREFIX
+            aws ecr-public get-login-password --region "$AWS_ECR_REGION" | docker login --username AWS --password-stdin "$AWS_ECR_PREFIX"
             REPO_PREFIX=$AWS_ECR_PREFIX/ docker buildx bake -f ./docker-compose.yml --progress plain --set *.platform=linux/arm64,linux/amd64 --push << parameters.target >>
 
           working_directory: factory

--- a/renovate.json
+++ b/renovate.json
@@ -3,6 +3,11 @@
   "dependencyDashboard": true,
   "extends": ["config:recommended"],
   "automerge": true,
+  "minimumReleaseAge": "7 days",
+  "osvVulnerabilityAlerts": true,
+  "vulnerabilityAlerts": {
+    "minimumReleaseAge": "0 days"
+  },
   "major": {
     "automerge": false
   },


### PR DESCRIPTION
Minor maintenance to the CI configuration:

- `circle.yml`: pass Docker registry credentials via stdin; pin `tonistiigi/binfmt` by digest.
- `renovate.json`: 7-day cooldown for routine updates; enable OSV alerts so security patches still flow through immediately.
- Example workflows: set default `contents: read` permission.

No change to published image contents or release triggers.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Config-only changes to example workflows, CircleCI login/binfmt usage, and Renovate policy; no application runtime or image build logic changes.
> 
> **Overview**
> Tightens **CI and dependency automation hygiene** without changing what gets built or when images publish.
> 
> **GitHub Actions** example workflows (`example-cypress-github-action`, `example-tests`) now declare **`permissions: contents: read`**, limiting the default token scope for checkout and test runs.
> 
> **CircleCI** `push` job: Docker Hub and ECR logins use **`--password-stdin`** instead of passing secrets on the command line; **`tonistiigi/binfmt`** is pinned to a **digest** instead of a floating tag.
> 
> **Renovate** adds a **7-day minimum release age** for routine dependency bumps, enables **OSV vulnerability alerts**, and sets **`vulnerabilityAlerts.minimumReleaseAge` to 0 days** so security fixes are not delayed by the cooldown.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c02f1916d7fc2c54a4177948aaf8feba36fb9311. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->