### PR TITLE
chore(renovate): set cypress minimumReleaseAge to 0 (no wait)

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -23,6 +23,10 @@
     {
       "matchPackageNames": ["/eslint/", "globals"],
       "groupName": "eslint"
+    },
+    {
+      "matchPackageNames": ["cypress"],
+      "minimumReleaseAge": "0 days"
     }
   ]
 }


### PR DESCRIPTION
## Situation

The [renovate.json](https://github.com/cypress-io/cypress-docker-images/blob/master/renovate.json) configuration sets `"minimumReleaseAge": "7 days"`

Other Cypress repos have removed the restriction for Cypress and allow upgrade without waiting.

## Change

In [renovate.json](https://github.com/cypress-io/cypress-docker-images/blob/master/renovate.json) add:

```json
    {
      "matchPackageNames": ["cypress"],
      "minimumReleaseAge": "0 days"
    }
```

to `packageRules` to allow Renovate to update [cypress](https://www.npmjs.com/package/cypress) immediately after publication of a new version to the npm registry.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Renovate-only configuration with no runtime or security impact; only affects when Cypress version bump PRs are created.
> 
> **Overview**
> **Renovate** still waits **7 days** before proposing most dependency bumps, but this PR adds a **`packageRules`** entry for the **`cypress`** npm package with **`minimumReleaseAge": "0 days"`**, so Renovate can open Cypress upgrade PRs as soon as a new version is published.
> 
> This aligns Cypress self-updates with other Cypress repos and does not change automerge, grouping, or other Renovate behavior.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit fc348f6183eb2dc3f3f580cee38f2debe9d66592. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->