### PR TITLE
chore(factory): bump Cypress 15.18.1 and browser pins

### DIFF
--- a/factory/.env
+++ b/factory/.env
@@ -25,23 +25,23 @@ FACTORY_VERSION='8.2.1'
 # Chrome versions: https://www.ubuntuupdates.org/package/google_chrome/stable/main/base/google-chrome-stable
 # Linux/amd64 only
 # Earlier versions of Google Chrome may no longer be available from http://dl.google.com
-CHROME_VERSION='149.0.7827.200-1'
+CHROME_VERSION='150.0.7871.46-1'
 
 # Chrome for Testing versions: https://googlechromelabs.github.io/chrome-for-testing/
 # not currently used for cypress/browsers and cypress/included images
 # Linux/amd64 only
-CHROME_FOR_TESTING_VERSION='149.0.7827.201'
+CHROME_FOR_TESTING_VERSION='150.0.7871.46'
 
 # Cypress versions: https://www.npmjs.com/package/cypress
-CYPRESS_VERSION='15.18.0'
+CYPRESS_VERSION='15.18.1'
 
 # Edge versions: https://packages.microsoft.com/repos/edge/pool/main/m/microsoft-edge-stable/
 # Linux/amd64 only
-EDGE_VERSION='149.0.4022.98-1'
+EDGE_VERSION='150.0.4078.48-1'
 
 # Firefox versions: https://download-installer.cdn.mozilla.net/pub/firefox/releases/
 # Linux/amd64 for all versions, Linux/arm64 for versions 136.0 and above
-FIREFOX_VERSION='152.0.3'
+FIREFOX_VERSION='152.0.5'
 
 # Geckodriver versions: https://github.com/mozilla/geckodriver/releases
 # Geckodriver documentation: https://firefox-source-docs.mozilla.org/testing/geckodriver/index.html


### PR DESCRIPTION
Updates `factory/.env` to the latest Cypress release and latest stable browser versions:

- Cypress `15.18.0` → `15.18.1`
- Chrome `149.0.7827.200-1` → `150.0.7871.46-1`
- Chrome for Testing `149.0.7827.201` → `150.0.7871.46`
- Edge `149.0.4022.98-1` → `150.0.4078.48-1`
- Firefox `152.0.3` → `152.0.5`

Geckodriver stays at `0.37.0` (current latest).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Routine dependency pin updates in the factory env file with no application logic or security-sensitive code changes.
> 
> **Overview**
> Refreshes primary version pins in `factory/.env` so factory-derived Docker images track the latest Cypress patch and current stable browsers.
> 
> **Cypress** moves from `15.18.0` to `15.18.1`. **Chrome** and **Chrome for Testing** advance to the 150 line (`150.0.7871.46`). **Edge** updates to `150.0.4078.48-1`, and **Firefox** to `152.0.5`. **Geckodriver** is unchanged at `0.37.0`.
> 
> Because `BROWSERS_IMAGE_TAG` and `INCLUDED_IMAGE_TAG` embed these values, this change is what drives new `cypress/browsers` and `cypress/included` image tags on release—not a `FACTORY_VERSION` bump.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 6c4cf491effa0e3aac584aa590043c4d7b9e1ae0. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->