### PR TITLE
feat: add Chrome for Testing Linux/arm64 for 153 and above (factory)

### DIFF
--- a/README.md
+++ b/README.md
@@ -72,7 +72,16 @@ Cypress officially [supports][Cypress Browser Support] the latest 3 major versio
 
 The [Google Chrome for Testing][Chrome for Testing] browser is supported by [Cypress 13.17.0](https://docs.cypress.io/app/references/changelog#13-17-0) and above.
 
-[cypress/factory](./factory/) provides the parameter [CHROME_FOR_TESTING_VERSION](./factory/README.md#chrome_for_testing_version) to optionally add Chrome for Testing to a custom image. The [examples/chrome-for-testing](./examples/chrome-for-testing/) directory describes an alternate way to install Chrome for Testing into a custom image using the [@puppeteer/browsers command-line utility](https://pptr.dev/browsers-api). At this time, Chrome for Testing is not included in [cypress/browsers](./browsers/) or [cypress/included](./included/) images. Chrome for Testing is currently not available for the `linux/arm64` platform.
+[cypress/factory](./factory/) provides the parameter
+[CHROME_FOR_TESTING_VERSION](./factory/README.md#chrome_for_testing_version)
+to add Chrome for Testing optionally to a custom image.
+The [examples/chrome-for-testing](./examples/chrome-for-testing/) directory describes an alternate way to install
+Chrome for Testing into a custom image using the
+[@puppeteer/browsers command-line utility](https://pptr.dev/browsers-api).
+At this time, Chrome for Testing is not included in
+[cypress/browsers](./browsers/) or [cypress/included](./included/) images.
+Chrome for Testing is available for the `linux/amd64` platform since `113.0.5672.0`.
+For the `linux/arm64` platform, the lowest available version is `153.0.8001.0`.
 
 ### Mozilla geckodriver
 

--- a/README.md
+++ b/README.md
@@ -80,8 +80,7 @@ Chrome for Testing into a custom image using the
 [@puppeteer/browsers command-line utility](https://pptr.dev/browsers-api).
 At this time, Chrome for Testing is not included in
 [cypress/browsers](./browsers/) or [cypress/included](./included/) images.
-Chrome for Testing is available for the `linux/amd64` platform since `113.0.5672.0`.
-For the `linux/arm64` platform, the lowest available version is `153.0.8001.0`.
+Chrome for Testing is available for the `linux/amd64` platform since `113.0.5672.0` and since `153.0.8001.0` for the `linux/arm64` platform.
 
 ### Mozilla geckodriver
 

--- a/circle.yml
+++ b/circle.yml
@@ -274,6 +274,7 @@ workflows:
               test-target:
                 - test-factory-electron
                 - test-factory-chrome
+                - test-factory-chrome-for-testing
                 - test-factory-firefox
                 - test-factory-cypress-included-electron
                 - test-factory-cypress-included-electron-non-root-user

--- a/factory/.env
+++ b/factory/.env
@@ -18,7 +18,7 @@ NODE_VERSION="${FACTORY_DEFAULT_NODE_VERSION}"
 
 # Update the FACTORY_VERSION to deploy cypress/factory if you make changes to
 # BASE_IMAGE, FACTORY_DEFAULT_NODE_VERSION, YARN_VERSION, factory.Dockerfile or installScripts
-FACTORY_VERSION='8.4.1'
+FACTORY_VERSION='8.5.0'
 
 # Cypress officially supports the latest 3 major versions of Chrome, Firefox, and Edge only
 
@@ -27,10 +27,12 @@ FACTORY_VERSION='8.4.1'
 # Earlier versions of Google Chrome may no longer be available from http://dl.google.com
 CHROME_VERSION='152.0.7977.64-1'
 
-# Chrome for Testing versions: https://googlechromelabs.github.io/chrome-for-testing/
-# not currently used for cypress/browsers and cypress/included images
-# Linux/amd64 only
-CHROME_FOR_TESTING_VERSION='152.0.7977.64'
+# Chrome for Testing versions dashboard: https://googlechromelabs.github.io/chrome-for-testing/
+# JSON API endpoint: https://googlechromelabs.github.io/chrome-for-testing/last-known-good-versions.json
+#
+# Not currently used for cypress/browsers and cypress/included images
+# Linux/amd64 for all current versions, Linux/arm64 supported for versions 153.0.8001.0 and above
+CHROME_FOR_TESTING_VERSION='153.0.8010.36'
 
 # Cypress versions: https://www.npmjs.com/package/cypress
 CYPRESS_VERSION='16.0.0'

--- a/factory/CHANGELOG.md
+++ b/factory/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Change log
 
+## 8.5.0
+
+- Add factory support for Chrome for Testing `arm64` with versions `153` and above.
+  Addresses [#1555](https://github.com/cypress-io/cypress-docker-images/issues/1555).
+
 ## 8.4.1
 
 - Updated `FACTORY_DEFAULT_NODE_VERSION` from `24.19.0` to `24.20.0`.

--- a/factory/README.md
+++ b/factory/README.md
@@ -92,11 +92,15 @@ This browser is available for the `Linux/amd64` platform in all versions, and fo
 
 The version of [Google Chrome for Testing](https://developer.chrome.com/blog/chrome-for-testing/) to install. If the `ARG` variable is unset or an empty string, Chrome for Testing is not installed.
 
-Example: `CHROME_FOR_TESTING_VERSION='150.0.7871.24'`
+Example: `CHROME_FOR_TESTING_VERSION='153.0.8010.36'`
 
-Refer to [Chrome for Testing availability](https://googlechromelabs.github.io/chrome-for-testing/) for current versions or [available downloads](https://googlechromelabs.github.io/chrome-for-testing/files) for other versions.
+Refer to [Chrome for Testing availability](https://googlechromelabs.github.io/chrome-for-testing/) for current versions
+and [JSON API endpoints](https://github.com/GoogleChromeLabs/chrome-for-testing#json-api-endpoints) for all versions.
 
-The parameter `CHROME_FOR_TESTING_VERSION` can be used for custom-built images based on `cypress/factory`. The browser is however not currently built into `cypress/browsers` or `cypress/included` images and is currently available only for the `Linux/amd64` platform.
+The parameter `CHROME_FOR_TESTING_VERSION` can be used for custom-built images based on `cypress/factory`.
+The browser is however not currently built into `cypress/browsers` or `cypress/included` images.
+Chrome for Testing is available for the `linux/amd64` platform since `113.0.5672.0`.
+For the `linux/arm64` platform, the lowest available version is `153.0.8001.0`.
 
 ### FIREFOX_VERSION
 

--- a/factory/README.md
+++ b/factory/README.md
@@ -99,8 +99,8 @@ and [JSON API endpoints](https://github.com/GoogleChromeLabs/chrome-for-testing#
 
 The parameter `CHROME_FOR_TESTING_VERSION` can be used for custom-built images based on `cypress/factory`.
 The browser is however not currently built into `cypress/browsers` or `cypress/included` images.
-Chrome for Testing is available for the `linux/amd64` platform since `113.0.5672.0`.
-For the `linux/arm64` platform, the lowest available version is `153.0.8001.0`.
+Chrome for Testing is available for the `linux/amd64` platform since `113.0.5672.0`
+and since `153.0.8001.0` for the `linux/arm64` platform.
 
 ### FIREFOX_VERSION
 

--- a/factory/installScripts/chrome-for-testing/default.sh
+++ b/factory/installScripts/chrome-for-testing/default.sh
@@ -2,9 +2,9 @@
 
 # Download locations on https://googlechromelabs.github.io/chrome-for-testing/ - see JSON endpoints
 
-wget --no-verbose -P /tmp/chrome-for-testing https://storage.googleapis.com/chrome-for-testing-public/${1}/linux64/chrome-linux64.zip
-unzip /tmp/chrome-for-testing/chrome-linux64.zip -d /tmp/chrome-for-testing
-mv /tmp/chrome-for-testing/chrome-linux64 /opt/chrome-for-testing
+wget --no-verbose -P /tmp/chrome-for-testing https://storage.googleapis.com/chrome-for-testing-public/${1}/${2}/chrome-${2}.zip
+unzip /tmp/chrome-for-testing/chrome-${2}.zip -d /tmp/chrome-for-testing
+mv /tmp/chrome-for-testing/chrome-${2} /opt/chrome-for-testing
 apt-get update
 while read -r pkg
 do

--- a/factory/installScripts/chrome-for-testing/install-chrome-for-testing-version.js
+++ b/factory/installScripts/chrome-for-testing/install-chrome-for-testing-version.js
@@ -8,15 +8,34 @@ if (!chromeVersion) {
   process.exit(0)
 }
 
-if (process.arch !== 'x64') {
-  console.log(`Chrome for Testing only available for x64. Not currently available for architecture: ${process.arch}`)
-  process.exit(0)
+const chromeMajorVersion = chromeVersion.split('.').map(Number)[0]
+
+const architecture = process.arch
+let platformFilename
+
+switch (architecture) {
+  case 'x64':
+    platformFilename = 'linux64'
+    break
+  case 'arm64':
+    platformFilename = 'linux-arm64'
+    if (chromeMajorVersion >= 153) {
+      break
+    }
+    else {
+      console.log(`Chrome for Testing ${chromeVersion} not available for arm64, minimum 153 required, skipping download`)
+      process.exit(0)
+    }
+  // eslint-disable-next-line no-fallthrough
+  default:
+    console.log(`Unsupported architecture ${architecture} for Chrome for Testing ${chromeVersion}, skipping download`)
+    process.exit(0)
 }
 
-console.log('Installing Chrome for Testing version: ', chromeVersion)
+console.log(`Installing Chrome for Testing version ${chromeVersion} for ${architecture}`)
 
 // Insert logic here if needed to run a different install script based on chrome version.
-const install = spawn(`${__dirname}/default.sh`, [chromeVersion], { stdio: 'inherit' })
+const install = spawn(`${__dirname}/default.sh`, [chromeVersion, platformFilename], { stdio: 'inherit' })
 
 install.on('error', function (error) {
   console.log('child process errored with ' + error.toString())


### PR DESCRIPTION
- closes https://github.com/cypress-io/cypress-docker-images/issues/1555
- relates to https://github.com/cypress-io/cypress-docker-images/pull/1554

## Situation

Previously, Google Chrome for Testing was available for Linux only with the `amd64` architecture.

[Chrome for Testing > Supported platforms](https://github.com/GoogleChromeLabs/chrome-for-testing#supported-platforms) now lists:

> linux-arm64 (supported since v153.0.8001.0)

and [Chrome for Testing availability](https://googlechromelabs.github.io/chrome-for-testing/) shows the stable version `153.0.8010.36` which meets the minimum required.

## Change

Add Google Chrome for Testing to `cypress/factory` capabilities for the `Linux/arm64` platform, for Chrome 153 and above.

In [factory/.env](https://github.com/cypress-io/cypress-docker-images/blob/master/factory/.env) make the following updates:

| Environment variable       | Before        | After         |
| -------------------------- | ------------- | ------------- |
| FACTORY_VERSION            | 8.4.1         | 8.5.0         |
| CHROME_FOR_TESTING_VERSION | 152.0.7977.64 | 153.0.8010.36 |

The version of Chrome for Testing matches the stable version displayed on
https://googlechromelabs.github.io/chrome-for-testing/ and listed on
https://googlechromelabs.github.io/chrome-for-testing/last-known-good-versions.json

Update [factory/installScripts/chrome-for-testing](https://github.com/cypress-io/cypress-docker-images/tree/master/factory/installScripts/chrome-for-testing) installation scripts to allow download of `linux-arm64` in addition to `linux64` (for `amd64`).

Add `test-factory-chrome-for-testing` to [circle.yml](https://github.com/cypress-io/cypress-docker-images/blob/master/circle.yml) for Chrome for Testing / arm64 as factory build.

Update [factory/README](https://github.com/cypress-io/cypress-docker-images/blob/master/factory/README.md) documentation.

## Verification

```shell
cd factory
docker compose --progress plain build factory
docker compose --progress plain build chrome-for-testing
docker compose --progress plain build cypress-chrome-for-testing
cd test-project
set -a && . ../.env && set +a
docker compose --progress plain run --build --rm test-factory-chrome-for-testing
```

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes factory image build/install behavior and default browser versions; impact is limited to optional Chrome-for-Testing installs but wrong platform/version logic could break arm64 or amd64 factory builds.
> 
> **Overview**
> **`cypress/factory` 8.5.0** adds **Chrome for Testing on `linux/arm64`** for versions **153+**, closing the gap where installs were skipped on non-`amd64` hosts.
> 
> The install path now picks **`linux64` vs `linux-arm64`** from `process.arch` (with a major-version guard on arm64) and passes that into `default.sh`, which downloads/unpacks the matching **`chrome-${platform}`** artifact instead of hard-coding `linux64`. Defaults move to **`CHROME_FOR_TESTING_VERSION='153.0.8010.36'`** and **`FACTORY_VERSION='8.5.0'`**.
> 
> **CircleCI** runs **`test-factory-chrome-for-testing`** on the factory **arm** matrix. **README**, **factory README**, and **CHANGELOG** document arm64 availability and the updated example version.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 2c22c1be3d94f405fa557d8102b32039b1ecdac9. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->