### PR TITLE
chore: increment cypress to v15.18.0; ms edge -> 149.0.4022.80-1

### DIFF
--- a/factory/.env
+++ b/factory/.env
@@ -33,11 +33,11 @@ CHROME_VERSION='149.0.7827.155-1'
 CHROME_FOR_TESTING_VERSION='150.0.7871.24'
 
 # Cypress versions: https://www.npmjs.com/package/cypress
-CYPRESS_VERSION='15.17.0'
+CYPRESS_VERSION='15.18.0'
 
 # Edge versions: https://packages.microsoft.com/repos/edge/pool/main/m/microsoft-edge-stable/
 # Linux/amd64 only
-EDGE_VERSION='149.0.4022.69-1'
+EDGE_VERSION='149.0.4022.80-1'
 
 # Firefox versions: https://download-installer.cdn.mozilla.net/pub/firefox/releases/
 # Linux/amd64 for all versions, Linux/arm64 for versions 136.0 and above


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Routine version pin updates in the factory env file with no application or security logic changes.
> 
> **Overview**
> Updates the primary Cypress Docker factory version pins in `factory/.env` so generated images track the latest supported Cypress and Edge releases.
> 
> **Cypress** moves from `15.17.0` to **`15.18.0`**, which updates `INCLUDED_IMAGE_SHORT_TAG` and the `cypress-*` portion of `INCLUDED_IMAGE_TAG`. **Microsoft Edge** moves from `149.0.4022.69-1` to **`149.0.4022.80-1`**, which updates the `edge-*` segment of `BROWSERS_IMAGE_TAG` (and thus included image tags that embed the browsers tag).
> 
> No Dockerfile or install script logic changes—only the pinned versions that downstream factory builds consume.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 785d20d80f2764ff2126c18a4758e70f97ea7e4f. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->