### PR TITLE
refactor: rearrange cypress and typescript install

### DIFF
--- a/factory/installScripts/cypress/install.sh
+++ b/factory/installScripts/cypress/install.sh
@@ -1,18 +1,26 @@
 #! /bin/bash
 set -e
-# TODO: Should typescript have its own ARG for the factory?
-# Typescript is installed to allow testing of .ts spec files.
-if [[ -n "$1" ]]; then
-  npm install -g "cypress@$1" typescript@6
-  echo "Installed TypeScript $(tsc --version)"
 
-  # Loosen file privileges for the cypress cache. The first time that cypress runs, it will create a
-  # binary_state.json file, if it hasn't already been created. This was causing issues with non-root
-  # users who do not have access to write to this directory. Since this is a development docker container
-  # and to lower barriers as much as possible, privileges are loosened to allow the binary_state.json file
-  # to be created. Previously this file was created by root when cypress verify was called, but this would
-  # apply to amd processors since cypress verify was not called on arm processors.
-  chmod -R 777 /root/.cache
-else
+# Highest major version of TypeScript that Cypress supports
+# See https://docs.cypress.io/app/tooling/typescript-support#Install-TypeScript
+TYPESCRIPT_VERSION=6
+
+if [[ -z "$1" ]]; then
   echo 'No Cypress version provided, skipping Cypress install'
+  exit 0
 fi
+
+npm install -g "cypress@$1"
+
+# Loosen file privileges for the Cypress cache. The first time that Cypress runs, it will create a
+# binary_state.json file, if it hasn't already been created. This was causing issues with non-root
+# users who do not have access to write to this directory. Since this is a development Docker container
+# and to lower barriers as much as possible, privileges are loosened to allow the binary_state.json file
+# to be created. Previously this file was created by root when 'cypress verify' was called, but this would
+# apply to amd processors since 'cypress verify' was not called on arm processors.
+chmod -R 777 /root/.cache
+
+# TODO: Should TypeScript have its own ARG for the factory?
+# TypeScript is installed to allow testing of .ts spec files.
+npm install -g "typescript@$TYPESCRIPT_VERSION"
+echo "Installed TypeScript $(tsc --version)"


### PR DESCRIPTION

## Situation

The [factory/installScripts/cypress/install.sh](https://github.com/cypress-io/cypress-docker-images/blob/master/factory/installScripts/cypress/install.sh) installs both `cypress` and `typescript`.

- The installations and comments are intertwined
- The TypeScript version `6` is embedded inline
- Script exit if no Cypress version is passed to the script does not conform to the style in other scripts that exit immediately if there is nothing to do

Issue https://github.com/cypress-io/cypress-docker-images/issues/1523 describes how [npm@11.16.0](https://github.com/npm/cli/releases/tag/v11.16.0) is causing a warning due to installing the Cypress binary. To silence this warning requires a change to the installation script, and this change would be cleaner if the script removed first the style issues mentioned above.

## Change

Modify [factory/installScripts/cypress/install.sh](https://github.com/cypress-io/cypress-docker-images/blob/master/factory/installScripts/cypress/install.sh):

- split `cypress` and `typescript` global install for better readability and maintainability
- add a commented environment variable `TYPESCRIPT_VERSION=6` for better visibility of the version being installed
- adapt code style to exit immediately when no installation is to be done, for consistency with other install scripts

## Verification

```shell
git clone https://github.com/cypress-io/cypress-docker-images
cd cypress-docker-images

cd factory
docker compose build factory
docker compose --progress plain build included --no-cache
cd ..
```

The installation section for Cypress and TypeScript should look similar to the following:

```console
#13 [included_image  9/21] ONBUILD RUN /opt/installScripts/cypress/install.sh 15.17.0
#13 39.59
#13 39.59 added 169 packages in 39s
#13 39.59
#13 39.59 53 packages are looking for funding
#13 39.59   run `npm fund` for details
#13 42.11
#13 42.11 added 1 package in 2s
#13 42.23 Installed TypeScript Version 6.0.3
#13 DONE 42.7s
```

```shell
docker run -it --rm --entrypoint bash cypress/included
```


At bash prompt:

```shell
npx cypress verify
npm ls -g
tsc --version
```

Confirm that both `cypress` and `typescript` are globally installed.

Output should be similar to the following:

```console
root@55641c7d1700:/# npx cypress verify
[STARTED] [11:36:54]  Verifying Cypress can run /root/.cache/Cypress/15.17.0/Cypress
[COMPLETED] [11:36:55]  Verified Cypress!       /root/.cache/Cypress/15.17.0/Cypress
root@55641c7d1700:/# npm ls -g
/usr/local/lib
+-- corepack@0.35.0
+-- cypress@15.17.0
+-- npm@11.13.0
`-- typescript@6.0.3
root@55641c7d1700:/# tsc --version
Version 6.0.3
```


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Install-script refactor only; intended behavior (global Cypress + TypeScript in dev images) is unchanged.
> 
> **Overview**
> Refactors **`factory/installScripts/cypress/install.sh`** so Cypress and TypeScript are installed in separate steps instead of a single `npm install -g` line, with **`TYPESCRIPT_VERSION=6`** documented at the top (per Cypress TypeScript support docs).
> 
> When no Cypress version argument is passed, the script now **exits immediately** after logging (matching other factory install scripts) instead of only printing a message in an `else` branch. **`chmod -R 777 /root/.cache`** still runs only on the install path, after Cypress is installed and before TypeScript. Comments are lightly cleaned up (e.g. “Docker”, quoted `cypress verify`).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 7b89cf6127dd2bfaa18a1858c9278ee1bbdeb36c. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->