### PR TITLE
test: scaffold test-project using Cypress 16.0.0

### DIFF
--- a/factory/test-project/cypress.config.js
+++ b/factory/test-project/cypress.config.js
@@ -1,8 +1,6 @@
 const { defineConfig } = require("cypress");
 
 module.exports = defineConfig({
-  allowCypressEnv: false,
-
   e2e: {
     setupNodeEvents(on, config) {
       // implement node event listeners here


### PR DESCRIPTION
## Situation

- The [test-project](https://github.com/cypress-io/cypress-docker-images/tree/master/factory/test-project) is currently in a hybrid state containing migration changes intended to allow both Cypress 15 and 16 tests to run.

- Running under Cypress 16 however causes the following warning to be shown:

  > The allowCypressEnv configuration option was removed in Cypress version 16.0.0.

## Change

The [factory/test-project](https://github.com/cypress-io/cypress-docker-images/tree/master/factory/test-project) is aligned with scaffolded tests from Cypress 16.0.0 (current `latest`), following the instructions in the [factory/test-project/README.md](https://github.com/cypress-io/cypress-docker-images/blob/master/factory/test-project/README.md) document.

This removes the Cypress 15 configuration option `allowCypressEnv: false` from [factory/test-project/cypress.config.js](https://github.com/cypress-io/cypress-docker-images/blob/master/factory/test-project/cypress.config.js).

## Verification

```shell
cd factory/test-project
docker run --rm -v .:/app -w /app --entrypoint cypress cypress/included:16.0.0 run -b chrome
```

confirm that there are no warning messages and that all tests succeed.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Single config cleanup in the Docker factory test project with no runtime or security impact.
> 
> **Overview**
> Removes the **`allowCypressEnv: false`** entry from `factory/test-project/cypress.config.js` so the factory test project matches Cypress **16.0.0** scaffolding and no longer triggers the removal warning for that option.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit be10348b0d7cae13a3acfad4c86c291d3a5309a7. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->