### PR TITLE
test: drop cy.exec() from test-project for Cypress 16 compatibility

### DIFF
--- a/factory/test-project/cypress/e2e/2-advanced-examples/misc.cy.js
+++ b/factory/test-project/cypress/e2e/2-advanced-examples/misc.cy.js
@@ -5,40 +5,6 @@ context('Misc', () => {
     cy.visit('https://example.cypress.io/commands/misc')
   })
 
-  it('cy.exec() - execute a system command', () => {
-    // execute a system command.
-    // so you can take actions necessary for
-    // your test outside the scope of Cypress.
-    // https://on.cypress.io/exec
-
-    // we can use Cypress.platform string to
-    // select appropriate command
-    // https://on.cypress/io/platform
-    cy.log(`Platform ${Cypress.platform} architecture ${Cypress.arch}`)
-
-    cy.exec('echo Jane Lane')
-      .its('stdout').should('contain', 'Jane Lane')
-
-    if (Cypress.platform === 'win32') {
-      cy.exec(`print ${Cypress.config('configFile')}`)
-        .its('stderr').should('be.empty')
-    }
-    else {
-      cy.exec(`cat ${Cypress.config('configFile')}`)
-        .its('stderr').should('be.empty')
-
-      cy.log(`Cypress version ${Cypress.version}`)
-      if (Cypress.version.split('.').map(Number)[0] < 15) {
-        cy.exec('pwd')
-          .its('code').should('eq', 0)
-      }
-      else {
-        cy.exec('pwd')
-          .its('exitCode').should('eq', 0)
-      }
-    }
-  })
-
   it('cy.focused() - get the DOM element that has focus', () => {
     // https://on.cypress.io/focused
     cy.get('.misc-form').find('#name').click()


### PR DESCRIPTION
## Situation

- The [test-project](https://github.com/cypress-io/cypress-docker-images/tree/master/factory/test-project) is scaffolded for Cypress 15.

- Breaking changes for Cypress 16 include dropping `cy.exec()` which is tested in [factory/test-project/cypress/e2e/2-advanced-examples/misc.cy.js](https://github.com/cypress-io/cypress-docker-images/blob/master/factory/test-project/cypress/e2e/2-advanced-examples/misc.cy.js)

## Change

The [factory/test-project](https://github.com/cypress-io/cypress-docker-images/tree/master/factory/test-project) is aligned with [cypress-example-kitchensink@6.1.0](https://github.com/cypress-io/cypress-example-kitchensink/releases/tag/v6.1.0) by manually cherry-picking the test spec deletions in https://github.com/cypress-io/cypress-example-kitchensink/commit/7790b145b6920ec1e55b6a952d2000cbfe1a6b9a

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Test-only change in sample e2e specs with no production or runtime impact.
> 
> **Overview**
> Removes the **`cy.exec()`** advanced-example test from `misc.cy.js` so the factory **test-project** no longer depends on a Cypress API dropped in **Cypress 16**.
> 
> The **Misc** suite still covers **`cy.focused()`**, screenshot helpers, and **`cy.wrap()`**; only the shell-command example (platform-specific `echo`/`cat`/`pwd` checks) is deleted, matching the kitchensink **v6.1.0** cherry-pick noted in the PR.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a5c872bd7454f4befefaa48625f7f3f149abade7. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->