### PR TITLE
fix: use npm allow-scripts for cypress global install

### DIFF
--- a/factory/.env
+++ b/factory/.env
@@ -18,7 +18,7 @@ NODE_VERSION="${FACTORY_DEFAULT_NODE_VERSION}"
 
 # Update the FACTORY_VERSION to deploy cypress/factory if you make changes to
 # BASE_IMAGE, FACTORY_DEFAULT_NODE_VERSION, YARN_VERSION, factory.Dockerfile or installScripts
-FACTORY_VERSION='8.1.1'
+FACTORY_VERSION='8.1.2'
 
 # Cypress officially supports the latest 3 major versions of Chrome, Firefox, and Edge only
 

--- a/factory/CHANGELOG.md
+++ b/factory/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Change log
 
+## 8.1.2
+
+- Modified Cypress install script to use `--allow-scripts`, introduced in
+  [npm@11.16.0](https://github.com/npm/cli/releases/tag/v11.16.0), to avoid
+  `npm warn allow-scripts` warnings.
+  Addresses [#1523](https://github.com/cypress-io/cypress-docker-images/issues/1523).
+
 ## 8.1.1
 
 - Updated `FACTORY_DEFAULT_NODE_VERSION` from `24.16.0` to `24.17.0`.

--- a/factory/installScripts/cypress/install.sh
+++ b/factory/installScripts/cypress/install.sh
@@ -10,7 +10,7 @@ if [[ -z "$1" ]]; then
   exit 0
 fi
 
-npm install -g "cypress@$1"
+npm install -g "cypress@$1" --allow-scripts=cypress
 
 # Loosen file privileges for the Cypress cache. The first time that Cypress runs, it will create a
 # binary_state.json file, if it hasn't already been created. This was causing issues with non-root


### PR DESCRIPTION
- support resolution of https://github.com/cypress-io/cypress-docker-images/issues/1523

## Situation

When the [factory/installScripts/node/default.sh](https://github.com/cypress-io/cypress-docker-images/blob/master/factory/installScripts/node/default.sh) runs under a version of Node.js that includes [npm@11.16.0](https://github.com/npm/cli/releases/tag/v11.16.0) or higher, an npm warning is logged:

```console
npm warn allow-scripts 1 package has install scripts not yet covered by allowScripts:
npm warn allow-scripts   cypress@15.17.0 (postinstall: node dist/index.js --exec install)
```

This is non-fatal in npm 11, and fatal in the planned npm 12 version (see also https://github.com/cypress-io/cypress/issues/33980).

## Change

Modify [factory/installScripts/node/default.sh](https://github.com/cypress-io/cypress-docker-images/blob/master/factory/installScripts/node/default.sh)

- install `cypress` globally with npm using [--allow-scripts](https://docs.npmjs.com/cli/v11/commands/npm-install#allow-scripts), allowing `cypress`

## Verification

https://nodejs.org/en/about/previous-releases

The npm version is not separately selectable. Cypress installs the version of npm bundled in Node.js and selected by `NODE_VERSION`.

| Node.js | npm     | Status                       |
| ------- | ------- | ---------------------------- |
| 22.0.0  | 10.5.1  | Earliest on LTS release line |
| 22.23.0 | 10.9.8  |                              |
| 24.0.0  | 11.3.0  |                              |
| 24.17.0 | 11.13.0 | Active LTS                   |
| 26.0.0  | 11.12.1 |                              |
| 26.3.1  | 11.16.0 | Current                      |

Check that each version is able to build, and no `npm warn allow-scripts` is shown in logs:

```shell
git clone https://github.com/cypress-io/cypress-docker-images
cd cypress-docker-images

cd factory
docker compose build factory
cd ..

cd examples/basic-mini

docker build --progress plain --build-arg NODE_VERSION="22.0.0" --build-arg CYPRESS_VERSION="15.17.0" -f Dockerfile.factory -t test . --no-cache

docker build --progress plain --build-arg NODE_VERSION="24.17.0" --build-arg CYPRESS_VERSION="15.17.0" -f Dockerfile.factory -t test . --no-cache

docker build --progress plain --build-arg NODE_VERSION="26.3.1" --build-arg CYPRESS_VERSION="15.17.0" -f Dockerfile.factory -t test . --no-cache

cd ../..
```

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Single-line change to the Docker build install script; no auth, data, or application runtime paths affected.
> 
> **Overview**
> Bumps **cypress/factory** to **8.1.2** and updates the Cypress global install in `factory/installScripts/cypress/install.sh` to pass **`--allow-scripts=cypress`** on `npm install -g`.
> 
> This opts in to Cypress’s postinstall script under npm’s **allow-scripts** behavior (npm ≥11.16), which removes **`npm warn allow-scripts`** during image builds and aligns with stricter npm 12 expectations. No other install steps or runtime behavior change beyond the documented version bump.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c8527c253cec24a94e65abca3e4ca68c3980be9e. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->