### PR TITLE
chore(factory): prepare Cypress 15.19.0 release and bump browser pins

### DIFF
--- a/factory/.env
+++ b/factory/.env
@@ -25,29 +25,29 @@ FACTORY_VERSION='8.3.0'
 # Chrome versions: https://www.ubuntuupdates.org/package/google_chrome/stable/main/base/google-chrome-stable
 # Linux/amd64 only
 # Earlier versions of Google Chrome may no longer be available from http://dl.google.com
-CHROME_VERSION='150.0.7871.114-1'
+CHROME_VERSION='150.0.7871.128-1'
 
 # Chrome for Testing versions: https://googlechromelabs.github.io/chrome-for-testing/
 # not currently used for cypress/browsers and cypress/included images
 # Linux/amd64 only
-CHROME_FOR_TESTING_VERSION='150.0.7871.114'
+CHROME_FOR_TESTING_VERSION='150.0.7871.128'
 
 # Cypress versions: https://www.npmjs.com/package/cypress
-CYPRESS_VERSION='15.18.1'
+CYPRESS_VERSION='15.19.0'
 
 # Edge versions: https://packages.microsoft.com/repos/edge/pool/main/m/microsoft-edge-stable/
 # Linux/amd64 only
-EDGE_VERSION='150.0.4078.65-1'
+EDGE_VERSION='150.0.4078.83-1'
 
 # Firefox versions: https://download-installer.cdn.mozilla.net/pub/firefox/releases/
 # Linux/amd64 for all versions, Linux/arm64 for versions 136.0 and above
-FIREFOX_VERSION='152.0.5'
+FIREFOX_VERSION='153.0'
 
 # Geckodriver versions: https://github.com/mozilla/geckodriver/releases
 # Geckodriver documentation: https://firefox-source-docs.mozilla.org/testing/geckodriver/index.html
 # Linux/amd64 and Linux/arm64 for all versions
 # Minimum version is 0.34.0
-GECKODRIVER_VERSION='0.37.0'
+GECKODRIVER_VERSION='0.37.1'
 
 # Yarn v1 Classic:
 # https://classic.yarnpkg.com/latest-version


### PR DESCRIPTION
## What changed

Updates `factory/.env` for the Cypress **15.19.0** release, bumping browser and driver pins to the latest available versions:

| Variable | Before | After |
|---|---|---|
| `CYPRESS_VERSION` | 15.18.1 | **15.19.0** |
| `CHROME_VERSION` | 150.0.7871.114-1 | **150.0.7871.128-1** |
| `CHROME_FOR_TESTING_VERSION` | 150.0.7871.114 | **150.0.7871.128** |
| `EDGE_VERSION` | 150.0.4078.65-1 | **150.0.4078.83-1** |
| `FIREFOX_VERSION` | 152.0.5 | **153.0** |
| `GECKODRIVER_VERSION` | 0.37.0 | **0.37.1** |

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Config-only version pin updates in `factory/.env` with no factory Dockerfile or install-script changes.
> 
> **Overview**
> Updates **`factory/.env`** for the **Cypress 15.19.0** Docker release by bumping primary version pins: **`CYPRESS_VERSION`** 15.18.1 → 15.19.0, plus aligned browser/driver updates (**Chrome** / **Chrome for Testing** 150.0.7871.128, **Edge** 150.0.4078.83, **Firefox** 153.0, **Geckodriver** 0.37.1).
> 
> **`FACTORY_VERSION`**, **Node**, and **base image** are unchanged, so this is a routine pin refresh that will drive new **`cypress/included`** and **`cypress/browsers`** image tags via the existing `INCLUDED_IMAGE_TAG` / `BROWSERS_IMAGE_TAG` formulas—not a factory image rebuild.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 24e27afbf06517d4313a8a29061c5df998dce291. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->