### PR TITLE
test(deps): extend Chrome for Testing Linux/arm64 (examples)

### DIFF
--- a/.github/workflows/example-tests.yml
+++ b/.github/workflows/example-tests.yml
@@ -5,6 +5,7 @@ on:
   push:
     paths:
       - examples/**
+      - .github/workflows/example-tests.yml
   pull_request:
   workflow_dispatch:
 
@@ -16,21 +17,17 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        directory: [
-            basic-mini, # testing cypress/included
-            basic, # testing cypress/browsers
-            chrome-for-testing,
-            chromium,
-            firefox-esr,
-            included-as-non-root,
-          ]
-        os: [
-            ubuntu-24.04, # testing Linux/amd64 platform
-            ubuntu-24.04-arm, # testing Linux/arm64 platform
-          ]
-        exclude:
-          - os: ubuntu-24.04-arm
-            directory: chrome-for-testing # browser not available for Linux/arm64
+        directory:
+          - basic-mini # testing cypress/included
+          - basic # testing cypress/browsers
+          - chrome-for-testing
+          - chromium
+          - firefox-esr
+          - included-as-non-root
+        os:
+          - ubuntu-24.04 # testing Linux/amd64 platform
+          - ubuntu-24.04-arm # testing Linux/arm64 platform
+
     runs-on: ${{ matrix.os }}
     timeout-minutes: 15
     steps:

--- a/examples/chrome-for-testing/Dockerfile
+++ b/examples/chrome-for-testing/Dockerfile
@@ -5,8 +5,9 @@ WORKDIR /opt/app
 RUN npx cypress install
 # Install Chrome for Testing
 ARG CHROME_VERSION=stable
+ARG PLATFORM_FILENAME=chrome-linux64
 RUN INSTALL_OUTPUT=$(npx @puppeteer/browsers install chrome@${CHROME_VERSION} --path /tmp/chrome-for-testing) && \
-DOWNLOAD_DIR=$(echo "$INSTALL_OUTPUT" | grep -o '\/.*\/chrome-linux64') && \
+DOWNLOAD_DIR=$(echo "$INSTALL_OUTPUT" | grep -o "/.*/${PLATFORM_FILENAME}") && \
 mv $DOWNLOAD_DIR /opt/chrome-for-testing
 RUN apt-get update && \
     while read -r pkg; do \

--- a/examples/chrome-for-testing/Dockerfile
+++ b/examples/chrome-for-testing/Dockerfile
@@ -5,10 +5,15 @@ WORKDIR /opt/app
 RUN npx cypress install
 # Install Chrome for Testing
 ARG CHROME_VERSION=stable
-ARG PLATFORM_FILENAME=chrome-linux64
-RUN INSTALL_OUTPUT=$(npx @puppeteer/browsers install chrome@${CHROME_VERSION} --path /tmp/chrome-for-testing) && \
-DOWNLOAD_DIR=$(echo "$INSTALL_OUTPUT" | grep -o "/.*/${PLATFORM_FILENAME}") && \
-mv $DOWNLOAD_DIR /opt/chrome-for-testing
+ARG TARGETARCH
+RUN case "${TARGETARCH}" in \
+      amd64) PLATFORM_FILENAME=chrome-linux64 ;; \
+      arm64) PLATFORM_FILENAME=chrome-linux-arm64 ;; \
+      *) echo "Unsupported architecture: ${TARGETARCH}" && exit 1 ;; \
+    esac && \
+    INSTALL_OUTPUT=$(npx @puppeteer/browsers install chrome@${CHROME_VERSION} --path /tmp/chrome-for-testing) && \
+    DOWNLOAD_DIR=$(echo "$INSTALL_OUTPUT" | grep -o "/.*/${PLATFORM_FILENAME}") && \
+    mv $DOWNLOAD_DIR /opt/chrome-for-testing
 RUN apt-get update && \
     while read -r pkg; do \
         apt-get satisfy -y --no-install-recommends "$pkg"; \

--- a/examples/chrome-for-testing/README.md
+++ b/examples/chrome-for-testing/README.md
@@ -1,8 +1,11 @@
 # examples/chrome-for-testing
 
-This directory contains a simple example of a Cypress E2E test with one test spec `cypress/e2e/spec.cy.js` running using the [Google Chrome for Testing](https://developer.chrome.com/blog/chrome-for-testing/) browser under the `linux/amd64` platform.
+This directory contains a simple example of a Cypress E2E test with one test spec `cypress/e2e/spec.cy.js` running using the
+[Google Chrome for Testing](https://developer.chrome.com/blog/chrome-for-testing/) browser
+under the `linux/amd64` and `linux/arm64` platforms.
 
-Note that Chrome for Testing is currently not available for the `linux/arm64` platform.
+[Chrome for Testing > Supported platforms](https://github.com/GoogleChromeLabs/chrome-for-testing#supported-platforms)
+lists `linux/arm64` as supported since `v153.0.8001.0`.
 
 ## Docker
 
@@ -12,28 +15,10 @@ The example below downloads Chrome for Testing using [@puppeteer/browsers](https
 
 ### Docker build and run
 
-In this example we use a customized `Dockerfile` which bases a new image on `cypress/base`, copies the complete Cypress project into the image, including installed dependencies, then installs the Cypress binary and Chrome for Testing into the image.
-
-The file is [examples/chrome-for-testing/Dockerfile](./Dockerfile). It has the following contents which build a custom Docker image using the `stable` version of Chrome for Testing, downloaded with [@puppeteer/browsers](https://pptr.dev/browsers-api):
-
-```dockerfile
-FROM cypress/base
-COPY . /opt/app
-WORKDIR /opt/app
-# Install Cypress binary
-RUN npx cypress install
-# Install Chrome for Testing
-ARG CHROME_VERSION=stable
-RUN INSTALL_OUTPUT=$(npx @puppeteer/browsers install chrome@${CHROME_VERSION} --path /tmp/chrome-for-testing) && \
-DOWNLOAD_DIR=$(echo "$INSTALL_OUTPUT" | grep -o '\/.*\/chrome-linux64') && \
-mv $DOWNLOAD_DIR /opt/chrome-for-testing
-RUN apt-get update && \
-    while read -r pkg; do \
-        apt-get satisfy -y --no-install-recommends "$pkg"; \
-    done < /opt/chrome-for-testing/deb.deps
-RUN ln -fs /opt/chrome-for-testing/chrome /usr/local/bin/chrome
-RUN rm -rf /tmp/chrome-for-testing
-```
+In this example we use a customized `Dockerfile` [examples/chrome-for-testing/Dockerfile](./Dockerfile) which bases a new image on `cypress/base`,
+copies the complete Cypress project into the image, including installed dependencies,
+then installs the Cypress binary and Chrome for Testing into the image.
+It downloads the `stable` version of Chrome for Testing using [@puppeteer/browsers](https://pptr.dev/browsers-api).
 
 We build the new image, run the container from the image and execute the Cypress command `npx cypress run --browser chrome-for-testing` to run the test using Chrome for Testing:
 
@@ -46,8 +31,8 @@ docker run --rm --entrypoint bash test-chrome-for-testing -c "npx cypress run --
 
 To build the Docker image with a different version of Chrome for Testing, change the value of the Docker environment variable `CHROME_VERSION.` Any value accepted by [@puppeteer/browsers](https://pptr.dev/browsers-api) is valid. This includes:
 
-- an explicit full version e.g. `131.0.6778.204`
-- a major version e.g. `131`
+- an explicit full version e.g. `153.0.8010.36`
+- a major version e.g. `153`
 - a channel alias:
   - `stable`
   - `beta`
@@ -67,12 +52,14 @@ Refer to [Chrome for Testing availability](https://googlechromelabs.github.io/ch
 
 ## Test
 
-To test a set of Chrome for Testing version selections (channel alias: `stable`, `beta`, `dev`, `canary`, explicit full version & major version), execute:
+To test the `stable` version of Chrome for Testing, execute:
 
 ```shell
 cd examples/chrome-for-testing
 ./scripts/test.sh
 ```
+
+Edit the script `test.sh` to test additional channel aliases: `beta`, `dev`, `canary`, explicit full versions or major versions.
 
 ## References
 

--- a/examples/chrome-for-testing/scripts/test.sh
+++ b/examples/chrome-for-testing/scripts/test.sh
@@ -7,36 +7,39 @@ set -e # fail on error
 # Run ./scripts/test.sh in directory examples/chrome-for-testing
 #
 ARCHITECTURE=$(uname -m)
-echo Running on $ARCHITECTURE
+echo Running on "$ARCHITECTURE"
 
 case $ARCHITECTURE in
   x86_64)
     echo Testing Chrome for Testing in amd64
-    npm ci # Install dependencies
-    #
-    chromeVersion=(
-        'stable'
-        'beta'
-        'dev'
-        'canary'
-        '151'
-        '151.0.7922.76'
-        )
-    # Build, show Cypress info and run Cypress test
-    for i in ${!chromeVersion[@]}; do
-    echo
-    echo CHROME_VERSION ${chromeVersion[$i]}
-    docker build --build-arg CHROME_VERSION=${chromeVersion[$i]} -t test-chrome-for-testing .
-    docker run --rm --entrypoint bash test-chrome-for-testing -c "npx cypress info"
-    docker run --rm --entrypoint bash test-chrome-for-testing -c "npx cypress run --browser chrome-for-testing"
-    done
+    platformFilename=chrome-linux64
     ;;
   aarch64)
-    echo Skipping Chrome for Testing for arm64
-    echo This browser is not available for Linux/arm64
+    echo Testing Chrome for Testing in arm64
+    platformFilename=chrome-linux-arm64
     ;;
   *)
     echo Unsupported architecture
     exit 1
     ;;
 esac
+
+npm ci # Install dependencies
+# uncomment lines below to test different versions of Chrome for Testing
+# See https://googlechromelabs.github.io/chrome-for-testing/ for current versions
+chromeVersion=(
+    'stable'
+    # 'beta'
+    # 'dev'
+    # 'canary'
+    # '153'
+    # '153.0.8010.36'
+    )
+# Build, show Cypress info and run Cypress test
+for i in "${!chromeVersion[@]}"; do
+echo
+echo CHROME_VERSION "${chromeVersion[$i]}"
+docker build --build-arg CHROME_VERSION="${chromeVersion[$i]}" --build-arg PLATFORM_FILENAME=${platformFilename} -t test-chrome-for-testing .
+docker run --rm --entrypoint bash test-chrome-for-testing -c "npx cypress info"
+docker run --rm --entrypoint bash test-chrome-for-testing -c "npx cypress run --browser chrome-for-testing"
+done

--- a/examples/chrome-for-testing/scripts/test.sh
+++ b/examples/chrome-for-testing/scripts/test.sh
@@ -6,24 +6,6 @@ set -e # fail on error
 #
 # Run ./scripts/test.sh in directory examples/chrome-for-testing
 #
-ARCHITECTURE=$(uname -m)
-echo Running on "$ARCHITECTURE"
-
-case $ARCHITECTURE in
-  x86_64)
-    echo Testing Chrome for Testing in amd64
-    platformFilename=chrome-linux64
-    ;;
-  aarch64)
-    echo Testing Chrome for Testing in arm64
-    platformFilename=chrome-linux-arm64
-    ;;
-  *)
-    echo Unsupported architecture
-    exit 1
-    ;;
-esac
-
 npm ci # Install dependencies
 # uncomment lines below to test different versions of Chrome for Testing
 # See https://googlechromelabs.github.io/chrome-for-testing/ for current versions
@@ -39,7 +21,7 @@ chromeVersion=(
 for i in "${!chromeVersion[@]}"; do
 echo
 echo CHROME_VERSION "${chromeVersion[$i]}"
-docker build --build-arg CHROME_VERSION="${chromeVersion[$i]}" --build-arg PLATFORM_FILENAME=${platformFilename} -t test-chrome-for-testing .
+docker build --build-arg CHROME_VERSION="${chromeVersion[$i]}" -t test-chrome-for-testing .
 docker run --rm --entrypoint bash test-chrome-for-testing -c "npx cypress info"
 docker run --rm --entrypoint bash test-chrome-for-testing -c "npx cypress run --browser chrome-for-testing"
 done


### PR DESCRIPTION
- relates to https://github.com/cypress-io/cypress-docker-images/issues/1555
- relates to https://github.com/cypress-io/cypress-docker-images/pull/1554

## Situation

Previously, Google Chrome for Testing was available for Linux only with the `amd64` architecture.

[Chrome for Testing > Supported platforms](https://github.com/GoogleChromeLabs/chrome-for-testing#supported-platforms) now lists:

> linux-arm64 (supported since v153.0.8001.0)

and [Chrome for Testing availability](https://googlechromelabs.github.io/chrome-for-testing/) shows the stable version `153.0.8010.36` which meets the minimum required.

[examples/chrome-for-testing](https://github.com/cypress-io/cypress-docker-images/tree/master/examples/chrome-for-testing#readme) states:

> Note that Chrome for Testing is currently not available for the linux/arm64 platform.

[examples/chrome-for-testing/scripts/test.sh](https://github.com/cypress-io/cypress-docker-images/blob/master/examples/chrome-for-testing/scripts/test.sh) restricts testing to `amd64`. The script also tests `beta`, `dev` & `canary` and fixed versions.

[@puppeteer/browsers@3.2.0](https://github.com/puppeteer/puppeteer/releases/tag/browsers-v3.2.0) minimum is required for CfT on `Linux/arm64`.

## Change

Update

- [examples/chrome-for-testing > README](https://github.com/cypress-io/cypress-docker-images/tree/master/examples/chrome-for-testing#readme).
- [examples/chrome-for-testing/scripts/test.sh](https://github.com/cypress-io/cypress-docker-images/blob/master/examples/chrome-for-testing/scripts/test.sh) to allow `arm64`. For both `amd64` and `arm64` test only `stable` release and comment out other versions. Restrict test matrix to `stable` only. This removes the exposure of testing against future versions, that may not have been verified. Removing fixed versions avoids the necessity to continually having to maintain these versions to keep within the three latest major version range supported by Cypress. Alternatives are left in the example script for users who would like to enable these tests manually.
- [.github/workflows/example-tests.yml](https://github.com/cypress-io/cypress-docker-images/blob/master/.github/workflows/example-tests.yml) to allow `chrome-for-testing` under `ubuntu-24.04-arm`

## Verification

```shell
cd examples/chrome-for-testing
npm ci
./scripts/test.sh
cd ../..
```

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Changes are limited to example Docker/CI scripts and documentation, with no production auth or data-path impact.
> 
> **Overview**
> Enables the **chrome-for-testing** example on **linux/arm64** now that Chrome for Testing supports that platform (v153+).
> 
> The example **Dockerfile** selects the correct download (`chrome-linux64` vs `chrome-linux-arm64`) via Docker **`TARGETARCH`**, and CI **drops the matrix exclude** that skipped `chrome-for-testing` on `ubuntu-24.04-arm`. The workflow also runs on pushes that touch **`.github/workflows/example-tests.yml`**.
> 
> **`test.sh`** and the **README** no longer skip or deny arm64; default testing is narrowed to the **`stable`** channel only, with beta/dev/canary and pinned versions left commented for manual use.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e4e6a84caa137babc90137d1d22a9448fcf41b13. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->