### PR TITLE
docs: fix typo in Change log

### DIFF
--- a/factory/CHANGELOG.md
+++ b/factory/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## 8.3.2
 
-- Updated `FACTORY_DEFAULT_NODE_VERSION` from `24.18.1` to `24.19.ß`.
+- Updated `FACTORY_DEFAULT_NODE_VERSION` from `24.18.1` to `24.19.0`.
   Addressed in [#1549](https://github.com/cypress-io/cypress-docker-images/issues/1549).
 
 ## 8.3.1


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Documentation-only change to the changelog with no runtime or build impact.
> 
> **Overview**
> Corrects a typo in **`factory/CHANGELOG.md`** for the 8.3.2 entry: the target `FACTORY_DEFAULT_NODE_VERSION` is now **`24.19.0`** instead of the erroneous **`24.19.ß`**, matching the actual Node bump described in that release note.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 79b7b168a660138bea070db6b2ecaace05b97d9a. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->