### PR TITLE
chore(factory): prepare Cypress 15.21.0 release and bump browser pins

### DIFF
--- a/factory/.env
+++ b/factory/.env
@@ -25,23 +25,23 @@ FACTORY_VERSION='8.4.0'
 # Chrome versions: https://www.ubuntuupdates.org/package/google_chrome/stable/main/base/google-chrome-stable
 # Linux/amd64 for all versions, Linux/arm64 for versions 151 and above
 # Earlier versions of Google Chrome may no longer be available from http://dl.google.com
-CHROME_VERSION='151.0.7922.108-1'
+CHROME_VERSION='151.0.7922.137-1'
 
 # Chrome for Testing versions: https://googlechromelabs.github.io/chrome-for-testing/
 # not currently used for cypress/browsers and cypress/included images
 # Linux/amd64 only
-CHROME_FOR_TESTING_VERSION='151.0.7922.77'
+CHROME_FOR_TESTING_VERSION='152.0.7977.42'
 
 # Cypress versions: https://www.npmjs.com/package/cypress
-CYPRESS_VERSION='15.20.1'
+CYPRESS_VERSION='15.21.0'
 
 # Edge versions: https://packages.microsoft.com/repos/edge/pool/main/m/microsoft-edge-stable/
 # Linux/amd64 only
-EDGE_VERSION='151.0.4129.78-1'
+EDGE_VERSION='151.0.4129.93-1'
 
 # Firefox versions: https://download-installer.cdn.mozilla.net/pub/firefox/releases/
 # Linux/amd64 for all versions, Linux/arm64 for versions 136.0 and above
-FIREFOX_VERSION='153.0.3'
+FIREFOX_VERSION='154.0'
 
 # Geckodriver versions: https://github.com/mozilla/geckodriver/releases
 # Geckodriver documentation: https://firefox-source-docs.mozilla.org/testing/geckodriver/index.html


### PR DESCRIPTION
Prepares the `cypress/included` and `cypress/browsers` images for the Cypress 15.21.0 release, and refreshes the browser pins that have moved since the 15.20.1 prep.

| Variable | Before | After |
| --- | --- | --- |
| `CYPRESS_VERSION` | 15.20.1 | 15.21.0 |
| `CHROME_VERSION` | 151.0.7922.108-1 | 151.0.7922.137-1 |
| `CHROME_FOR_TESTING_VERSION` | 151.0.7922.77 | 152.0.7977.42 |
| `EDGE_VERSION` | 151.0.4129.78-1 | 151.0.4129.93-1 |
| `FIREFOX_VERSION` | 153.0.3 | 154.0 |

`GECKODRIVER_VERSION` (0.37.1) is already at the latest stable and is unchanged. `FACTORY_VERSION` is not bumped and there is no changelog entry, since this touches none of `BASE_IMAGE`, `FACTORY_DEFAULT_NODE_VERSION`, `YARN_VERSION`, `factory.Dockerfile`, or `installScripts`.

Each new pin was verified to resolve to a downloadable artifact/version: Chrome stable via the official version-history API, the Chrome for Testing `linux64` zip (200), the Edge `amd64` deb listing, and Firefox via Mozilla's product-details API.

**Do not merge yet:** Cypress 15.21.0 is not published to npm at the time of opening. CI asserts that the installed Cypress package version equals `CYPRESS_VERSION`, so the build will be red until the npm publish lands. Re-run CI once it does.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Routine version-pin updates in factory/.env only; no Dockerfile or install-script changes, with the main operational risk being timing CI against the npm publish.
> 
> **Overview**
> Updates **`factory/.env`** primary version pins so **`cypress/included`** and **`cypress/browsers`** image tags move to **Cypress 15.21.0** and newer browser builds.
> 
> **`CYPRESS_VERSION`** goes from 15.20.1 → 15.21.0. Chrome stable, Chrome for Testing, Edge, and Firefox pins are refreshed (e.g. Firefox 153.0.3 → 154.0). **`GECKODRIVER_VERSION`** and **`FACTORY_VERSION`** are unchanged, so **`cypress/factory`** is not redeployed from this diff alone—only the derived **`BROWSERS_IMAGE_TAG`** / **`INCLUDED_IMAGE_TAG`** values change.
> 
> CI will stay red until **15.21.0** is on npm, since installs are checked against **`CYPRESS_VERSION`**.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 6312096dfd267a3374694c4bdaed5c36c6fa090e. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->