### PR TITLE
docs: update test-project README for cypress binary installation

### DIFF
--- a/factory/test-project/README.md
+++ b/factory/test-project/README.md
@@ -6,14 +6,12 @@ This project can be updated to the latest Cypress default scaffolded E2E test sp
 
 ```shell
 rm -rf cypress cypress.config.js
-npm install cypress@latest --no-package-lock
-npx cypress open
+npm install cypress@latest --no-package-lock --ignore-scripts
+npx cypress install
+npx cypress open --e2e --browser electron
 ```
 
-- Select "E2E Testing"
 - Select "Continue"
-- Select "Electron" browser
-- Select "Start E2E Testing in Electron"
 - Select "Scaffold example specs"
 - Close all Cypress windows
 


### PR DESCRIPTION
## Situation

The [factory/test-project/README.MD](https://github.com/cypress-io/cypress-docker-images/blob/master/factory/test-project/README.MD) contains instructions for maintainers who need to update the [factory/test-project](https://github.com/cypress-io/cypress-docker-images/blob/master/factory/test-project/README.MD).

These instructions produce warnings when used with Node.js 24.18.0 with bundled npm@11.16.0:

```console
npm warn allow-scripts 1 package has install scripts not yet covered by allowScripts:
npm warn allow-scripts   cypress@15.18.1 (postinstall: node dist/index.js --exec install)
npm warn allow-scripts
npm warn allow-scripts Run `npm approve-scripts --allow-scripts-pending` to review, or `npm approve-scripts <pkg>` to allow.
```

## Change

Update the [README.MD](https://github.com/cypress-io/cypress-docker-images/blob/master/factory/test-project/README.MD) documentation:

Use a separate step to install the Cypress binary to avoid npm warning about the `postinstall` script and jump directly into the E2E setup with Electron to reduce the number of other manual steps:

```shell
npm install cypress@latest --no-package-lock --ignore-scripts
npx cypress install --e2e --browser electron
```

This is similar to the way that [factory/installScripts/cypress/install.sh](https://github.com/cypress-io/cypress-docker-images/blob/master/factory/installScripts/cypress/install.sh) installs `cypress`.

Rename the file extension from `.MD` to `.md` for consistency with other README files in the repo.

## Verification

Execute:

```shell
git clone https://github.com/cypress-io/cypress-docker-images
cd cypress-docker-images
```

then follow the instructions in the `README` in the [factory/test-project](https://github.com/cypress-io/cypress-docker-images/blob/master/factory/test-project) directory, confirming that the instructions work as described.

## Predictions

Ultimately, when npm@12 is rolled out as packaged in a Node.js Active LTS version, the warnings would turn to a blocked installation. I don't expect this to become mainstream until the future Node.js 27 version is released and transitions to Active LTS status in October 2027. Bundling decisions for npm@12 are however still pending with the Node.js Releasers Team, and so this may be decided differently.

Implementing this PR guards against whatever bundling decisions are made and avoids npm blocking the Cypress binary installation during manual update of the `test-project`.


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only change to maintainer workflow; no runtime or security impact.
> 
> **Overview**
> Updates **factory/test-project** maintainer docs so Cypress is installed with `--ignore-scripts`, then the binary is fetched via `npx cypress install`, matching **factory/installScripts/cypress/install.sh**.
> 
> `npx cypress open` now passes `--e2e --browser electron`, so maintainers skip the GUI prompts for E2E mode and Electron. Several obsolete manual selection steps were removed from the checklist.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 62c58435af85cfa0320e4eb6b540fce16d15e8f7. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->