### PR TITLE
fix(deps): update to Node.js 24.18.0

### DIFF
--- a/factory/.env
+++ b/factory/.env
@@ -11,37 +11,37 @@ BASE_IMAGE='debian:13.5-slim'
 # Node Versions: https://nodejs.org/en/download/releases/
 # master branch needs "Active LTS" version
 # use feature branch for "Maintenance LTS" or "Current" versions
-FACTORY_DEFAULT_NODE_VERSION='24.17.0'
+FACTORY_DEFAULT_NODE_VERSION='24.18.0'
 
 # Node Versions: https://nodejs.org/en/download/releases/
 NODE_VERSION="${FACTORY_DEFAULT_NODE_VERSION}"
 
 # Update the FACTORY_VERSION to deploy cypress/factory if you make changes to
 # BASE_IMAGE, FACTORY_DEFAULT_NODE_VERSION, YARN_VERSION, factory.Dockerfile or installScripts
-FACTORY_VERSION='8.2.0'
+FACTORY_VERSION='8.2.1'
 
 # Cypress officially supports the latest 3 major versions of Chrome, Firefox, and Edge only
 
 # Chrome versions: https://www.ubuntuupdates.org/package/google_chrome/stable/main/base/google-chrome-stable
 # Linux/amd64 only
 # Earlier versions of Google Chrome may no longer be available from http://dl.google.com
-CHROME_VERSION='149.0.7827.155-1'
+CHROME_VERSION='149.0.7827.200-1'
 
 # Chrome for Testing versions: https://googlechromelabs.github.io/chrome-for-testing/
 # not currently used for cypress/browsers and cypress/included images
 # Linux/amd64 only
-CHROME_FOR_TESTING_VERSION='150.0.7871.24'
+CHROME_FOR_TESTING_VERSION='149.0.7827.201'
 
 # Cypress versions: https://www.npmjs.com/package/cypress
 CYPRESS_VERSION='15.18.0'
 
 # Edge versions: https://packages.microsoft.com/repos/edge/pool/main/m/microsoft-edge-stable/
 # Linux/amd64 only
-EDGE_VERSION='149.0.4022.80-1'
+EDGE_VERSION='149.0.4022.98-1'
 
 # Firefox versions: https://download-installer.cdn.mozilla.net/pub/firefox/releases/
 # Linux/amd64 for all versions, Linux/arm64 for versions 136.0 and above
-FIREFOX_VERSION='152.0'
+FIREFOX_VERSION='152.0.3'
 
 # Geckodriver versions: https://github.com/mozilla/geckodriver/releases
 # Geckodriver documentation: https://firefox-source-docs.mozilla.org/testing/geckodriver/index.html

--- a/factory/CHANGELOG.md
+++ b/factory/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Change log
 
+## 8.2.1
+
+- Updated `FACTORY_DEFAULT_NODE_VERSION` from `24.17.0` to `24.18.0`.
+  Addresses [#1536](https://github.com/cypress-io/cypress-docker-images/issues/1536).
+
 ## 8.2.0
 
 - Modified Cypress install script to use separate `cypress install`, instead of implicit `postinstall` script to install Cypress binary.


### PR DESCRIPTION
- Closes https://github.com/cypress-io/cypress-docker-images/issues/1536

## Situation

- Node.js released an update [Node.js v24.18.0 LTS](https://github.com/nodejs/node/releases/tag/v24.18.0) on June 23, 2026.

## Change

In [factory/.env](https://github.com/cypress-io/cypress-docker-images/blob/master/factory/.env) make the following updates:

| Environment variable         | Before           | After            |
| ---------------------------- | ---------------- | ---------------- |
| FACTORY_VERSION              | 8.2.0            | 8.2.1            |
| FACTORY_DEFAULT_NODE_VERSION | 24.17.0          | 24.18.0          |
| CHROME_VERSION               | 149.0.7827.155-1 | 149.0.7827.200-1 |
| CHROME_FOR_TESTING_VERSION   | 150.0.7871.24    | 149.0.7827.201   |
| EDGE_VERSION                 | 149.0.4022.80-1  | 149.0.4022.98-1  |
| FIREFOX_VERSION              | 152.0            | 152.0.3          |
| GECKODRIVER_VERSION          | 0.37.0           | no change        |


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Routine version-pin bumps in factory config and changelog only; no application logic or security-sensitive code paths change.
> 
> **Overview**
> Bumps **`cypress/factory`** primary toolchain versions in `factory/.env` and records **8.2.1** in `factory/CHANGELOG.md`.
> 
> **Node** moves from `24.17.0` to **Active LTS `24.18.0`** via `FACTORY_DEFAULT_NODE_VERSION` (and thus `NODE_VERSION` / image tags). **`FACTORY_VERSION`** is raised to **`8.2.1`** so a new factory image is published for this change.
> 
> The same `.env` update also refreshes bundled browser pins: Chrome, Chrome for Testing, Edge, and Firefox patch levels. Cypress and Geckodriver versions are unchanged.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit be75754bdee15e91f0669b389753127ee38754c0. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->