### PR TITLE
chore(factory): remove node install script unsupported architectures

### DIFF
--- a/factory/installScripts/node/default.sh
+++ b/factory/installScripts/node/default.sh
@@ -7,11 +7,7 @@ groupadd --gid 1000 node \
 ARCH= && dpkgArch="$(dpkg --print-architecture)" \
     && case "${dpkgArch##*-}" in \
       amd64) ARCH='x64';; \
-      ppc64el) ARCH='ppc64le';; \
-      s390x) ARCH='s390x';; \
       arm64) ARCH='arm64';; \
-      armhf) ARCH='armv7l';; \
-      i386) ARCH='x86';; \
       *) echo "unsupported architecture"; exit 1 ;; \
     esac \
     && set -ex \


### PR DESCRIPTION
## Situation

The installation script for Node.js [factory/installScripts/node/default.sh](https://github.com/cypress-io/cypress-docker-images/blob/master/factory/installScripts/node/default.sh), which was originally derived from https://github.com/nodejs/docker-node/blob/main/Dockerfile-slim.template, supports architectures that are unsupported by Cypress.

Cypress supports only `x64` and `arm64` under Linux according to [Cypress Documentation > Operating System](https://docs.cypress.io/app/get-started/install-cypress#Operating-System)

The Node.js script [factory/installScripts/node/default.sh](https://github.com/cypress-io/cypress-docker-images/blob/master/factory/installScripts/node/default.sh) lists:

| Debian name | Node.js name      | Docker hub name  | Cypress support |
| ----------- | ----------------- | ---------------- | --------------- |
| `amd64`     | `x64`             | `linux/amd64`    | YES             |
| `ppc64el`   | `ppc64le`         | `linux/ppc64le`  | NO              |
| `s390x`     | `s390x`           | `linux/s390x`    | NO              |
| `arm64`     | `arm64`           | `linux/arm64/v8` | YES             |
| `armhf`     | `armv7l` (32 bit) | `linux/arm/v7`   | NO              |
| `i386`      | `x86` (32 bit)    | `linux/386`      | NO              |

## Change

Remove the following architectures from [factory/installScripts/node/default.sh](https://github.com/cypress-io/cypress-docker-images/blob/master/factory/installScripts/node/default.sh):

| Debian name | Node.js name      |
| ----------- | ----------------- |
| `ppc64el`   | `ppc64le`         |
| `s390x`     | `s390x`           |
| `armhf`     | `armv7l` (32 bit) |
| `i386`      | `x86` (32 bit)    |

for consistency with other build scripts, leaving:

| Debian name | Node.js name |
| ----------- | ------------ |
| `amd64`     | `x64`        |
| `arm64`     | `arm64`      |

 Attempting to build on the unsupported architectures using `cypress/factory` will result in a clear build error "unsupported architecture" and immediate exit. This should however never be needed, which is why this PR is marked only as `chore` without releasing a new version of `cypress/factory`.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Narrowing supported build targets in a factory install script; only affects builds on architectures Cypress already does not support.
> 
> **Overview**
> Aligns the **Node.js install script** (`factory/installScripts/node/default.sh`) with Cypress’s supported Linux platforms by trimming the `dpkg --print-architecture` case statement.
> 
> **Removed** Debian→Node mappings for `ppc64el`, `s390x`, `armhf`, and `i386`; **kept** only `amd64` → `x64` and `arm64` → `arm64`. Any other architecture still hits the existing `unsupported architecture` exit path instead of downloading a Node build Cypress does not support.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 60497609a2b93370a60de9619bb0ba7af16b1742. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->