### PR TITLE
fix(deps): update to Node.js 24.18.1

### DIFF
--- a/factory/.env
+++ b/factory/.env
@@ -11,37 +11,37 @@ BASE_IMAGE='debian:13.6-slim'
 # Node Versions: https://nodejs.org/en/download/releases/
 # master branch needs "Active LTS" version
 # use feature branch for "Maintenance LTS" or "Current" versions
-FACTORY_DEFAULT_NODE_VERSION='24.18.0'
+FACTORY_DEFAULT_NODE_VERSION='24.18.1'
 
 # Node Versions: https://nodejs.org/en/download/releases/
 NODE_VERSION="${FACTORY_DEFAULT_NODE_VERSION}"
 
 # Update the FACTORY_VERSION to deploy cypress/factory if you make changes to
 # BASE_IMAGE, FACTORY_DEFAULT_NODE_VERSION, YARN_VERSION, factory.Dockerfile or installScripts
-FACTORY_VERSION='8.3.0'
+FACTORY_VERSION='8.3.1'
 
 # Cypress officially supports the latest 3 major versions of Chrome, Firefox, and Edge only
 
 # Chrome versions: https://www.ubuntuupdates.org/package/google_chrome/stable/main/base/google-chrome-stable
 # Linux/amd64 only
 # Earlier versions of Google Chrome may no longer be available from http://dl.google.com
-CHROME_VERSION='150.0.7871.128-1'
+CHROME_VERSION='150.0.7871.186-1'
 
 # Chrome for Testing versions: https://googlechromelabs.github.io/chrome-for-testing/
 # not currently used for cypress/browsers and cypress/included images
 # Linux/amd64 only
-CHROME_FOR_TESTING_VERSION='150.0.7871.128'
+CHROME_FOR_TESTING_VERSION='151.0.7922.47'
 
 # Cypress versions: https://www.npmjs.com/package/cypress
 CYPRESS_VERSION='15.19.0'
 
 # Edge versions: https://packages.microsoft.com/repos/edge/pool/main/m/microsoft-edge-stable/
 # Linux/amd64 only
-EDGE_VERSION='150.0.4078.83-1'
+EDGE_VERSION='150.0.4078.105-1'
 
 # Firefox versions: https://download-installer.cdn.mozilla.net/pub/firefox/releases/
 # Linux/amd64 for all versions, Linux/arm64 for versions 136.0 and above
-FIREFOX_VERSION='153.0'
+FIREFOX_VERSION='153.0.1'
 
 # Geckodriver versions: https://github.com/mozilla/geckodriver/releases
 # Geckodriver documentation: https://firefox-source-docs.mozilla.org/testing/geckodriver/index.html

--- a/factory/CHANGELOG.md
+++ b/factory/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Change log
 
+## 8.3.1
+
+- Updated `FACTORY_DEFAULT_NODE_VERSION` from `24.18.0` to `24.18.1`.
+  Addressed in [#1548](https://github.com/cypress-io/cypress-docker-images/issues/1548).
+
 ## 8.3.0
 
 - Updated Debian `BASE_IMAGE` from `debian:13.5-slim` to `debian:13.6-slim`


### PR DESCRIPTION
## Situation

- Node.js released a security update [Node.js v24.18.1 LTS](https://github.com/nodejs/node/releasgites/tag/v24.18.1) on July 29, 2026.

## Change

In [factory/.env](https://github.com/cypress-io/cypress-docker-images/blob/master/factory/.env) make the following updates:

| Environment variable         | Before           | After            |
| ---------------------------- | ---------------- | ---------------- |
| FACTORY_VERSION              | 8.3.0            | 8.3.1            |
| FACTORY_DEFAULT_NODE_VERSION | 24.18.0          | 24.18.1          |
| CHROME_VERSION               | 150.0.7871.128-1 | 150.0.7871.186-1 |
| CHROME_FOR_TESTING_VERSION   | 150.0.7871.128   | 151.0.7922.47    |
| EDGE_VERSION                 | 150.0.4078.83-1  | 150.0.4078.105-1 |
| FIREFOX_VERSION              | 153.0            | 153.0.1          |
| GECKODRIVER_VERSION          | 0.37.1           | no change        |

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Config-only version pin bumps with no application logic changes; main impact is rebuilt Docker images and tag churn.
> 
> **Overview**
> **Routine `cypress/factory` release 8.3.1** updates primary pinned versions in `factory/.env` so rebuilt images pick up Node.js **24.18.1** (Active LTS security patch) and bumps **`FACTORY_VERSION`** from `8.3.0` to `8.3.1`.
> 
> The same env file refresh also moves **Chrome**, **Chrome for Testing**, **Edge**, and **Firefox** to newer patch/minor builds; **`GECKODRIVER_VERSION`** and **`CYPRESS_VERSION`** are unchanged. Derived Docker image tags that embed `NODE_VERSION` and browser versions will change accordingly on the next factory deploy.
> 
> `factory/CHANGELOG.md` adds an **8.3.1** entry calling out the Node bump ([#1548](https://github.com/cypress-io/cypress-docker-images/issues/1548)).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e9e29924dec01f615a645f10193c0f6018b030b3. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->