### PR TITLE
chore(factory): bump Cypress 15.17.0 and browser pins

### DIFF
--- a/factory/.env
+++ b/factory/.env
@@ -25,23 +25,23 @@ FACTORY_VERSION='8.1.0'
 # Chrome versions: https://www.ubuntuupdates.org/package/google_chrome/stable/main/base/google-chrome-stable
 # Linux/amd64 only
 # Earlier versions of Google Chrome may no longer be available from http://dl.google.com
-CHROME_VERSION='148.0.7778.178-1'
+CHROME_VERSION='149.0.7827.102-1'
 
 # Chrome for Testing versions: https://googlechromelabs.github.io/chrome-for-testing/
 # not currently used for cypress/browsers and cypress/included images
 # Linux/amd64 only
-CHROME_FOR_TESTING_VERSION='149.0.7827.22'
+CHROME_FOR_TESTING_VERSION='149.0.7827.55'
 
 # Cypress versions: https://www.npmjs.com/package/cypress
-CYPRESS_VERSION='15.16.0'
+CYPRESS_VERSION='15.17.0'
 
 # Edge versions: https://packages.microsoft.com/repos/edge/pool/main/m/microsoft-edge-stable/
 # Linux/amd64 only
-EDGE_VERSION='148.0.3967.83-1'
+EDGE_VERSION='149.0.4022.52-1'
 
 # Firefox versions: https://download-installer.cdn.mozilla.net/pub/firefox/releases/
 # Linux/amd64 for all versions, Linux/arm64 for versions 136.0 and above
-FIREFOX_VERSION='151.0.2'
+FIREFOX_VERSION='151.0.4'
 
 # Geckodriver versions: https://github.com/mozilla/geckodriver/releases
 # Geckodriver documentation: https://firefox-source-docs.mozilla.org/testing/geckodriver/index.html


### PR DESCRIPTION
## Summary
- Bump `CYPRESS_VERSION` to 15.17.0 in `factory/.env`
- Update browser pins to latest stable versions:
  - Chrome: 149.0.7827.102-1
  - Chrome for Testing: 149.0.7827.55
  - Edge: 149.0.4022.52-1
  - Firefox: 151.0.4

## Test plan
- [ ] Verify CI builds and tests pass for `cypress/factory`, `cypress/browsers`, and `cypress/included` images
- [ ] Confirm Cypress 15.17.0 is available on npm before merging
- [ ] Validate installed browser versions match the pinned values in CI


Made with [Cursor](https://cursor.com)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Version-pin-only change in factory config; no application logic, with new Docker tags expected instead of republishing existing ones.
> 
> **Overview**
> Updates **`factory/.env`** primary version pins so published **`cypress/browsers`** and **`cypress/included`** images pick up newer tooling on merge.
> 
> **Cypress** moves from **15.16.0** to **15.17.0**. Browser pins move to current stable builds: **Chrome 149.0.7827.102-1**, **Chrome for Testing 149.0.7827.55**, **Edge 149.0.4022.52-1**, and **Firefox 151.0.4**. **`FACTORY_VERSION`** is unchanged, which matches the repo rule that Cypress/browser-only bumps do not require a new **`cypress/factory`** release.
> 
> Derived tags **`BROWSERS_IMAGE_TAG`** and **`INCLUDED_IMAGE_TAG`** will change with these values, so CI should publish new browser/included images rather than overwriting existing tags.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 90bf52e1d075c461ab8e6a2858696543eab2b6c1. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->