### PR TITLE
chore(factory): bump Cypress 15.16.0 and browser pins

### DIFF
--- a/factory/.env
+++ b/factory/.env
@@ -25,23 +25,23 @@ FACTORY_VERSION='8.0.2'
 # Chrome versions: https://www.ubuntuupdates.org/package/google_chrome/stable/main/base/google-chrome-stable
 # Linux/amd64 only
 # Earlier versions of Google Chrome may no longer be available from http://dl.google.com
-CHROME_VERSION='148.0.7778.96-1'
+CHROME_VERSION='148.0.7778.178-1'
 
 # Chrome for Testing versions: https://googlechromelabs.github.io/chrome-for-testing/
 # not currently used for cypress/browsers and cypress/included images
 # Linux/amd64 only
-CHROME_FOR_TESTING_VERSION='148.0.7778.96'
+CHROME_FOR_TESTING_VERSION='149.0.7827.22'
 
 # Cypress versions: https://www.npmjs.com/package/cypress
-CYPRESS_VERSION='15.15.0'
+CYPRESS_VERSION='15.16.0'
 
 # Edge versions: https://packages.microsoft.com/repos/edge/pool/main/m/microsoft-edge-stable/
 # Linux/amd64 only
-EDGE_VERSION='148.0.3967.54-1'
+EDGE_VERSION='148.0.3967.83-1'
 
 # Firefox versions: https://download-installer.cdn.mozilla.net/pub/firefox/releases/
 # Linux/amd64 for all versions, Linux/arm64 for versions 136.0 and above
-FIREFOX_VERSION='150.0.3'
+FIREFOX_VERSION='151.0.2'
 
 # Geckodriver versions: https://github.com/mozilla/geckodriver/releases
 # Geckodriver documentation: https://firefox-source-docs.mozilla.org/testing/geckodriver/index.html

--- a/factory/test-project/cypress/e2e/2-advanced-examples/cookies.cy.js
+++ b/factory/test-project/cypress/e2e/2-advanced-examples/cookies.cy.js
@@ -44,22 +44,27 @@ context('Cookies', () => {
     cy.setCookie('key', 'value')
     cy.setCookie('key', 'value', { domain: '.example.com' })
 
-    // cy.getAllCookies() yields an array of cookies
+    // cy.getAllCookies() yields an array of cookies (order is not guaranteed)
     cy.getAllCookies().should('have.length', 2).should((cookies) => {
-      // each cookie has these properties
-      expect(cookies[0]).to.have.property('name', 'key')
-      expect(cookies[0]).to.have.property('value', 'value')
-      expect(cookies[0]).to.have.property('httpOnly', false)
-      expect(cookies[0]).to.have.property('secure', false)
-      expect(cookies[0]).to.have.property('domain')
-      expect(cookies[0]).to.have.property('path')
+      const hostCookie = cookies.find((cookie) => cookie.domain !== '.example.com')
+      const exampleCookie = cookies.find((cookie) => cookie.domain === '.example.com')
 
-      expect(cookies[1]).to.have.property('name', 'key')
-      expect(cookies[1]).to.have.property('value', 'value')
-      expect(cookies[1]).to.have.property('httpOnly', false)
-      expect(cookies[1]).to.have.property('secure', false)
-      expect(cookies[1]).to.have.property('domain', '.example.com')
-      expect(cookies[1]).to.have.property('path')
+      // each cookie has these properties
+      expect(hostCookie).to.exist
+      expect(hostCookie).to.have.property('name', 'key')
+      expect(hostCookie).to.have.property('value', 'value')
+      expect(hostCookie).to.have.property('httpOnly', false)
+      expect(hostCookie).to.have.property('secure', false)
+      expect(hostCookie).to.have.property('domain')
+      expect(hostCookie).to.have.property('path')
+
+      expect(exampleCookie).to.exist
+      expect(exampleCookie).to.have.property('name', 'key')
+      expect(exampleCookie).to.have.property('value', 'value')
+      expect(exampleCookie).to.have.property('httpOnly', false)
+      expect(exampleCookie).to.have.property('secure', false)
+      expect(exampleCookie).to.have.property('domain', '.example.com')
+      expect(exampleCookie).to.have.property('path')
     })
   })
 


### PR DESCRIPTION
## Summary

- Bumps `CYPRESS_VERSION` to `15.16.0` in `factory/.env`
- Updates browser pins for the 15.16.0 factory image release:
  - Chrome: `148.0.7778.178-1`
  - Chrome for Testing: `149.0.7827.22`
  - Edge: `148.0.3967.83-1`
  - Firefox: `151.0.2`

## Test plan

- [ ] Factory image build passes in CI
- [ ] Published images include Cypress 15.16.0 with updated browser versions

Made with [Cursor](https://cursor.com)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Version pin and example-test updates only; no auth, data, or application runtime logic changes.
> 
> **Overview**
> Updates **`factory/.env`** so factory and derived Docker images ship **Cypress `15.16.0`** and newer browser pins: Chrome **`148.0.7778.178-1`**, Chrome for Testing **`149.0.7827.22`**, Edge **`148.0.3967.83-1`**, and Firefox **`151.0.2`**. Image tags that embed these values (e.g. `INCLUDED_IMAGE_TAG`) will change on the next build.
> 
> The **`cy.getAllCookies()`** example in `cookies.cy.js` no longer assumes cookie array order; it selects cookies by **domain** with `find()` so the test stays stable when Cypress/browser behavior does not guarantee ordering.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 50667d94d4849d2fe222acaf0e671cf167a8a9bb. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->