### PR TITLE
chore(factory): prepare Cypress 15.20.1 release and bump browser pins

### DIFF
--- a/factory/.env
+++ b/factory/.env
@@ -25,19 +25,19 @@ FACTORY_VERSION='8.4.0'
 # Chrome versions: https://www.ubuntuupdates.org/package/google_chrome/stable/main/base/google-chrome-stable
 # Linux/amd64 for all versions, Linux/arm64 for versions 151 and above
 # Earlier versions of Google Chrome may no longer be available from http://dl.google.com
-CHROME_VERSION='151.0.7922.75-1'
+CHROME_VERSION='151.0.7922.108-1'
 
 # Chrome for Testing versions: https://googlechromelabs.github.io/chrome-for-testing/
 # not currently used for cypress/browsers and cypress/included images
 # Linux/amd64 only
-CHROME_FOR_TESTING_VERSION='151.0.7922.76'
+CHROME_FOR_TESTING_VERSION='151.0.7922.77'
 
 # Cypress versions: https://www.npmjs.com/package/cypress
-CYPRESS_VERSION='15.20.0'
+CYPRESS_VERSION='15.20.1'
 
 # Edge versions: https://packages.microsoft.com/repos/edge/pool/main/m/microsoft-edge-stable/
 # Linux/amd64 only
-EDGE_VERSION='151.0.4129.59-1'
+EDGE_VERSION='151.0.4129.78-1'
 
 # Firefox versions: https://download-installer.cdn.mozilla.net/pub/firefox/releases/
 # Linux/amd64 for all versions, Linux/arm64 for versions 136.0 and above


### PR DESCRIPTION
Prepares the `cypress/included` and `cypress/browsers` images for the Cypress 15.20.1 release, and refreshes the browser pins that have moved since the 15.20.0 prep.

| Variable | Before | After |
| --- | --- | --- |
| `CYPRESS_VERSION` | 15.20.0 | 15.20.1 |
| `CHROME_VERSION` | 151.0.7922.75-1 | 151.0.7922.108-1 |
| `CHROME_FOR_TESTING_VERSION` | 151.0.7922.76 | 151.0.7922.77 |
| `EDGE_VERSION` | 151.0.4129.59-1 | 151.0.4129.78-1 |

`FIREFOX_VERSION` (153.0.3) and `GECKODRIVER_VERSION` (0.37.1) are already at the latest stable and are unchanged. `FACTORY_VERSION` is not bumped and there is no changelog entry, since this touches none of `BASE_IMAGE`, `FACTORY_DEFAULT_NODE_VERSION`, `YARN_VERSION`, `factory.Dockerfile`, or `installScripts`.

Each new pin was verified to resolve to a downloadable artifact: the Chrome deb for both `amd64` and `arm64`, the Chrome for Testing `linux64` zip, and the Edge `amd64` deb all return 200.

**Do not merge yet:** Cypress 15.20.1 is not published to npm at the time of opening. CI asserts that the installed Cypress package version equals `CYPRESS_VERSION`, so the build will be red until the npm publish lands. Re-run CI once it does.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Version-pin-only change in factory/.env with no Dockerfile or install-script edits; main operational risk is timing CI against the npm publish.
> 
> **Overview**
> Updates **`factory/.env`** so **`cypress/included`** and **`cypress/browsers`** image tags track a new Cypress patch and fresher browser builds.
> 
> **`CYPRESS_VERSION`** moves **15.20.0 → 15.20.1**, which drives **`INCLUDED_IMAGE_SHORT_TAG`** and the **`INCLUDED_IMAGE_TAG`** string. Chrome (**`CHROME_VERSION`**), Chrome for Testing (**`CHROME_FOR_TESTING_VERSION`**), and Edge (**`EDGE_VERSION`**) get minor patch bumps; **`FIREFOX_VERSION`**, **`GECKODRIVER_VERSION`**, and **`FACTORY_VERSION`** stay the same because factory base/install scripts were not touched.
> 
> CI will stay red until **15.20.1** is on npm, since builds assert the installed Cypress package matches **`CYPRESS_VERSION`**.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit fd14dac76d11718e224e8a49d9b6729e741b8811. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->