### PR TITLE
feat: Debian 13.5 & Node.js 24.16.0 factory update

### DIFF
--- a/factory/.env
+++ b/factory/.env
@@ -6,19 +6,19 @@
 
 # Use Debian stable release https://www.debian.org/releases/stable/
 # The Debian image cypress/factory is based on
-BASE_IMAGE='debian:13.4-slim'
+BASE_IMAGE='debian:13.5-slim'
 
 # Node Versions: https://nodejs.org/en/download/releases/
 # master branch needs "Active LTS" version
 # use feature branch for "Maintenance LTS" or "Current" versions
-FACTORY_DEFAULT_NODE_VERSION='24.15.0'
+FACTORY_DEFAULT_NODE_VERSION='24.16.0'
 
 # Node Versions: https://nodejs.org/en/download/releases/
 NODE_VERSION="${FACTORY_DEFAULT_NODE_VERSION}"
 
 # Update the FACTORY_VERSION to deploy cypress/factory if you make changes to
 # BASE_IMAGE, FACTORY_DEFAULT_NODE_VERSION, YARN_VERSION, factory.Dockerfile or installScripts
-FACTORY_VERSION='8.0.2'
+FACTORY_VERSION='8.1.0'
 
 # Cypress officially supports the latest 3 major versions of Chrome, Firefox, and Edge only
 

--- a/factory/CHANGELOG.md
+++ b/factory/CHANGELOG.md
@@ -1,5 +1,13 @@
 # Change log
 
+## 8.1.0
+
+- Updated Debian `BASE_IMAGE` from `debian:13.4-slim` to `debian:13.5-slim`
+  using [Debian 13.5 (trixie)](https://www.debian.org/releases/trixie/).
+  Addresses [#1510](https://github.com/cypress-io/cypress-docker-images/issues/1510).
+- Updated `FACTORY_DEFAULT_NODE_VERSION` from `24.15.0` to `24.16.0`.
+  Addresses [#1511](https://github.com/cypress-io/cypress-docker-images/issues/1511).
+
 ## 8.0.2
 
 - Modified Cypress installation script to pin installation to `typescript@6` instead of `typescript@latest`. Addresses [#1491](https://github.com/cypress-io/cypress-docker-images/issues/1491).


### PR DESCRIPTION
- closes https://github.com/cypress-io/cypress-docker-images/issues/1509
- closes https://github.com/cypress-io/cypress-docker-images/issues/1511

## Situation

Dependencies affecting `cypress/factory` are outdated:

- The base operating system image debian:13.4
- The Node.js LTS version 24.15.0

## Changes

Changes to `cypress/factory`:

| Environment variable         | Before           | After            |
| ---------------------------- | ---------------- | ---------------- |
| BASE_IMAGE                   | debian:13.4-slim | debian:13.5-slim |
| FACTORY_VERSION              | 8.0.2            | 8.1.0            |
| FACTORY_DEFAULT_NODE_VERSION | 24.15.0          | 24.16.0          |

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Routine dependency pin bumps for the factory image with no application or install-script logic changes in the diff.
> 
> **Overview**
> Bumps **`cypress/factory`** to **8.1.0** by updating `factory/.env`: the Debian slim base moves from **`debian:13.4-slim`** to **`debian:13.5-slim`**, and the default Node (Active LTS) moves from **24.15.0** to **24.16.0**. `NODE_VERSION` still follows `FACTORY_DEFAULT_NODE_VERSION`, so derived **`cypress/base`**, **`cypress/browsers`**, and **`cypress/included`** tags that embed that Node version will change on the next build.
> 
> `factory/CHANGELOG.md` documents the release and links issues **#1510** and **#1511**. No Dockerfile or install-script changes in this diff—only version pins and changelog.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 2d1271adb4c508ebf6eba183def7ecab556dda54. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->