### PR TITLE
chore(factory): prepare Cypress 15.20.0 release and bump Firefox pin

### DIFF
--- a/factory/.env
+++ b/factory/.env
@@ -33,7 +33,7 @@ CHROME_VERSION='151.0.7922.71-1'
 CHROME_FOR_TESTING_VERSION='151.0.7922.71'
 
 # Cypress versions: https://www.npmjs.com/package/cypress
-CYPRESS_VERSION='15.19.0'
+CYPRESS_VERSION='15.20.0'
 
 # Edge versions: https://packages.microsoft.com/repos/edge/pool/main/m/microsoft-edge-stable/
 # Linux/amd64 only
@@ -41,7 +41,7 @@ EDGE_VERSION='151.0.4129.59-1'
 
 # Firefox versions: https://download-installer.cdn.mozilla.net/pub/firefox/releases/
 # Linux/amd64 for all versions, Linux/arm64 for versions 136.0 and above
-FIREFOX_VERSION='153.0.1'
+FIREFOX_VERSION='153.0.3'
 
 # Geckodriver versions: https://github.com/mozilla/geckodriver/releases
 # Geckodriver documentation: https://firefox-source-docs.mozilla.org/testing/geckodriver/index.html


### PR DESCRIPTION
Prepares the Docker image release for Cypress `15.20.0`, following the primary-versions process in [CONTRIBUTING](https://github.com/cypress-io/cypress-docker-images/blob/master/CONTRIBUTING.md#primary-versions). Only `factory/.env` changes, so no `FACTORY_VERSION` bump or factory `CHANGELOG` entry is needed.

| Variable | Before | After |
| --- | --- | --- |
| `CYPRESS_VERSION` | `15.19.0` | `15.20.0` |
| `FIREFOX_VERSION` | `153.0.1` | `153.0.3` |

## Verification

- Firefox `153.0.3` — `LATEST_FIREFOX_VERSION` per [Mozilla product-details](https://product-details.mozilla.org/1.0/firefox_versions.json), up from `153.0.1`. Tarballs return 200 for both `linux-x86_64` and `linux-aarch64`.

Resulting image tags:

```
BROWSERS_IMAGE_TAG=node-24.19.0-chrome-151.0.7922.71-1-ff-153.0.3-edge-151.0.4129.59-1
INCLUDED_IMAGE_TAG=cypress-15.20.0-node-24.19.0-chrome-151.0.7922.71-1-ff-153.0.3-edge-151.0.4129.59-1
INCLUDED_IMAGE_SHORT_TAG=15.20.0
```

## ⚠️ Do not merge until Cypress 15.20.0 is published to npm

The latest version on npm is currently `15.19.0` (published 2026-07-21). The CircleCI version check compares the installed Cypress package version against `CYPRESS_VERSION`, so the build will fail until `15.20.0` is available on the registry.

## Out of scope

- `examples/*/package.json` (`cypress: ^15.16.0`), `factory/README.md` version examples, and `factory/test-project` scaffolding are refreshed in their own PRs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)