### PR TITLE
feat: update BASE_IMAGE to debian:13.6-slim (trixie)

### DIFF
--- a/factory/.env
+++ b/factory/.env
@@ -6,7 +6,7 @@
 
 # Use Debian stable release https://www.debian.org/releases/stable/
 # The Debian image cypress/factory is based on
-BASE_IMAGE='debian:13.5-slim'
+BASE_IMAGE='debian:13.6-slim'
 
 # Node Versions: https://nodejs.org/en/download/releases/
 # master branch needs "Active LTS" version
@@ -18,26 +18,26 @@ NODE_VERSION="${FACTORY_DEFAULT_NODE_VERSION}"
 
 # Update the FACTORY_VERSION to deploy cypress/factory if you make changes to
 # BASE_IMAGE, FACTORY_DEFAULT_NODE_VERSION, YARN_VERSION, factory.Dockerfile or installScripts
-FACTORY_VERSION='8.2.1'
+FACTORY_VERSION='8.3.0'
 
 # Cypress officially supports the latest 3 major versions of Chrome, Firefox, and Edge only
 
 # Chrome versions: https://www.ubuntuupdates.org/package/google_chrome/stable/main/base/google-chrome-stable
 # Linux/amd64 only
 # Earlier versions of Google Chrome may no longer be available from http://dl.google.com
-CHROME_VERSION='150.0.7871.46-1'
+CHROME_VERSION='150.0.7871.114-1'
 
 # Chrome for Testing versions: https://googlechromelabs.github.io/chrome-for-testing/
 # not currently used for cypress/browsers and cypress/included images
 # Linux/amd64 only
-CHROME_FOR_TESTING_VERSION='150.0.7871.46'
+CHROME_FOR_TESTING_VERSION='150.0.7871.114'
 
 # Cypress versions: https://www.npmjs.com/package/cypress
 CYPRESS_VERSION='15.18.1'
 
 # Edge versions: https://packages.microsoft.com/repos/edge/pool/main/m/microsoft-edge-stable/
 # Linux/amd64 only
-EDGE_VERSION='150.0.4078.48-1'
+EDGE_VERSION='150.0.4078.65-1'
 
 # Firefox versions: https://download-installer.cdn.mozilla.net/pub/firefox/releases/
 # Linux/amd64 for all versions, Linux/arm64 for versions 136.0 and above

--- a/factory/CHANGELOG.md
+++ b/factory/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Change log
 
+## 8.3.0
+
+- Updated Debian `BASE_IMAGE` from `debian:13.5-slim` to `debian:13.6-slim`
+  using [Debian 13.6 (trixie)](https://www.debian.org/releases/trixie/).
+  Addresses [#1540](https://github.com/cypress-io/cypress-docker-images/issues/1540).
+
 ## 8.2.1
 
 - Updated `FACTORY_DEFAULT_NODE_VERSION` from `24.17.0` to `24.18.0`.


### PR DESCRIPTION
- closes https://github.com/cypress-io/cypress-docker-images/issues/1540

## Situation

Cypress Docker images built from [factory/.env](https://github.com/cypress-io/cypress-docker-images/blob/master/factory/.env) currently use `BASE_IMAGE='debian:13.5-slim'`. [Debian 13.6 (trixie)](https://www.debian.org/releases/trixie/), which was [released](https://www.debian.org/News/2026/20260711) on July 11, 2026, supersedes Debian 13.5 (trixie).

## Change

Update the base image for `cypress/factory` to use [Debian 13.6 (trixie)](https://www.debian.org/releases/trixie/).

The environment variables in [factory/.env](https://github.com/cypress-io/cypress-docker-images/blob/master/factory/.env) that control the default build process, are updated as follows:

| Environment variable         | Before           | After            |
| ---------------------------- | ---------------- | ---------------- |
| BASE_IMAGE                   | debian:13.5-slim | debian:13.6-slim |
| FACTORY_VERSION              | 8.2.1            | 8.3.0            |
| FACTORY_DEFAULT_NODE_VERSION | 24.18.0          | no change        |
| CHROME_VERSION               | 150.0.7871.46-1  | 150.0.7871.114-1 |
| CHROME_FOR_TESTING_VERSION   | 150.0.7871.46    | 150.0.7871.114   |
| EDGE_VERSION                 | 150.0.4078.48-1  | 150.0.4078.65-1  |
| FIREFOX_VERSION              | 152.0.5          | no change        |
| GECKODRIVER_VERSION          | 0.37.0           | no change        |

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changing the OS base and browser versions affects all downstream cypress/factory-derived images; risk is moderate but typical for routine factory maintenance releases.
> 
> **Overview**
> Bumps **`cypress/factory`** default build pins in `factory/.env`: **`BASE_IMAGE`** moves from `debian:13.5-slim` to **`debian:13.6-slim`**, and **`FACTORY_VERSION`** from `8.2.1` to **`8.3.0`** so a new factory image deploys per project rules.
> 
> The same release also refreshes bundled browser pins—**Chrome**, **Chrome for Testing**, and **Edge**—to newer 150.x builds; Node, Firefox, Geckodriver, and Cypress versions are unchanged.
> 
> **`factory/CHANGELOG.md`** adds an **8.3.0** entry documenting the Debian base update (closes #1540).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 5b44b89261379ce788b68291e2c4653302b8d677. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->