### PR TITLE
feat: add Chrome Linux/arm64 for 151 and above

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,7 +42,7 @@ Cypress Docker images [cypress/browsers](./browsers/) include browsers for the `
 
 | Browser                    |   `Linux/amd64`    | `Linux/arm64`                                                                |
 | -------------------------- | :----------------: | :--------------------------------------------------------------------------- |
-| [Google Chrome][Chrome]    | :white_check_mark: | see [#1188](https://github.com/cypress-io/cypress-docker-images/issues/1188) |
+| [Google Chrome][Chrome]    | :white_check_mark: | :white_check_mark:                                                           |
 | [Mozilla Firefox][Firefox] | :white_check_mark: | :white_check_mark:                                                           |
 | [Microsoft Edge][Edge]     | :white_check_mark: | see [#1189](https://github.com/cypress-io/cypress-docker-images/issues/1189) |
 
@@ -52,7 +52,7 @@ On POSIX-based systems, or with [Git for Windows](https://gitforwindows.org/) at
 
 [Tags](#tags) for [cypress/browsers](./browsers/) and [cypress/included](./included/) images show which versions of the browsers are loaded into the respective image.
 
-For `Linux/arm64` images, the lowest available Firefox version is `136`.
+For `Linux/arm64` images, the lowest available versions are Chrome `151` and Firefox `136`.
 
 Building a custom image with [cypress/factory](./factory/) allows selection of individual browsers from the above list.
 

--- a/browsers/README.md
+++ b/browsers/README.md
@@ -7,7 +7,9 @@
 ## Platforms
 
 `cypress/browsers` images are available for `Linux/amd64` and `Linux/arm64` platforms.
-`Linux/arm64` images contain no Chrome or Edge browsers. Firefox is included in `Linux/arm64` images starting with Firefox `136.0.2`.
+`Linux/arm64` images contain no Edge browser.
+Firefox is included in `Linux/arm64` images starting with Firefox `136.0.2`.
+Chrome is included in `Linux/arm64` images starting with Chrome `151`.
 
 ## Tags
 

--- a/circle.yml
+++ b/circle.yml
@@ -272,15 +272,14 @@ workflows:
             alias: factory-arm
             parameters:
               test-target:
-                [
-                  test-factory-electron,
-                  test-factory-firefox,
-                  test-factory-cypress-included-electron,
-                  test-factory-cypress-included-electron-non-root-user,
-                  test-factory-cypress-included-firefox,
-                  test-factory-cypress-included-firefox-non-root-user,
-                  test-factory-all-included-electron-only,
-                ]
+                - test-factory-electron
+                - test-factory-chrome
+                - test-factory-firefox
+                - test-factory-cypress-included-electron
+                - test-factory-cypress-included-electron-non-root-user
+                - test-factory-cypress-included-firefox
+                - test-factory-cypress-included-firefox-non-root-user
+                - test-factory-all-included-electron-only
               resourceClass: [arm.medium]
               target: [factory]
       - test-image:
@@ -288,21 +287,19 @@ workflows:
             alias: factory
             parameters:
               test-target:
-                [
-                  test-factory-electron,
-                  test-factory-chrome,
-                  test-factory-chrome-for-testing,
-                  test-factory-chrome-non-root-user,
-                  test-factory-firefox,
-                  test-factory-edge,
-                  test-factory-cypress-included-electron,
-                  test-factory-cypress-included-electron-non-root-user,
-                  test-factory-cypress-included-chrome,
-                  test-factory-cypress-included-firefox,
-                  test-factory-cypress-included-firefox-non-root-user,
-                  test-factory-cypress-included-edge,
-                  test-factory-all-included,
-                ]
+                - test-factory-electron
+                - test-factory-chrome
+                - test-factory-chrome-for-testing
+                - test-factory-chrome-non-root-user
+                - test-factory-firefox
+                - test-factory-edge
+                - test-factory-cypress-included-electron
+                - test-factory-cypress-included-electron-non-root-user
+                - test-factory-cypress-included-chrome
+                - test-factory-cypress-included-firefox
+                - test-factory-cypress-included-firefox-non-root-user
+                - test-factory-cypress-included-edge
+                - test-factory-all-included
               resourceClass: [medium]
               target: [factory]
       - test-image:
@@ -323,12 +320,11 @@ workflows:
           matrix:
             alias: browsers
             parameters:
-              test-target: [
-                  test-browsers-electron, #
-                  test-browsers-chrome,
-                  test-browsers-firefox,
-                  test-browsers-edge,
-                ]
+              test-target:
+                - test-browsers-electron
+                - test-browsers-chrome
+                - test-browsers-firefox
+                - test-browsers-edge
               resourceClass: [medium]
               target: [browsers]
 
@@ -336,29 +332,31 @@ workflows:
           matrix:
             alias: browsers-arm
             parameters:
-              test-target: [test-browsers-electron, test-browsers-firefox]
+              test-target:
+                - test-browsers-electron
+                - test-browsers-chrome
+                - test-browsers-firefox
               resourceClass: [arm.medium]
               target: [browsers]
       - test-image:
           matrix:
             alias: included
             parameters:
-              test-target: [
-                  test-included-electron, #
-                  test-included-chrome,
-                  test-included-firefox,
-                  test-included-edge,
-                ]
+              test-target:
+                - test-included-electron
+                - test-included-chrome
+                - test-included-firefox
+                - test-included-edge
               resourceClass: [medium]
               target: [included]
       - test-image:
           matrix:
             alias: included-arm
             parameters:
-              test-target: [
-                  test-included-electron, #
-                  test-included-firefox,
-                ]
+              test-target:
+                - test-included-electron
+                - test-included-chrome
+                - test-included-firefox
               resourceClass: [arm.medium]
               target: [included]
       # pushing the factory image must come first because the other images may pull it down to build

--- a/factory/.env
+++ b/factory/.env
@@ -23,7 +23,7 @@ FACTORY_VERSION='8.4.0'
 # Cypress officially supports the latest 3 major versions of Chrome, Firefox, and Edge only
 
 # Chrome versions: https://www.ubuntuupdates.org/package/google_chrome/stable/main/base/google-chrome-stable
-# Linux/amd64 only
+# Linux/amd64 for all versions, Linux/arm64 for versions 151 and above
 # Earlier versions of Google Chrome may no longer be available from http://dl.google.com
 CHROME_VERSION='151.0.7922.75-1'
 

--- a/factory/.env
+++ b/factory/.env
@@ -18,19 +18,19 @@ NODE_VERSION="${FACTORY_DEFAULT_NODE_VERSION}"
 
 # Update the FACTORY_VERSION to deploy cypress/factory if you make changes to
 # BASE_IMAGE, FACTORY_DEFAULT_NODE_VERSION, YARN_VERSION, factory.Dockerfile or installScripts
-FACTORY_VERSION='8.3.2'
+FACTORY_VERSION='8.4.0'
 
 # Cypress officially supports the latest 3 major versions of Chrome, Firefox, and Edge only
 
 # Chrome versions: https://www.ubuntuupdates.org/package/google_chrome/stable/main/base/google-chrome-stable
 # Linux/amd64 only
 # Earlier versions of Google Chrome may no longer be available from http://dl.google.com
-CHROME_VERSION='151.0.7922.71-1'
+CHROME_VERSION='151.0.7922.75-1'
 
 # Chrome for Testing versions: https://googlechromelabs.github.io/chrome-for-testing/
 # not currently used for cypress/browsers and cypress/included images
 # Linux/amd64 only
-CHROME_FOR_TESTING_VERSION='151.0.7922.71'
+CHROME_FOR_TESTING_VERSION='151.0.7922.76'
 
 # Cypress versions: https://www.npmjs.com/package/cypress
 CYPRESS_VERSION='15.20.0'

--- a/factory/CHANGELOG.md
+++ b/factory/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Change log
 
+## 8.4.0
+
+- Add factory support for Chrome `arm64` with versions `151` and above.
+  Addresses [#1188](https://github.com/cypress-io/cypress-docker-images/issues/1188).
+
 ## 8.3.2
 
 - Updated `FACTORY_DEFAULT_NODE_VERSION` from `24.18.1` to `24.19.0`.

--- a/factory/README.md
+++ b/factory/README.md
@@ -86,7 +86,7 @@ Example: `CHROME_VERSION='149.0.7827.155-1'`
 
 [Chrome versions](https://www.ubuntuupdates.org/package/google_chrome/stable/main/base/google-chrome-stable)
 
-This browser is currently available only for the `Linux/amd64` platform.
+This browser is available for the `Linux/amd64` platform in all versions, and for the `Linux/arm64` platform in Chrome `151` and above.
 
 ### CHROME_FOR_TESTING_VERSION
 

--- a/factory/installScripts/chrome/default.sh
+++ b/factory/installScripts/chrome/default.sh
@@ -1,7 +1,8 @@
 #! /bin/bash
 
 # Chrome offers a debian package, download the specific debian package and install it with apt-get to also install dependencies.
-wget --no-verbose -O /usr/src/google-chrome-stable_current_amd64.deb http://dl.google.com/linux/chrome/deb/pool/main/g/google-chrome-stable/google-chrome-stable_${1}_amd64.deb
+wget --no-verbose -O /usr/src/google-chrome-stable_current_${2}.deb \
+http://dl.google.com/linux/chrome/deb/pool/main/g/google-chrome-stable/google-chrome-stable_${1}_${2}.deb
 
 if [[ $? -ne 0 ]]; then
     echo "failed to download chrome. Check the version?"
@@ -9,7 +10,7 @@ if [[ $? -ne 0 ]]; then
 fi
 
 apt-get update
-apt-get install -f -y /usr/src/google-chrome-stable_current_amd64.deb
+apt-get install -f -y /usr/src/google-chrome-stable_current_${2}.deb
 
 # remove temp download
-rm -f /usr/src/google-chrome-stable_current_amd64.deb
+rm -f /usr/src/google-chrome-stable_current_${2}.deb

--- a/factory/installScripts/chrome/install-chrome-version.js
+++ b/factory/installScripts/chrome/install-chrome-version.js
@@ -8,15 +8,34 @@ if (!chromeVersion) {
   process.exit(0)
 }
 
-if (process.arch !== 'x64') {
-  console.log('Not downloading Chrome since we are not on x64. For arm64 status see https://crbug.com/677140')
-  process.exit(0)
+const chromeMajorVersion = chromeVersion.split('.').map(Number)[0]
+
+const architecture = process.arch
+let platformFilename
+
+switch (architecture) {
+  case 'x64':
+    platformFilename = 'amd64'
+    break
+  case 'arm64':
+    platformFilename = 'arm64'
+    if (chromeMajorVersion >= 151) {
+      break
+    }
+    else {
+      console.log(`Chrome ${chromeVersion} not available for arm64, minimum 151 required, skipping download`)
+      process.exit(0)
+    }
+  // eslint-disable-next-line no-fallthrough
+  default:
+    console.log(`Unsupported architecture ${architecture} for Chrome, skipping download`)
+    process.exit(0)
 }
 
-console.log('Installing Chrome version: ', chromeVersion)
+console.log(`Installing Chrome version ${chromeVersion} for ${architecture}`)
 
 // Insert logic here if needed to run a different install script based on chrome version.
-const install = spawn(`${__dirname}/default.sh`, [chromeVersion], { stdio: 'inherit' })
+const install = spawn(`${__dirname}/default.sh`, [chromeVersion, platformFilename], { stdio: 'inherit' })
 
 install.on('error', function (error) {
   console.log('child process errored with ' + error.toString())

--- a/included/README.md
+++ b/included/README.md
@@ -7,7 +7,9 @@
 ## Platforms
 
 `cypress/included` images are available for `Linux/amd64` and `Linux/arm64` platforms.
-`Linux/arm64` images contain no Chrome or Edge browsers. Firefox is included in `Linux/arm64` images starting with Firefox `136.0.2`.
+`Linux/arm64` images contain no Edge browser.
+Firefox is included in `Linux/arm64` images starting with Firefox `136.0.2`.
+Chrome is included in `Linux/arm64` images starting with Chrome `151`.
 
 ## Tags
 


### PR DESCRIPTION
- closes https://github.com/cypress-io/cypress-docker-images/issues/1188

## Situation

Previously, Google Chrome was available for Linux only with the `amd64` architecture. After announcing plans in the blog post [Bringing Chrome to ARM64 Linux Devices](https://blog.chromium.org/2026/03/bringing-chrome-to-arm64-linux-devices.html) in March 2026, an `arm64` build of Google Chrome became available in August 2026.

https://www.google.com/chrome/other-platforms/ now lists both `Debian/Ubuntu` and `Debian/Ubuntu ARM` as Linux choices.

## Change

Add Google Chrome to Cypress Docker images for the `Linux/arm64` platform, for Chrome 151.

In [factory/.env](https://github.com/cypress-io/cypress-docker-images/blob/master/factory/.env) make the following updates:

| Environment variable         | Before          | After           |
| ---------------------------- | --------------- | --------------- |
| FACTORY_VERSION              | 8.3.2           | 8.4.0           |
| FACTORY_DEFAULT_NODE_VERSION | 24.19.0         | no change       |
| CHROME_VERSION               | 151.0.7922.71-1 | 151.0.7922.75-1 |
| CHROME_FOR_TESTING_VERSION   | 151.0.7922.71   | 151.0.7922.76   |
| EDGE_VERSION                 | 151.0.4129.59-1 | no change       |
| FIREFOX_VERSION              | 153.0.3         | no change       |
| GECKODRIVER_VERSION          | 0.37.1          | no change       |

Chrome / arm64 tests are added to [circle.yml](https://github.com/cypress-io/cypress-docker-images/blob/master/circle.yml). List formatting in the pipeline is harmonized.

Documentation is updated.


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches image build/install scripts and expands arm64 CI coverage; wrong deb/arch logic could break factory builds or arm images, but scope is limited to Chrome installation paths.
> 
> **Overview**
> **Adds Google Chrome to `Linux/arm64` Cypress Docker images** (factory, browsers, and included) for Chrome **151+**, closing the long-standing arm64 Chrome gap ([#1188](https://github.com/cypress-io/cypress-docker-images/issues/1188)).
> 
> The factory Chrome installer no longer skips non-`x64` hosts: it maps `arm64` to the `arm64` `.deb`, requires major version ≥151 on arm64, and passes the platform into `default.sh` so downloads use `google-chrome-stable_*_{amd64|arm64}.deb`. **Factory release 8.4.0** bumps pinned Chrome/CfT versions in `factory/.env`.
> 
> **CI** runs Chrome browser/included tests on `arm.medium` and adds `test-factory-chrome` to the arm factory matrix; matrix `test-target` lists are normalized to YAML dash lists. **Docs** mark Chrome as supported on `Linux/arm64` and note minimum Chrome **151** alongside Firefox **136** on arm64.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit fa059dd167b9710c8fd4df9f84e18a6092e51f2a. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->