### PR TITLE
test: scaffold test-project using Cypress 15.20.0

### DIFF
--- a/factory/test-project/cypress/e2e/2-advanced-examples/misc.cy.js
+++ b/factory/test-project/cypress/e2e/2-advanced-examples/misc.cy.js
@@ -16,27 +16,6 @@ context('Misc', () => {
     // https://on.cypress/io/platform
     cy.log(`Platform ${Cypress.platform} architecture ${Cypress.arch}`)
 
-    // on CircleCI Windows build machines we have a failure to run bash shell
-    // https://github.com/cypress-io/cypress/issues/5169
-    // so skip some of the tests by passing flag "--expose circle=true"
-    const isCircleOnWindows = Cypress.platform === 'win32' && Cypress.expose('circle')
-
-    if (isCircleOnWindows) {
-      cy.log('Skipping test on CircleCI')
-
-      return
-    }
-
-    // cy.exec problem on Shippable CI
-    // https://github.com/cypress-io/cypress/issues/6718
-    const isShippable = Cypress.platform === 'linux' && Cypress.expose('shippable')
-
-    if (isShippable) {
-      cy.log('Skipping test on ShippableCI')
-
-      return
-    }
-
     cy.exec('echo Jane Lane')
       .its('stdout').should('contain', 'Jane Lane')
 


### PR DESCRIPTION
## Situation

- The [test-project](https://github.com/cypress-io/cypress-docker-images/tree/master/factory/test-project) was last updated through https://github.com/cypress-io/cypress-docker-images/pull/1519.

## Change

The [factory/test-project](https://github.com/cypress-io/cypress-docker-images/tree/master/factory/test-project) is aligned with scaffolded tests from Cypress 15.20.0 (current `latest`), following the instructions in the [factory/test-project/README.md](https://github.com/cypress-io/cypress-docker-images/blob/master/factory/test-project/README.md) document.

This updates `cypress/e2e/2-advanced-examples/misc.cy.js` to the latest version, so that the complete test project is aligned with Cypress 15.20.0.

The changes affect CircleCI on Windows and the Shippable CI. They should have no effect on testing Cypress Docker images.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Test-only change in an example spec with no production or Docker build logic affected.
> 
> **Overview**
> Updates **`misc.cy.js`** in the factory test project so the `cy.exec()` example matches the Cypress **15.20.0** scaffold.
> 
> The diff **removes** early-return guards that skipped the test when `Cypress.expose('circle')` (CircleCI on Windows) or `Cypress.expose('shippable')` (Shippable CI) were set. **`cy.exec()`** assertions now run unconditionally on all platforms, consistent with upstream example tests.
> 
> This is part of aligning the whole **`factory/test-project`** with Cypress 15.20.0; Docker image validation behavior should be unchanged because those CI-specific flags are not used in that workflow.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 8ab45d04fd186f79454f4c34b4bda03b6a6e4a02. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->