### PR TITLE
fix(deps): update to Node.js 24.17.0

### DIFF
--- a/factory/.env
+++ b/factory/.env
@@ -11,43 +11,43 @@ BASE_IMAGE='debian:13.5-slim'
 # Node Versions: https://nodejs.org/en/download/releases/
 # master branch needs "Active LTS" version
 # use feature branch for "Maintenance LTS" or "Current" versions
-FACTORY_DEFAULT_NODE_VERSION='24.16.0'
+FACTORY_DEFAULT_NODE_VERSION='24.17.0'
 
 # Node Versions: https://nodejs.org/en/download/releases/
 NODE_VERSION="${FACTORY_DEFAULT_NODE_VERSION}"
 
 # Update the FACTORY_VERSION to deploy cypress/factory if you make changes to
 # BASE_IMAGE, FACTORY_DEFAULT_NODE_VERSION, YARN_VERSION, factory.Dockerfile or installScripts
-FACTORY_VERSION='8.1.0'
+FACTORY_VERSION='8.1.1'
 
 # Cypress officially supports the latest 3 major versions of Chrome, Firefox, and Edge only
 
 # Chrome versions: https://www.ubuntuupdates.org/package/google_chrome/stable/main/base/google-chrome-stable
 # Linux/amd64 only
 # Earlier versions of Google Chrome may no longer be available from http://dl.google.com
-CHROME_VERSION='149.0.7827.102-1'
+CHROME_VERSION='149.0.7827.155-1'
 
 # Chrome for Testing versions: https://googlechromelabs.github.io/chrome-for-testing/
 # not currently used for cypress/browsers and cypress/included images
 # Linux/amd64 only
-CHROME_FOR_TESTING_VERSION='149.0.7827.55'
+CHROME_FOR_TESTING_VERSION='150.0.7871.24'
 
 # Cypress versions: https://www.npmjs.com/package/cypress
 CYPRESS_VERSION='15.17.0'
 
 # Edge versions: https://packages.microsoft.com/repos/edge/pool/main/m/microsoft-edge-stable/
 # Linux/amd64 only
-EDGE_VERSION='149.0.4022.52-1'
+EDGE_VERSION='149.0.4022.69-1'
 
 # Firefox versions: https://download-installer.cdn.mozilla.net/pub/firefox/releases/
 # Linux/amd64 for all versions, Linux/arm64 for versions 136.0 and above
-FIREFOX_VERSION='151.0.4'
+FIREFOX_VERSION='152.0'
 
 # Geckodriver versions: https://github.com/mozilla/geckodriver/releases
 # Geckodriver documentation: https://firefox-source-docs.mozilla.org/testing/geckodriver/index.html
 # Linux/amd64 and Linux/arm64 for all versions
 # Minimum version is 0.34.0
-GECKODRIVER_VERSION='0.36.0'
+GECKODRIVER_VERSION='0.37.0'
 
 # Yarn v1 Classic:
 # https://classic.yarnpkg.com/latest-version

--- a/factory/CHANGELOG.md
+++ b/factory/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Change log
 
+## 8.1.1
+
+- Updated `FACTORY_DEFAULT_NODE_VERSION` from `24.16.0` to `24.17.0`.
+  Addressed in [#1529](https://github.com/cypress-io/cypress-docker-images/pull/1529).
+
 ## 8.1.0
 
 - Updated Debian `BASE_IMAGE` from `debian:13.4-slim` to `debian:13.5-slim`


### PR DESCRIPTION
## Situation

- Node.js released a security update [Node.js 24.17.0 LTS](https://github.com/nodejs/node/releases/tag/v24.17.0) on June 18, 2026.

## Change

In [factory/.env](https://github.com/cypress-io/cypress-docker-images/blob/master/factory/.env) make the following updates:

| Environment variable         | Before           | After            |
| ---------------------------- | ---------------- | ---------------- |
| FACTORY_VERSION              | 8.1.0            | 8.1.1            |
| FACTORY_DEFAULT_NODE_VERSION | 24.16.0          | 24.17.0          |
| CHROME_VERSION               | 149.0.7827.102-1 | 149.0.7827.155-1 |
| CHROME_FOR_TESTING_VERSION   | 149.0.7827.55    | 150.0.7871.24    |
| EDGE_VERSION                 | 149.0.4022.52-1  | 149.0.4022.69-1  |
| FIREFOX_VERSION              | 151.0.4          | 152.0            |
| GECKODRIVER_VERSION          | 0.36.0           | 0.37.0           |

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Config-only version bumps with no Dockerfile or install-script logic changes; main impact is rebuilt images and updated runtime/browser stacks for consumers.
> 
> **Overview**
> Bumps **`cypress/factory`** release **`8.1.0` → `8.1.1`** by updating primary version pins in `factory/.env`, which flow into `docker-compose` builds for `cypress/factory`, `base`, `browsers`, and `included` images.
> 
> **Node** Active LTS default moves **`24.16.0` → `24.17.0`** (`FACTORY_DEFAULT_NODE_VERSION` / `NODE_VERSION`). Bundled browser and driver versions are refreshed: Chrome, Chrome for Testing, Edge, Firefox **`151.0.4` → `152.0`**, and Geckodriver **`0.36.0` → `0.37.0`**.
> 
> `factory/CHANGELOG.md` adds **8.1.1** documenting the Node bump (PR #1529); it does not list the browser pin changes.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 2019558e12c9834c1562e5db7ed93128e89650e3. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->