### PR TITLE
chore(factory): prepare Cypress 16.0.0 release and bump browser pins

### DIFF
--- a/factory/.env
+++ b/factory/.env
@@ -33,15 +33,15 @@ CHROME_VERSION='152.0.7977.64-1'
 CHROME_FOR_TESTING_VERSION='152.0.7977.64'
 
 # Cypress versions: https://www.npmjs.com/package/cypress
-CYPRESS_VERSION='15.21.1'
+CYPRESS_VERSION='16.0.0'
 
 # Edge versions: https://packages.microsoft.com/repos/edge/pool/main/m/microsoft-edge-stable/
 # Linux/amd64 only
-EDGE_VERSION='151.0.4129.107-1'
+EDGE_VERSION='152.0.4191.53-1'
 
 # Firefox versions: https://download-installer.cdn.mozilla.net/pub/firefox/releases/
 # Linux/amd64 for all versions, Linux/arm64 for versions 136.0 and above
-FIREFOX_VERSION='154.0.1'
+FIREFOX_VERSION='155.0'
 
 # Geckodriver versions: https://github.com/mozilla/geckodriver/releases
 # Geckodriver documentation: https://firefox-source-docs.mozilla.org/testing/geckodriver/index.html


### PR DESCRIPTION
Prepares the `cypress/included` and `cypress/browsers` images for the Cypress 16.0.0 release, and refreshes the browser pins that have moved since the 15.21.1 prep.

| Variable | Before | After |
| --- | --- | --- |
| `CYPRESS_VERSION` | 15.21.1 | 16.0.0 |
| `EDGE_VERSION` | 151.0.4129.107-1 | 152.0.4191.53-1 |
| `FIREFOX_VERSION` | 154.0.1 | 155.0 |

`CHROME_VERSION` (152.0.7977.64-1), `CHROME_FOR_TESTING_VERSION` (152.0.7977.64), and `GECKODRIVER_VERSION` (0.37.1) are already at the latest stable and are unchanged.

Cypress 16.0.0 is a major release that drops Node 20 support (`engines.node` is now `^22.0.0 || ^24.0.0 || >=26.0.0`, verified via `npm view cypress@16.0.0 engines`). `FACTORY_DEFAULT_NODE_VERSION` (24.20.0) already satisfies that range, so it is left unchanged. `FACTORY_VERSION` is not bumped and there is no changelog entry, since this touches none of `BASE_IMAGE`, `FACTORY_DEFAULT_NODE_VERSION`, `YARN_VERSION`, `factory.Dockerfile`, or `installScripts`.

Each new pin was verified to resolve to a downloadable artifact/version: the Edge `amd64` deb in the Microsoft pool, and Firefox via Mozilla's product-details API plus a 200 on the `linux-x86_64` `.tar.xz`.

**Do not merge yet:** as of this writing, npm's `dist-tags.latest` for `cypress` is still `15.21.1`; `16.0.0` is published but tagged `dev`. `npm install -g cypress@16.0.0` (what `installScripts/cypress/install.sh` runs) resolves by exact version and isn't affected by the dist-tag, so this isn't expected to fail CI's version-match check on its own — but per team precedent (#1557, #1558), this PR is opened as a draft ahead of the `latest` promotion so it's ready to merge once Cypress promotes 16.0.0 to `latest` and CI is confirmed green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Major Cypress and browser version pins change what ships in official Docker images and can break consumers still on Node 20 or older browser assumptions.
> 
> **Overview**
> Updates **`factory/.env`** to prep **`cypress/included`** and **`cypress/browsers`** for Cypress **16.0.0** and refresh browser pins: **`CYPRESS_VERSION`** 15.21.1 → 16.0.0, **`EDGE_VERSION`** → 152.0.4191.53-1, **`FIREFOX_VERSION`** → 155.0. Chrome, Chrome for Testing, and Geckodriver pins stay as-is.
> 
> Those values feed **`INCLUDED_IMAGE_*`** and **`BROWSERS_IMAGE_*`** tags, so merging triggers new derived images without a **`FACTORY_VERSION`** bump. Cypress 16 is a major release (Node 20 no longer supported); existing **`FACTORY_DEFAULT_NODE_VERSION`** (24.20.0) already meets its engine range.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a64cf798139a31f9d96c84a76d98382e5ef434c5. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->