### PR TITLE
chore(renovate): ignore .node-version & .nvmrc

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -2,7 +2,7 @@
   "configMigration": true,
   "dependencyDashboard": true,
   "extends": ["config:recommended"],
-  "ignorePaths": ["**/node_modules/**", "base-internal/**", "browsers-internal/**"],
+  "ignorePaths": ["**/node_modules/**", "base-internal/**", "browsers-internal/**", ".node-version", ".nvmrc"],
   "automerge": true,
   "minimumReleaseAge": "7 days",
   "osvVulnerabilityAlerts": true,


### PR DESCRIPTION
## Situation

Renovate will attempt to update the version of Node.js in:

- [.node-version](https://github.com/cypress-io/cypress-docker-images/blob/master/.node-version)
- [.nvmrc](https://github.com/cypress-io/cypress-docker-images/blob/master/.nvmrc)

which is currently set to select Node.js `24.15.0`.

This version is aligned to the currently used [CircleCI machine image](https://circleci.com/developer/images?imageType=machine) specified in [circle.yml](https://github.com/cypress-io/cypress-docker-images/blob/master/circle.yml) which is [ubuntu-2404:2026.05.1](https://discuss.circleci.com/t/ubuntu-22-04-24-04-26-04-q2-2026-edge-release-including-cuda/54579) and is the latest currently available from CircleCI.

The version needs to be manually maintained to keep this alignment.

## Change

In [renovate.json](https://github.com/cypress-io/cypress-docker-images/blob/master/renovate.json) add the following to `ignorePaths`:

- [.node-version](https://github.com/cypress-io/cypress-docker-images/blob/master/.node-version)
- [.nvmrc](https://github.com/cypress-io/cypress-docker-images/blob/master/.nvmrc)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Configuration-only change to Renovate; no runtime, CI, or application behavior is modified.
> 
> **Overview**
> Renovate’s `ignorePaths` now includes **`.node-version`** and **`.nvmrc`**, so it will no longer open PRs to bump the pinned Node.js version in those files.
> 
> Those versions stay **manually aligned** with the CircleCI machine image in `circle.yml` rather than tracking Renovate’s Node dependency updates.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit b8ed514f0c9e090ae17cb116b4be577537c868b9. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->