### PR TITLE
docs: add Node.js updating information to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,8 +28,12 @@ In the case of Windows environments, see [Docker Desktop for Windows](https://do
 
 `cypress/base`, `cypress/browsers` and `cypress/included` include the following components:
 
-- Node.js (see [Node.js distribution policy](https://github.com/nodejs/node/blob/main/doc/contributing/distribution.md) for bundled components)
-- [corepack](https://github.com/nodejs/corepack) through Node.js - dropped in Node.js 25 and above
+- Node.js (see [Node.js distribution policy](https://github.com/nodejs/node/blob/main/doc/contributing/distribution.md) for bundled components).
+  Images with a `latest` tag track the [Node.js Active LTS release line](https://github.com/nodejs/release#release-schedule).
+- [npm](https://github.com/npm/cli) through Node.js.
+  To update the bundled version use `npm install -g npm@<version>`.
+- [corepack](https://github.com/nodejs/corepack) through Node.js - dropped in Node.js 25 and above.
+  To update the bundled version, or to install, use `npm install -g corepack@<version>`.
 - [Yarn v1 Classic](https://github.com/yarnpkg/yarn) installed globally with npm - dropped in Node.js 26 and above
 
 ## Browsers


### PR DESCRIPTION
## Situation

In the [README > Component bundles](https://github.com/cypress-io/cypress-docker-images#component-bundles) section, the bundling of Node.js components `npm` and `corepack` are mentioned.

It does not however describe what to do if these components are outdated.

[Node.js backporting policy](https://github.com/nodejs/node/blob/main/doc/contributing/backporting-to-release-lines.md#criteria-for-backporting) specifies a minimum of 2 weeks wait in the current release line before a commit is backported to the Active LTS release line. Current releases have a cadence of 2 weeks, Active LTS is based on a 4 week cadence (see release plans in https://github.com/nodejs/Release/issues). This adds up to 8 weeks settling-in time.

## Change

- Describe that published Cypress Docker images are based on the latest [Node.js Active LTS](https://nodejs.org/en/about/previous-releases) version.

- Add update information:

    ```shell
    npm install -g npm@<version>
    ```
    ```shell
    npm install -g corepack@<version>
    ```

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only README edits with no runtime, build, or security behavior changes.
> 
> **Overview**
> Expands the **Component bundles** section so readers know how `latest` images relate to Node and how to refresh bundled tooling without waiting for a new image.
> 
> **Node.js** now notes that `latest`-tagged images follow the **Node.js Active LTS** release line. **npm** and **corepack** are called out as separate bullets (with links), each with global update/install commands: `npm install -g npm@<version>` and `npm install -g corepack@<version>`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 0ae266356cb8249034e612cbcfa06c783e6e0c5b. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->