### PR TITLE
chore(deps): convert package.json to private package

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -16,9 +16,6 @@
         "globals": "^17.11.0",
         "markdown-link-check": "^3.15.0",
         "prettier": "^3.9.6"
-      },
-      "engines": {
-        "node": ">=20.19.0"
       }
     },
     "node_modules/@eslint-community/eslint-utils": {

--- a/package.json
+++ b/package.json
@@ -2,18 +2,12 @@
   "name": "cypress-docker-images",
   "version": "1.0.0",
   "description": "These images provide all of the required dependencies for running Cypress in Docker.",
-  "main": "index.js",
-  "directories": {
-    "example": "examples"
-  },
+  "private": true,
   "scripts": {
     "check:markdown": "find . -type f -name '*.md' ! -path '*/node_modules/*' | xargs -L1 npx markdown-link-check -c markdownLinkConfig.json",
     "format": "prettier --write .",
     "format:check": "prettier --check .",
     "lint": "eslint"
-  },
-  "engines": {
-    "node": ">=20.19.0"
   },
   "repository": {
     "type": "git",


### PR DESCRIPTION
## Situation

- Renovate PR https://github.com/cypress-io/cypress-docker-images/pull/1566 attempted to update the `engines` field of [package.json](https://github.com/cypress-io/cypress-docker-images/blob/master/package.json).

- This highlighted the discrepancy that the repo is not intended for publication as an npm package to any registry. Rather it is intended as an in-place factory for generating Cypress Docker images. Artifacts are published to [Docker Hub](https://hub.docker.com/u/cypress). Users who want to build customized Cypress Docker images do not need to clone the repo. Instead they base their images on `cypress/factory` and specify configurations using parameters.

- The `engines.node` field is only relevant if it is expected that a published package will be used with different Node.js versions. Instead it is expected that script, builds and CI are run under the version of Node.js defined in [.node-version](https://github.com/cypress-io/cypress-docker-images/blob/master/.node-version) - currently set to Node.js `24.15.0`.

## Change

In [package.json](https://github.com/cypress-io/cypress-docker-images/blob/master/package.json)

- Set [private](https://docs.npmjs.com/cli/v12/configuring-npm/package-json#private) to `true`.

- Remove irrelevant content:
  - `main` (`index.js` does not exist)
  - `directories`
  - `engines`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Metadata-only `package.json` cleanup with no runtime, CI script, or dependency behavior changes beyond dropping the unused engines constraint.
> 
> **Overview**
> Marks the root `package.json` as **`private: true`** so the repo is treated as an internal tooling manifest for Docker image builds, not something meant for npm publication.
> 
> It also **removes publish-oriented fields** that no longer apply: the nonexistent `main` entry, `directories.example`, and **`engines.node`** (Node for local/CI scripts is expected to follow **`.node-version`** instead). `package-lock.json` is updated to match the root package definition.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 5bd37bac9edba76d0cffd303cdd6382752ca0bda. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->