### PR TITLE
docs: add Node.js information to SECURITY

### DIFF
--- a/SECURITY.md
+++ b/SECURITY.md
@@ -15,6 +15,21 @@ Refer to [Debian security](https://www.debian.org/security/) for further informa
 
 Debian is used in [cypress/factory][factory], [cypress/base][base], [cypress/browsers][browsers] and [cypress/included][included] Cypress Docker images.
 
+## Node.js
+
+[Node.js][] is installed into Cypress Docker images, unchanged from the distribution on https://nodejs.org/download/release/.
+This includes bundles of certain products as described in the
+[Node.js Distribution Policy](https://github.com/nodejs/node/blob/main/doc/contributing/distribution.md) document.
+Fixes for the bundled products may be individually available before they are packaged and distributed.
+See the [README > Component bundles](./README.md#component-bundles) document section for information
+on updating these products independently of the Node.js releases.
+
+Refer to
+[Node.js security](https://github.com/nodejs/node/blob/main/SECURITY.md) and
+[npm security](https://github.com/npm/cli/blob/latest/SECURITY.md) for further information.
+
+[Node.js][] is installed in [cypress/base][base], [cypress/browsers][browsers] and [cypress/included][included] Cypress Docker images.
+
 ## Browsers
 
 Please refer to the associated browser owner's documentation regarding browser security vulnerabilities.
@@ -31,3 +46,4 @@ Cypress is included only in [cypress/included][included] Cypress Docker images.
 [base]: https://github.com/cypress-io/cypress-docker-images/tree/master/base
 [browsers]: https://github.com/cypress-io/cypress-docker-images/tree/master/browsers
 [included]: https://github.com/cypress-io/cypress-docker-images/tree/master/included
+[Node.js]: https://nodejs.org/


### PR DESCRIPTION
## Situation

The [SECURITY](https://github.com/cypress-io/cypress-docker-images/blob/master/SECURITY.md) document does not specifically mention Node.js.

Node.js bundles [npm](https://github.com/npm/cli#readme) and [Corepack](https://github.com/nodejs/corepack#readme).

[Vulnerabilities in npm packaged components](https://github.com/npm/cli/issues?q=is%3Aissue%20CVE%20in%3Atitle) are regularly reported and remediated.

Remediation can take up to 8 weeks before they are available in a [Node.js Active LTS](https://nodejs.org/en/about/previous-releases) due to Node.js release cycles, stabilization and compatibility policies.

## Change

Add a Node.js section to the [SECURITY](https://github.com/cypress-io/cypress-docker-images/blob/master/SECURITY.md) to inform about dealing with security issues relating to Node.js.

State that Cypress installs Node.js unchanged and give links to the [README > Component bundles](./README.md#component-bundles) document section for instructions on updating components.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only change to SECURITY.md with no runtime or image build behavior changes.
> 
> **Overview**
> Adds a **Node.js** section to `SECURITY.md` so security guidance matches Debian, Browsers, and Cypress.
> 
> The new text states that images ship Node.js unchanged from nodejs.org, that bundled products follow the Node.js distribution policy, and that fixes for those bundles may land before they appear in a Node release. It points readers to **README > Component bundles** for updating bundled tools outside Node releases, links to Node.js and npm security policies, and notes which image families include Node (`cypress/base`, `cypress/browsers`, `cypress/included`). A `[Node.js]` reference link is added at the bottom.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e6499a35f198e9fae7019a5d3b7ec5be826437ba. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->