### PR TITLE
test: scaffold test-project using Cypress 15.16.0

### DIFF
--- a/factory/test-project/cypress/e2e/2-advanced-examples/actions.cy.js
+++ b/factory/test-project/cypress/e2e/2-advanced-examples/actions.cy.js
@@ -239,24 +239,33 @@ context('Actions', () => {
     // because they're not within
     // the viewable area of their parent
     // (we need to scroll to see them)
-    cy.get('#scroll-horizontal button')
-      .should('not.be.visible')
+    cy.get('#scroll-horizontal button').then(($el) => {
+      const container = $el[0].closest('#scroll-horizontal')
+      expect($el[0].getBoundingClientRect().left).to.be.greaterThan(container.getBoundingClientRect().right)
+    })
 
     // scroll the button into view, as if the user had scrolled
     cy.get('#scroll-horizontal button').scrollIntoView()
     cy.get('#scroll-horizontal button')
       .should('be.visible')
 
-    cy.get('#scroll-vertical button')
-      .should('not.be.visible')
+    cy.get('#scroll-vertical button').then(($el) => {
+      const container = $el[0].closest('#scroll-vertical')
+      expect($el[0].getBoundingClientRect().top).to.be.greaterThan(container.getBoundingClientRect().bottom)
+    })
 
     // Cypress handles the scroll direction needed
     cy.get('#scroll-vertical button').scrollIntoView()
     cy.get('#scroll-vertical button')
       .should('be.visible')
 
-    cy.get('#scroll-both button')
-      .should('not.be.visible')
+    cy.get('#scroll-both button').then(($el) => {
+      const container = $el[0].closest('#scroll-both')
+      const elRect = $el[0].getBoundingClientRect()
+      const containerRect = container.getBoundingClientRect()
+      expect(elRect.left).to.be.greaterThan(containerRect.right)
+      expect(elRect.top).to.be.greaterThan(containerRect.bottom)
+    })
 
     // Cypress knows to scroll to the right and down
     cy.get('#scroll-both button').scrollIntoView()


### PR DESCRIPTION
## Situation

- The [test-project](https://github.com/cypress-io/cypress-docker-images/tree/master/factory/test-project) was patched by https://github.com/cypress-io/cypress-docker-images/pull/1516 which updated the `cookies.cy.js` test only. It is no longer equivalent to regular scaffolding from any specific Cypress version and currently contains a mixture of test versions.

## Change

- The [factory/test-project](https://github.com/cypress-io/cypress-docker-images/tree/master/factory/test-project) is aligned with scaffolded tests from Cypress 15.16.0 (current `latest`), following the instructions in the [factory/test-project/README.MD](https://github.com/cypress-io/cypress-docker-images/blob/master/factory/test-project/README.MD) document.

This updates `cypress/e2e/2-advanced-examples/actions.cy.js` to the latest version and aligns all tests to Cypress 15.16.0.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Example E2E test-only changes in the Docker factory test project; no production or security impact.
> 
> **Overview**
> Updates the factory **test-project** example spec `actions.cy.js` so the `.scrollIntoView()` example matches Cypress **15.16.0** scaffolding.
> 
> Before scrolling, the test no longer asserts buttons are `not.be.visible`. It now uses `getBoundingClientRect()` against each scroll container (`#scroll-horizontal`, `#scroll-vertical`, `#scroll-both`) to confirm the target sits outside the container’s visible bounds. Post-`scrollIntoView()` checks still expect the buttons to be visible.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 006966e9c6da08aa32bc8e47abcccf11391bc982. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->