### PR TITLE
test(deps): add npm allow-scripts for cypress in examples

### DIFF
--- a/examples/basic/package.json
+++ b/examples/basic/package.json
@@ -8,5 +8,8 @@
   "private": true,
   "devDependencies": {
     "cypress": "^15.16.0"
+  },
+  "allowScripts": {
+    "cypress": true
   }
 }

--- a/examples/chrome-for-testing/package.json
+++ b/examples/chrome-for-testing/package.json
@@ -11,5 +11,8 @@
   "devDependencies": {
     "@puppeteer/browsers": "^3.0.4",
     "cypress": "^15.16.0"
+  },
+  "allowScripts": {
+    "cypress": true
   }
 }

--- a/examples/chromium/package.json
+++ b/examples/chromium/package.json
@@ -10,5 +10,8 @@
   "private": true,
   "devDependencies": {
     "cypress": "^15.16.0"
+  },
+  "allowScripts": {
+    "cypress": true
   }
 }

--- a/examples/firefox-esr/package.json
+++ b/examples/firefox-esr/package.json
@@ -10,5 +10,8 @@
   "private": true,
   "devDependencies": {
     "cypress": "^15.16.0"
+  },
+  "allowScripts": {
+    "cypress": true
   }
 }


### PR DESCRIPTION
- partially resolves issue https://github.com/cypress-io/cypress-docker-images/issues/1523

## Situation

Executing `npm ci` in the sub-directories of [examples](https://github.com/cypress-io/cypress-docker-images/tree/master/examples) that include `cypress` in their `package.json` using [npm@11.16.0](https://github.com/npm/cli/releases/tag/v11.16.0) (current `latest`) causes a warning similar to:

```console
npm warn allow-scripts 1 package has install scripts not yet covered by allowScripts:
npm warn allow-scripts   cypress@15.16.0 (postinstall: node dist/index.js --exec install)
npm warn allow-scripts
npm warn allow-scripts Run `npm approve-scripts --allow-scripts-pending` to review, or `npm approve-scripts <pkg>` to allow.
```

## Change

Execute the following in each of the sub-directories of [examples](https://github.com/cypress-io/cypress-docker-images/tree/master/examples) that include `cypress` in their `package.json` using [npm@11.16.0](https://github.com/npm/cli/releases/tag/v11.16.0):

```shell
npm approve-scripts cypress --no-allow-scripts-pin
```

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Config-only changes in example projects; no runtime, auth, or production dependency logic is modified.
> 
> **Overview**
> Adds an **`allowScripts`** block to each Cypress example **`package.json`** (`basic`, `chrome-for-testing`, `chromium`, `firefox-esr`) so **`cypress`** postinstall scripts are explicitly approved under npm 11.16+ **`allow-scripts`** behavior.
> 
> This silences **`npm ci`** warnings about uncovered install scripts and matches the workflow described in the PR (`npm approve-scripts cypress`).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 63e7f14d3fe2430edd090f6db30a58861dfee553. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->