### PR TITLE
fix(deps): update to Node.js 24.20.0

### DIFF
--- a/factory/.env
+++ b/factory/.env
@@ -11,26 +11,26 @@ BASE_IMAGE='debian:13.6-slim'
 # Node Versions: https://nodejs.org/en/download/releases/
 # master branch needs "Active LTS" version
 # use feature branch for "Maintenance LTS" or "Current" versions
-FACTORY_DEFAULT_NODE_VERSION='24.19.0'
+FACTORY_DEFAULT_NODE_VERSION='24.20.0'
 
 # Node Versions: https://nodejs.org/en/download/releases/
 NODE_VERSION="${FACTORY_DEFAULT_NODE_VERSION}"
 
 # Update the FACTORY_VERSION to deploy cypress/factory if you make changes to
 # BASE_IMAGE, FACTORY_DEFAULT_NODE_VERSION, YARN_VERSION, factory.Dockerfile or installScripts
-FACTORY_VERSION='8.4.0'
+FACTORY_VERSION='8.4.1'
 
 # Cypress officially supports the latest 3 major versions of Chrome, Firefox, and Edge only
 
 # Chrome versions: https://www.ubuntuupdates.org/package/google_chrome/stable/main/base/google-chrome-stable
 # Linux/amd64 for all versions, Linux/arm64 for versions 151 and above
 # Earlier versions of Google Chrome may no longer be available from http://dl.google.com
-CHROME_VERSION='151.0.7922.173-1'
+CHROME_VERSION='152.0.7977.64-1'
 
 # Chrome for Testing versions: https://googlechromelabs.github.io/chrome-for-testing/
 # not currently used for cypress/browsers and cypress/included images
 # Linux/amd64 only
-CHROME_FOR_TESTING_VERSION='152.0.7977.54'
+CHROME_FOR_TESTING_VERSION='152.0.7977.64'
 
 # Cypress versions: https://www.npmjs.com/package/cypress
 CYPRESS_VERSION='15.21.1'

--- a/factory/CHANGELOG.md
+++ b/factory/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Change log
 
+## 8.4.1
+
+- Updated `FACTORY_DEFAULT_NODE_VERSION` from `24.19.0` to `24.20.0`.
+  Addressed in [#1574](https://github.com/cypress-io/cypress-docker-images/issues/1574).
+
 ## 8.4.0
 
 - Add factory support for Chrome `arm64` with versions `151` and above.

--- a/factory/CHANGELOG.md
+++ b/factory/CHANGELOG.md
@@ -3,7 +3,7 @@
 ## 8.4.1
 
 - Updated `FACTORY_DEFAULT_NODE_VERSION` from `24.19.0` to `24.20.0`.
-  Addressed in [#1574](https://github.com/cypress-io/cypress-docker-images/issues/1574).
+  Addressed in [#1574](https://github.com/cypress-io/cypress-docker-images/pull/1574).
 
 ## 8.4.0
 
@@ -13,12 +13,12 @@
 ## 8.3.2
 
 - Updated `FACTORY_DEFAULT_NODE_VERSION` from `24.18.1` to `24.19.0`.
-  Addressed in [#1549](https://github.com/cypress-io/cypress-docker-images/issues/1549).
+  Addressed in [#1549](https://github.com/cypress-io/cypress-docker-images/pull/1549).
 
 ## 8.3.1
 
 - Updated `FACTORY_DEFAULT_NODE_VERSION` from `24.18.0` to `24.18.1`.
-  Addressed in [#1548](https://github.com/cypress-io/cypress-docker-images/issues/1548).
+  Addressed in [#1548](https://github.com/cypress-io/cypress-docker-images/pull/1548).
 
 ## 8.3.0
 


### PR DESCRIPTION
## Situation

- Node.js released an update [Node.js v24.20.0 LTS](https://github.com/nodejs/node/releases/tag/v24.20.0) on Aug 26, 2026.

## Change

In [factory/.env](https://github.com/cypress-io/cypress-docker-images/blob/master/factory/.env) make the following updates:

| Environment variable         | Before           | After           |
| ---------------------------- | ---------------- | --------------- |
| FACTORY_VERSION              | 8.4.0            | 8.4.1           |
| FACTORY_DEFAULT_NODE_VERSION | 24.19.0          | 24.20.0         |
| CHROME_VERSION               | 151.0.7922.173-1 | 152.0.7977.64-1 |
| CHROME_FOR_TESTING_VERSION   | 152.0.7977.54    | 152.0.7977.64   |
| EDGE_VERSION                 | 151.0.4129.107-1 | no change       |
| FIREFOX_VERSION              | 154.0.1          | no change       |
| GECKODRIVER_VERSION          | 0.37.1           | no change       |

Also, minor tweak to PR links that confusingly used an `issue` link. This did work, but was misleading, so it has been corrected.


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Routine dependency version pins and changelog edits; no application logic or install script changes in this diff.
> 
> **Overview**
> Bumps **cypress/factory** release **8.4.0 → 8.4.1** in `factory/.env`, driven mainly by **Node.js Active LTS `24.19.0` → `24.20.0`** (`FACTORY_DEFAULT_NODE_VERSION`, which still feeds `NODE_VERSION`).
> 
> Also refreshes bundled browser pins in the same file: **Chrome stable** `151.0.7922.173-1` → `152.0.7977.64-1` and **Chrome for Testing** `152.0.7977.54` → `152.0.7977.64`.
> 
> Documents the release in `factory/CHANGELOG.md` with a new **8.4.1** entry, and corrects a few older changelog links that pointed at **issues** URLs to **pull** URLs instead.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 9f24e5b2476a96e91e560cfcddba5c8bae9fbc5b. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->