### PR TITLE
chore(factory): prepare Cypress 15.21.1 release and bump browser pins

### DIFF
--- a/factory/.env
+++ b/factory/.env
@@ -25,23 +25,23 @@ FACTORY_VERSION='8.4.0'
 # Chrome versions: https://www.ubuntuupdates.org/package/google_chrome/stable/main/base/google-chrome-stable
 # Linux/amd64 for all versions, Linux/arm64 for versions 151 and above
 # Earlier versions of Google Chrome may no longer be available from http://dl.google.com
-CHROME_VERSION='151.0.7922.137-1'
+CHROME_VERSION='151.0.7922.173-1'
 
 # Chrome for Testing versions: https://googlechromelabs.github.io/chrome-for-testing/
 # not currently used for cypress/browsers and cypress/included images
 # Linux/amd64 only
-CHROME_FOR_TESTING_VERSION='152.0.7977.42'
+CHROME_FOR_TESTING_VERSION='152.0.7977.54'
 
 # Cypress versions: https://www.npmjs.com/package/cypress
-CYPRESS_VERSION='15.21.0'
+CYPRESS_VERSION='15.21.1'
 
 # Edge versions: https://packages.microsoft.com/repos/edge/pool/main/m/microsoft-edge-stable/
 # Linux/amd64 only
-EDGE_VERSION='151.0.4129.93-1'
+EDGE_VERSION='151.0.4129.107-1'
 
 # Firefox versions: https://download-installer.cdn.mozilla.net/pub/firefox/releases/
 # Linux/amd64 for all versions, Linux/arm64 for versions 136.0 and above
-FIREFOX_VERSION='154.0'
+FIREFOX_VERSION='154.0.1'
 
 # Geckodriver versions: https://github.com/mozilla/geckodriver/releases
 # Geckodriver documentation: https://firefox-source-docs.mozilla.org/testing/geckodriver/index.html


### PR DESCRIPTION
Prepares the `cypress/included` and `cypress/browsers` images for the Cypress 15.21.1 release, and refreshes the browser pins that have moved since the 15.21.0 prep.

| Variable | Before | After |
| --- | --- | --- |
| `CYPRESS_VERSION` | 15.21.0 | 15.21.1 |
| `CHROME_VERSION` | 151.0.7922.137-1 | 151.0.7922.173-1 |
| `CHROME_FOR_TESTING_VERSION` | 152.0.7977.42 | 152.0.7977.54 |
| `EDGE_VERSION` | 151.0.4129.93-1 | 151.0.4129.107-1 |
| `FIREFOX_VERSION` | 154.0 | 154.0.1 |

`GECKODRIVER_VERSION` (0.37.1) is already at the latest stable and is unchanged. `FACTORY_VERSION` is not bumped and there is no changelog entry, since this touches none of `BASE_IMAGE`, `FACTORY_DEFAULT_NODE_VERSION`, `YARN_VERSION`, `factory.Dockerfile`, or `installScripts`.

Each new pin was verified to resolve to a downloadable artifact: the Chrome stable `amd64` and `arm64` debs on `dl.google.com` (200), the Chrome for Testing `linux64` zip (200), the Edge `amd64` deb in the Microsoft pool (200), and the Firefox `linux-x86_64` and `linux-aarch64` tarballs on Mozilla's CDN (200). Cypress 15.21.1 is published to npm.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Configuration-only version pin updates for Docker image builds; no application logic, auth, or infrastructure code changes.
> 
> **Overview**
> Updates **`factory/.env`** version pins to prepare **`cypress/included`** and **`cypress/browsers`** for the **Cypress 15.21.1** release, and refreshes browser packages that moved since the 15.21.0 prep.
> 
> **Cypress** goes from `15.21.0` to **`15.21.1`**. **Chrome**, **Chrome for Testing**, **Edge**, and **Firefox** pins are bumped to newer stable builds (`151.0.7922.173-1`, `152.0.7977.54`, `151.0.4129.107-1`, and `154.0.1` respectively). **`GECKODRIVER_VERSION`** and **`FACTORY_VERSION`** are unchanged, so **`cypress/factory`** is not redeployed from this change alone—only the derived **`INCLUDED_IMAGE_*`** and **`BROWSERS_IMAGE_*`** tags that reference these variables will shift when images are built.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 32a2814edb4bfd5c610ea2906d8e31e237b77d82. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->