### PR TITLE
fix(deps): update to Node.js 24.21.0

### DIFF
--- a/factory/.env
+++ b/factory/.env
@@ -11,21 +11,21 @@ BASE_IMAGE='debian:13.6-slim'
 # Node Versions: https://nodejs.org/en/download/releases/
 # master branch needs "Active LTS" version
 # use feature branch for "Maintenance LTS" or "Current" versions
-FACTORY_DEFAULT_NODE_VERSION='24.20.0'
+FACTORY_DEFAULT_NODE_VERSION='24.21.0'
 
 # Node Versions: https://nodejs.org/en/download/releases/
 NODE_VERSION="${FACTORY_DEFAULT_NODE_VERSION}"
 
 # Update the FACTORY_VERSION to deploy cypress/factory if you make changes to
 # BASE_IMAGE, FACTORY_DEFAULT_NODE_VERSION, YARN_VERSION, factory.Dockerfile or installScripts
-FACTORY_VERSION='8.5.0'
+FACTORY_VERSION='8.5.1'
 
 # Cypress officially supports the latest 3 major versions of Chrome, Firefox, and Edge only
 
 # Chrome versions: https://www.ubuntuupdates.org/package/google_chrome/stable/main/base/google-chrome-stable
 # Linux/amd64 for all versions, Linux/arm64 for versions 151 and above
 # Earlier versions of Google Chrome may no longer be available from http://dl.google.com
-CHROME_VERSION='152.0.7977.64-1'
+CHROME_VERSION='153.0.8010.36-1'
 
 # Chrome for Testing versions dashboard: https://googlechromelabs.github.io/chrome-for-testing/
 # JSON API endpoint: https://googlechromelabs.github.io/chrome-for-testing/last-known-good-versions.json
@@ -39,11 +39,11 @@ CYPRESS_VERSION='16.0.0'
 
 # Edge versions: https://packages.microsoft.com/repos/edge/pool/main/m/microsoft-edge-stable/
 # Linux/amd64 only
-EDGE_VERSION='152.0.4191.53-1'
+EDGE_VERSION='153.0.4234.32-1'
 
 # Firefox versions: https://download-installer.cdn.mozilla.net/pub/firefox/releases/
 # Linux/amd64 for all versions, Linux/arm64 for versions 136.0 and above
-FIREFOX_VERSION='155.0'
+FIREFOX_VERSION='155.0.1'
 
 # Geckodriver versions: https://github.com/mozilla/geckodriver/releases
 # Geckodriver documentation: https://firefox-source-docs.mozilla.org/testing/geckodriver/index.html

--- a/factory/CHANGELOG.md
+++ b/factory/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Change log
 
+## 8.5.1
+
+- Updated `FACTORY_DEFAULT_NODE_VERSION` from `24.20.0` to `24.21.0`.
+  Addresses [#1587](https://github.com/cypress-io/cypress-docker-images/issues/1587).
+
 ## 8.5.0
 
 - Add factory support for Chrome for Testing `arm64` with versions `153` and above.


### PR DESCRIPTION
- closes https://github.com/cypress-io/cypress-docker-images/issues/1587

## Situation

- Node.js released an update [Node.js v24.21.0 LTS](https://github.com/nodejs/node/releases/tag/v24.21.0) on Sep 8, 2026.

## Change

In [factory/.env](https://github.com/cypress-io/cypress-docker-images/blob/master/factory/.env) make the following updates:

| Environment variable         | Before          | After           |
| ---------------------------- | --------------- | --------------- |
| FACTORY_VERSION              | 8.5.0           | 8.5.1           |
| FACTORY_DEFAULT_NODE_VERSION | 24.20.0         | 24.21.0         |
| CHROME_VERSION               | 152.0.7977.64-1 | 153.0.8010.36-1 |
| CHROME_FOR_TESTING_VERSION   | 153.0.8010.36   | no change       |
| EDGE_VERSION                 | 152.0.4191.53-1 | 153.0.4234.32-1 |
| FIREFOX_VERSION              | 155.0           | 155.0.1         |
| GECKODRIVER_VERSION          | 0.37.1          | no change       |

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Routine version-pin updates in factory configuration with no application logic changes; main risk is downstream Docker image tag churn from new browser/Node pins.
> 
> **Overview**
> Bumps **cypress/factory** primary versions in `factory/.env` for release **8.5.1**: default Node moves from **24.20.0** to **24.21.0** (Active LTS), with `FACTORY_VERSION` **8.5.0 → 8.5.1** so factory images rebuild on the next deploy.
> 
> The same env file refreshes bundled browsers—Chrome **152 → 153**, Edge **152 → 153**, and Firefox **155.0 → 155.0.1**—which also updates derived `BROWSERS_IMAGE_TAG` / `INCLUDED_IMAGE_TAG` strings tied to those variables.
> 
> `factory/CHANGELOG.md` adds an **8.5.1** entry documenting the Node bump and issue **#1587** (browser bumps are in `.env` but not listed in the changelog section added here).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c55b64c770cd4ef1fed888c84358222061f78357. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->