### PR TITLE
fix(deps): update to Node.js 24.19.0

### DIFF
--- a/factory/.env
+++ b/factory/.env
@@ -11,33 +11,33 @@ BASE_IMAGE='debian:13.6-slim'
 # Node Versions: https://nodejs.org/en/download/releases/
 # master branch needs "Active LTS" version
 # use feature branch for "Maintenance LTS" or "Current" versions
-FACTORY_DEFAULT_NODE_VERSION='24.18.1'
+FACTORY_DEFAULT_NODE_VERSION='24.19.0'
 
 # Node Versions: https://nodejs.org/en/download/releases/
 NODE_VERSION="${FACTORY_DEFAULT_NODE_VERSION}"
 
 # Update the FACTORY_VERSION to deploy cypress/factory if you make changes to
 # BASE_IMAGE, FACTORY_DEFAULT_NODE_VERSION, YARN_VERSION, factory.Dockerfile or installScripts
-FACTORY_VERSION='8.3.1'
+FACTORY_VERSION='8.3.2'
 
 # Cypress officially supports the latest 3 major versions of Chrome, Firefox, and Edge only
 
 # Chrome versions: https://www.ubuntuupdates.org/package/google_chrome/stable/main/base/google-chrome-stable
 # Linux/amd64 only
 # Earlier versions of Google Chrome may no longer be available from http://dl.google.com
-CHROME_VERSION='150.0.7871.186-1'
+CHROME_VERSION='151.0.7922.71-1'
 
 # Chrome for Testing versions: https://googlechromelabs.github.io/chrome-for-testing/
 # not currently used for cypress/browsers and cypress/included images
 # Linux/amd64 only
-CHROME_FOR_TESTING_VERSION='151.0.7922.47'
+CHROME_FOR_TESTING_VERSION='151.0.7922.71'
 
 # Cypress versions: https://www.npmjs.com/package/cypress
 CYPRESS_VERSION='15.19.0'
 
 # Edge versions: https://packages.microsoft.com/repos/edge/pool/main/m/microsoft-edge-stable/
 # Linux/amd64 only
-EDGE_VERSION='150.0.4078.105-1'
+EDGE_VERSION='151.0.4129.59-1'
 
 # Firefox versions: https://download-installer.cdn.mozilla.net/pub/firefox/releases/
 # Linux/amd64 for all versions, Linux/arm64 for versions 136.0 and above

--- a/factory/CHANGELOG.md
+++ b/factory/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Change log
 
+## 8.3.2
+
+- Updated `FACTORY_DEFAULT_NODE_VERSION` from `24.18.1` to `24.19.ß`.
+  Addressed in [#1549](https://github.com/cypress-io/cypress-docker-images/issues/1549).
+
 ## 8.3.1
 
 - Updated `FACTORY_DEFAULT_NODE_VERSION` from `24.18.0` to `24.18.1`.


### PR DESCRIPTION
## Situation

- Node.js released an update [Node.js v24.19.0 LTS](https://github.com/nodejs/node/releases/tag/v24.19.0) on Aug 3, 2026.

## Change

In [factory/.env](https://github.com/cypress-io/cypress-docker-images/blob/master/factory/.env) make the following updates:

| Environment variable         | Before           | After           |
| ---------------------------- | ---------------- | --------------- |
| FACTORY_VERSION              | 8.3.1            | 8.3.2           |
| FACTORY_DEFAULT_NODE_VERSION | 24.18.1          | 24.19.0         |
| CHROME_VERSION               | 150.0.7871.186-1 | 151.0.7922.71-1 |
| CHROME_FOR_TESTING_VERSION   | 151.0.7922.47    | 151.0.7922.71   |
| EDGE_VERSION                 | 150.0.4078.105-1 | 151.0.4129.59-1 |
| FIREFOX_VERSION              | 153.0.1          | no change       |
| GECKODRIVER_VERSION          | 0.37.1           | no change       |

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Routine version pin updates for Docker factory images with no application logic changes; only risk is incorrect pins or the changelog typo misleading release notes.
> 
> **Overview**
> Bumps **cypress/factory** release pins in `factory/.env`: **`FACTORY_VERSION`** `8.3.1` → `8.3.2`, **`FACTORY_DEFAULT_NODE_VERSION`** `24.18.1` → `24.19.0`, plus **Chrome**, **Chrome for Testing**, and **Edge** to newer 151.x builds (Firefox/geckodriver unchanged).
> 
> Adds a **8.3.2** entry to `factory/CHANGELOG.md` for the Node bump. Note the changelog text uses **`24.19.ß`** instead of **`24.19.0`**, and it does not document the browser version updates that are in `.env`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit b0dbca6d741fe095ff0a0edc0f0fdf4f91ada65c. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->