### PR TITLE
chore(renovate): disable updating base-internal & browsers-internal

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -2,7 +2,7 @@
   "configMigration": true,
   "dependencyDashboard": true,
   "extends": ["config:recommended"],
-  "ignorePaths": ["base-internal/**", "browsers-internal/**"],
+  "ignorePaths": ["**/node_modules/**", "base-internal/**", "browsers-internal/**"],
   "automerge": true,
   "minimumReleaseAge": "7 days",
   "osvVulnerabilityAlerts": true,

--- a/renovate.json
+++ b/renovate.json
@@ -2,6 +2,7 @@
   "configMigration": true,
   "dependencyDashboard": true,
   "extends": ["config:recommended"],
+  "ignorePaths": ["base-internal/**", "browsers-internal/**"],
   "automerge": true,
   "minimumReleaseAge": "7 days",
   "osvVulnerabilityAlerts": true,


### PR DESCRIPTION
## Situation

Renovate is attempting to update `Dockerfile` contents in `browsers-internal` directories in PR https://github.com/cypress-io/cypress-docker-images/pull/1560.

These Dockerfiles are however manually maintained records of builds with fixed versions and it is not desired to have them automatically updated.

## Change

Update [renovate.json](https://github.com/cypress-io/cypress-docker-images/blob/master/renovate.json) to exclude the directories `base-internal` and `browsers-internal` from any Renovate updates.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Config-only change to Renovate ignore rules; no runtime or deployment behavior changes.
> 
> **Overview**
> Renovate was opening PRs that auto-update **Dockerfiles** under `base-internal` and `browsers-internal`, which are **fixed-version build records** maintained by hand—not live dependencies to bump.
> 
> This PR adds **`ignorePaths`** in `renovate.json` so Renovate skips **`base-internal/**`** and **`browsers-internal/**`** (alongside the existing `**/node_modules/**` entry), stopping unwanted update PRs for those trees.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 5cdabf78e606d03c1ff32ab6c7988bdab1d1ca79. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->